### PR TITLE
feat(spanner): add emulator support

### DIFF
--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -222,7 +222,7 @@ class Client(ClientWithProject):
                 self._instance_admin_api = InstanceAdminClient(
                     client_info=self._client_info,
                     client_options=self._client_options,
-                    transport=transport
+                    transport=transport,
                 )
             else:
                 self._instance_admin_api = InstanceAdminClient(
@@ -243,7 +243,7 @@ class Client(ClientWithProject):
                 self._database_admin_api = DatabaseAdminClient(
                     client_info=self._client_info,
                     client_options=self._client_options,
-                    transport=transport
+                    transport=transport,
                 )
             else:
                 self._database_admin_api = DatabaseAdminClient(
@@ -334,7 +334,14 @@ class Client(ClientWithProject):
         :rtype: :class:`~google.cloud.spanner_v1.instance.Instance`
         :returns: an instance owned by this client.
         """
-        return Instance(instance_id, self, configuration_name, node_count, display_name, _get_spanner_emulator_host())
+        return Instance(
+            instance_id,
+            self,
+            configuration_name,
+            node_count,
+            display_name,
+            _get_spanner_emulator_host(),
+        )
 
     def list_instances(self, filter_="", page_size=None, page_token=None):
         """List instances for the client's project.

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -23,10 +23,20 @@ In the hierarchy of API concepts
 * a :class:`~google.cloud.spanner_v1.instance.Instance` owns a
   :class:`~google.cloud.spanner_v1.database.Database`
 """
+import grpc
+import os
 import warnings
 
 from google.api_core.gapic_v1 import client_info
 import google.api_core.client_options
+
+from google.cloud.spanner_admin_instance_v1.gapic.transports import (
+    instance_admin_grpc_transport,
+)
+
+from google.cloud.spanner_admin_database_v1.gapic.transports import (
+    database_admin_grpc_transport,
+)
 
 # pylint: disable=line-too-long
 from google.cloud.spanner_admin_database_v1.gapic.database_admin_client import (  # noqa
@@ -45,11 +55,21 @@ from google.cloud.spanner_v1.instance import DEFAULT_NODE_COUNT
 from google.cloud.spanner_v1.instance import Instance
 
 _CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
+EMULATOR_ENV_VAR = "SPANNER_EMULATOR_HOST"
+_EMULATOR_HOST_HTTP_SCHEME = (
+    "%s contains a http scheme. When used with a scheme it may cause gRPC's "
+    "DNS resolver to endlessly attempt to resolve. %s is intended to be used "
+    "without a scheme: ex %s=localhost:8080."
+) % ((EMULATOR_ENV_VAR,) * 3)
 SPANNER_ADMIN_SCOPE = "https://www.googleapis.com/auth/spanner.admin"
 _USER_AGENT_DEPRECATED = (
     "The 'user_agent' argument to 'Client' is deprecated / unused. "
     "Please pass an appropriate 'client_info' instead."
 )
+
+
+def _get_spanner_emulator_host():
+    return os.getenv(EMULATOR_ENV_VAR)
 
 
 class InstanceConfig(object):
@@ -156,6 +176,12 @@ class Client(ClientWithProject):
             warnings.warn(_USER_AGENT_DEPRECATED, DeprecationWarning, stacklevel=2)
             self.user_agent = user_agent
 
+        if _get_spanner_emulator_host() is not None and (
+            "http://" in _get_spanner_emulator_host()
+            or "https://" in _get_spanner_emulator_host()
+        ):
+            warnings.warn(_EMULATOR_HOST_HTTP_SCHEME)
+
     @property
     def credentials(self):
         """Getter for client's credentials.
@@ -189,22 +215,42 @@ class Client(ClientWithProject):
     def instance_admin_api(self):
         """Helper for session-related API calls."""
         if self._instance_admin_api is None:
-            self._instance_admin_api = InstanceAdminClient(
-                credentials=self.credentials,
-                client_info=self._client_info,
-                client_options=self._client_options,
-            )
+            if _get_spanner_emulator_host() is not None:
+                transport = instance_admin_grpc_transport.InstanceAdminGrpcTransport(
+                    channel=grpc.insecure_channel(_get_spanner_emulator_host())
+                )
+                self._instance_admin_api = InstanceAdminClient(
+                    client_info=self._client_info,
+                    client_options=self._client_options,
+                    transport=transport
+                )
+            else:
+                self._instance_admin_api = InstanceAdminClient(
+                    credentials=self.credentials,
+                    client_info=self._client_info,
+                    client_options=self._client_options,
+                )
         return self._instance_admin_api
 
     @property
     def database_admin_api(self):
         """Helper for session-related API calls."""
         if self._database_admin_api is None:
-            self._database_admin_api = DatabaseAdminClient(
-                credentials=self.credentials,
-                client_info=self._client_info,
-                client_options=self._client_options,
-            )
+            if _get_spanner_emulator_host() is not None:
+                transport = database_admin_grpc_transport.DatabaseAdminGrpcTransport(
+                    channel=grpc.insecure_channel(_get_spanner_emulator_host())
+                )
+                self._database_admin_api = DatabaseAdminClient(
+                    client_info=self._client_info,
+                    client_options=self._client_options,
+                    transport=transport
+                )
+            else:
+                self._database_admin_api = DatabaseAdminClient(
+                    credentials=self.credentials,
+                    client_info=self._client_info,
+                    client_options=self._client_options,
+                )
         return self._database_admin_api
 
     def copy(self):
@@ -288,7 +334,7 @@ class Client(ClientWithProject):
         :rtype: :class:`~google.cloud.spanner_v1.instance.Instance`
         :returns: an instance owned by this client.
         """
-        return Instance(instance_id, self, configuration_name, node_count, display_name)
+        return Instance(instance_id, self, configuration_name, node_count, display_name, _get_spanner_emulator_host())
 
     def list_instances(self, filter_="", page_size=None, page_token=None):
         """List instances for the client's project.

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -46,6 +46,7 @@ from google.cloud.spanner_v1.proto.transaction_pb2 import (
     TransactionSelector,
     TransactionOptions,
 )
+
 # pylint: enable=ungrouped-imports
 
 
@@ -200,7 +201,7 @@ class Database(object):
                 self._spanner_api = SpannerClient(
                     client_info=client_info,
                     client_options=client_options,
-                    transport=transport
+                    transport=transport,
                 )
                 return self._spanner_api
             credentials = self._instance._client.credentials

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -16,6 +16,7 @@
 
 import copy
 import functools
+import grpc
 import os
 import re
 import threading
@@ -33,6 +34,7 @@ from google.cloud.spanner_v1._helpers import _make_value_pb
 from google.cloud.spanner_v1._helpers import _metadata_with_prefix
 from google.cloud.spanner_v1.batch import Batch
 from google.cloud.spanner_v1.gapic.spanner_client import SpannerClient
+from google.cloud.spanner_v1.gapic.transports import spanner_grpc_transport
 from google.cloud.spanner_v1.keyset import KeySet
 from google.cloud.spanner_v1.pool import BurstyPool
 from google.cloud.spanner_v1.pool import SessionCheckout
@@ -44,7 +46,6 @@ from google.cloud.spanner_v1.proto.transaction_pb2 import (
     TransactionSelector,
     TransactionOptions,
 )
-
 # pylint: enable=ungrouped-imports
 
 
@@ -190,11 +191,21 @@ class Database(object):
     def spanner_api(self):
         """Helper for session-related API calls."""
         if self._spanner_api is None:
+            client_info = self._instance._client._client_info
+            client_options = self._instance._client._client_options
+            if self._instance.emulator_host is not None:
+                transport = spanner_grpc_transport.SpannerGrpcTransport(
+                    channel=grpc.insecure_channel(self._instance.emulator_host)
+                )
+                self._spanner_api = SpannerClient(
+                    client_info=client_info,
+                    client_options=client_options,
+                    transport=transport
+                )
+                return self._spanner_api
             credentials = self._instance._client.credentials
             if isinstance(credentials, google.auth.credentials.Scoped):
                 credentials = credentials.with_scopes((SPANNER_DATA_SCOPE,))
-            client_info = self._instance._client._client_info
-            client_options = self._instance._client._client_options
             if (
                 os.getenv("GOOGLE_CLOUD_SPANNER_ENABLE_RESOURCE_BASED_ROUTING")
                 == "true"

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -76,12 +76,14 @@ class Instance(object):
         configuration_name=None,
         node_count=DEFAULT_NODE_COUNT,
         display_name=None,
+        emulator_host=None,
     ):
         self.instance_id = instance_id
         self._client = client
         self.configuration_name = configuration_name
         self.node_count = node_count
         self.display_name = display_name or instance_id
+        self.emulator_host = emulator_host
 
     def _update_from_pb(self, instance_pb):
         """Refresh self from the server-provided protobuf.

--- a/noxfile.py
+++ b/noxfile.py
@@ -94,9 +94,9 @@ def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
-    # Sanity check: Only run tests if the environment variable is set.
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", ""):
-        session.skip("Credentials must be set via environment variable")
+    # Sanity check: Only run tests if either credentials or emulator host is set.
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "") and not os.environ.get("SPANNER_EMULATOR_HOST", ""):
+        session.skip("Credentials or emulator host must be set via environment variable")
 
     system_test_exists = os.path.exists(system_test_path)
     system_test_folder_exists = os.path.exists(system_test_folder_path)

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,8 +95,12 @@ def system(session):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
     # Sanity check: Only run tests if either credentials or emulator host is set.
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "") and not os.environ.get("SPANNER_EMULATOR_HOST", ""):
-        session.skip("Credentials or emulator host must be set via environment variable")
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "") and not os.environ.get(
+        "SPANNER_EMULATOR_HOST", ""
+    ):
+        session.skip(
+            "Credentials or emulator host must be set via environment variable"
+        )
 
     system_test_exists = os.path.exists(system_test_path)
     system_test_folder_exists = os.path.exists(system_test_folder_path)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -384,7 +384,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
             temp_db_id, ddl_statements=[create_table, index]
         )
         self.to_delete.append(temp_db)
-        with self.assertRaises(exceptions.NotFound) as exc_info:
+        with self.assertRaises(exceptions.NotFound):
             temp_db.create()
 
     @pytest.mark.skip(
@@ -1725,7 +1725,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             batch.insert(table, columns, valid_input)
 
         invalid_input = ((0, ""),)
-        with self.assertRaises(exceptions.FailedPrecondition) as exc_info:
+        with self.assertRaises(exceptions.FailedPrecondition):
             with self._db.batch() as batch:
                 batch.delete(table, self.ALL)
                 batch.insert(table, columns, invalid_input)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -386,9 +386,6 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         with self.assertRaises(exceptions.NotFound) as exc_info:
             temp_db.create()
 
-        expected = "Table not found: {0}".format(incorrect_table)
-        self.assertEqual(exc_info.exception.args, (expected,))
-
     @pytest.mark.skip(
         reason=(
             "update_dataset_ddl() has a flaky timeout"
@@ -1729,11 +1726,6 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             with self._db.batch() as batch:
                 batch.delete(table, self.ALL)
                 batch.insert(table, columns, invalid_input)
-
-        error_msg = (
-            "Invalid value for column value in table " "counters: Expected INT64."
-        )
-        self.assertIn(error_msg, str(exc_info.exception))
 
     def test_execute_sql_select_1(self):
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -56,6 +56,7 @@ from tests._fixtures import DDL_STATEMENTS
 
 
 CREATE_INSTANCE = os.getenv("GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE") is not None
+USE_EMULATOR = os.getenv("SPANNER_EMULATOR_HOST") is not None
 USE_RESOURCE_ROUTING = (
     os.getenv("GOOGLE_CLOUD_SPANNER_ENABLE_RESOURCE_BASED_ROUTING") == "true"
 )
@@ -105,10 +106,10 @@ def setUpModule():
     EXISTING_INSTANCES[:] = instances
 
     if CREATE_INSTANCE:
-
-        # Defend against back-end returning configs for regions we aren't
-        # actually allowed to use.
-        configs = [config for config in configs if "-us-" in config.name]
+        if not USE_EMULATOR:
+            # Defend against back-end returning configs for regions we aren't
+            # actually allowed to use.
+            configs = [config for config in configs if "-us-" in config.name]
 
         if not configs:
             raise ValueError("List instance configs failed in module set up.")

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -186,6 +186,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         self.assertEqual(instance, instance_alt)
         self.assertEqual(instance.display_name, instance_alt.display_name)
 
+    @unittest.skipIf(USE_EMULATOR, "Skipping updating instance")
     def test_update_instance(self):
         OLD_DISPLAY_NAME = Config.INSTANCE.display_name
         NEW_DISPLAY_NAME = "Foo Bar Baz"
@@ -991,6 +992,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             with self.assertRaises(InvalidArgument):
                 transaction.batch_update([])
 
+    @unittest.skipIf(USE_EMULATOR, "Skipping partitioned DML")
     def test_execute_partitioned_dml(self):
         # [START spanner_test_dml_partioned_dml_update]
         retry = RetryInstanceState(_has_all_ddl)
@@ -1623,6 +1625,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             expected = [data[keyrow]] + data[start + 1 : end]
             self.assertEqual(rows, expected)
 
+    @unittest.skipIf(USE_EMULATOR, "Skipping partitioned reads")
     def test_partition_read_w_index(self):
         row_count = 10
         columns = self.COLUMNS[1], self.COLUMNS[2]
@@ -2104,6 +2107,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             # NaNs cannot be searched for by equality.
             self.assertTrue(math.isnan(float_array[2]))
 
+    @unittest.skipIf(USE_EMULATOR, "Skipping partitioned queries")
     def test_partition_query(self):
         row_count = 40
         sql = "SELECT * FROM {}".format(self.TABLE)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -98,6 +98,17 @@ class TestClient(unittest.TestCase):
                 expected_client_options.api_endpoint,
             )
 
+    @mock.patch("google.cloud.spanner_v1.client.os.getenv")
+    @mock.patch("warnings.warn")
+    def test_constructor_emulator_host_warning(self, mock_warn, mock_os):
+        from google.cloud.spanner_v1 import client as MUT
+
+        expected_scopes = (MUT.SPANNER_ADMIN_SCOPE,)
+        creds = _make_credentials()
+        mock_os.return_value = "http://emulator.host.com"
+        self._constructor_test_helper(expected_scopes, creds)
+        mock_warn.assert_called_once_with(MUT._EMULATOR_HOST_HTTP_SCHEME)
+
     def test_constructor_default_scopes(self):
         from google.cloud.spanner_v1 import client as MUT
 
@@ -164,7 +175,8 @@ class TestClient(unittest.TestCase):
             expected_scopes, creds, client_options={"api_endpoint": "endpoint"}
         )
 
-    def test_instance_admin_api(self):
+    @mock.patch("google.cloud.spanner_v1.client.os.getenv")
+    def test_instance_admin_api(self, mock_getenv):
         from google.cloud.spanner_v1.client import SPANNER_ADMIN_SCOPE
 
         credentials = _make_credentials()
@@ -178,6 +190,7 @@ class TestClient(unittest.TestCase):
         )
         expected_scopes = (SPANNER_ADMIN_SCOPE,)
 
+        mock_getenv.return_value = None
         inst_module = "google.cloud.spanner_v1.client.InstanceAdminClient"
         with mock.patch(inst_module) as instance_admin_client:
             api = client.instance_admin_api
@@ -196,7 +209,39 @@ class TestClient(unittest.TestCase):
 
         credentials.with_scopes.assert_called_once_with(expected_scopes)
 
-    def test_database_admin_api(self):
+    @mock.patch("google.cloud.spanner_v1.client.os.getenv")
+    def test_instance_admin_api_emulator(self, mock_getenv):
+        credentials = _make_credentials()
+        client_info = mock.Mock()
+        client_options = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            client_info=client_info,
+            client_options=client_options,
+        )
+
+        mock_getenv.return_value = "true"
+        inst_module = "google.cloud.spanner_v1.client.InstanceAdminClient"
+        with mock.patch(inst_module) as instance_admin_client:
+            api = client.instance_admin_api
+
+        self.assertIs(api, instance_admin_client.return_value)
+
+        # API instance is cached
+        again = client.instance_admin_api
+        self.assertIs(again, api)
+
+        self.assertEqual(len(instance_admin_client.call_args_list), 1)
+        called_args, called_kw = instance_admin_client.call_args
+        self.assertEqual(called_args, ())
+        self.assertEqual(called_kw["client_info"], client_info)
+        self.assertEqual(called_kw["client_options"], client_options)
+        self.assertIn("transport", called_kw)
+        self.assertNotIn("credentials", called_kw)
+
+    @mock.patch("google.cloud.spanner_v1.client.os.getenv")
+    def test_database_admin_api(self, mock_getenv):
         from google.cloud.spanner_v1.client import SPANNER_ADMIN_SCOPE
 
         credentials = _make_credentials()
@@ -210,6 +255,7 @@ class TestClient(unittest.TestCase):
         )
         expected_scopes = (SPANNER_ADMIN_SCOPE,)
 
+        mock_getenv.return_value = None
         db_module = "google.cloud.spanner_v1.client.DatabaseAdminClient"
         with mock.patch(db_module) as database_admin_client:
             api = client.database_admin_api
@@ -227,6 +273,37 @@ class TestClient(unittest.TestCase):
         )
 
         credentials.with_scopes.assert_called_once_with(expected_scopes)
+
+    @mock.patch("google.cloud.spanner_v1.client.os.getenv")
+    def test_database_admin_api_emulator(self, mock_getenv):
+        credentials = _make_credentials()
+        client_info = mock.Mock()
+        client_options = mock.Mock()
+        client = self._make_one(
+            project=self.PROJECT,
+            credentials=credentials,
+            client_info=client_info,
+            client_options=client_options,
+        )
+
+        mock_getenv.return_value = "true"
+        db_module = "google.cloud.spanner_v1.client.DatabaseAdminClient"
+        with mock.patch(db_module) as database_admin_client:
+            api = client.database_admin_api
+
+        self.assertIs(api, database_admin_client.return_value)
+
+        # API instance is cached
+        again = client.database_admin_api
+        self.assertIs(again, api)
+
+        self.assertEqual(len(database_admin_client.call_args_list), 1)
+        called_args, called_kw = database_admin_client.call_args
+        self.assertEqual(called_args, ())
+        self.assertEqual(called_kw["client_info"], client_info)
+        self.assertEqual(called_kw["client_options"], client_options)
+        self.assertIn("transport", called_kw)
+        self.assertNotIn("credentials", called_kw)
 
     def test_copy(self):
         credentials = _make_credentials()


### PR DESCRIPTION
Add support for emulators.

To use an emulator, set the environment flag to the gRPC server host:
e.g. $ export SPANNER_EMULATOR_HOST=localhost:9010

Avoid using http schemes in the emulator host as it can cause the gRPC DNS resolver to endlessly attempt to resolve.

Closes #7 