### PR TITLE
refactor: remove unnecessary import

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -23,7 +23,6 @@ import time
 import unittest
 import uuid
 
-import pytest
 import grpc
 from google.rpc import code_pb2
 
@@ -388,8 +387,8 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         expected = "Table not found: {0}".format(incorrect_table)
         self.assertEqual(exc_info.exception.args, (expected,))
 
-    @pytest.mark.skip(
-        reason=(
+    @unittest.skip(
+        (
             "update_dataset_ddl() has a flaky timeout"
             "https://github.com/GoogleCloudPlatform/google-cloud-python/issues/"
             "5629"


### PR DESCRIPTION
The system tests import pytest to skip a single test. This functionality is supported by unittest which is already being imported. This PR replaces the usage of pytest in the system tests with unittest.