### PR TITLE
chore!: remove Python 2.7 from testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Python >= 3.5
 
 Deprecated Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+Python == 2.7. Python 2.7 support has been removed as of January 1, 2020.
 
 
 Mac/Linux

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,13 +83,13 @@ def default(session):
     )
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8"])
+@nox.session(python=["3.5", "3.6", "3.7", "3.8"])
 def unit(session):
     """Run the unit test suite."""
     default(session)
 
 
-@nox.session(python=["2.7", "3.7"])
+@nox.session(python="3.7")
 def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,6 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
@@ -84,7 +82,7 @@ setuptools.setup(
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
+    python_requires=">=3.5",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Python 2.7 has been deprecated which means we no longer need to run these tests to ensure compatibility. Removing these will significantly speed up the presubmit checks.