### PR TITLE
fix: pass gRPC config options to gRPC channel creation

### DIFF
--- a/google/cloud/spanner_v1/gapic/transports/spanner_grpc_transport.py
+++ b/google/cloud/spanner_v1/gapic/transports/spanner_grpc_transport.py
@@ -107,6 +107,9 @@ class SpannerGrpcTransport(object):
             pkg_resources.resource_string(__name__, _SPANNER_GRPC_CONFIG)
         )
         options = [(grpc_gcp.API_CONFIG_CHANNEL_ARG, grpc_gcp_config)]
+        if "options" in kwargs:
+            options.extend(kwargs["options"])
+        kwargs["options"] = options
         return google.api_core.grpc_helpers.create_channel(
             address, credentials=credentials, scopes=cls._OAUTH_SCOPES, **kwargs
         )

--- a/synth.py
+++ b/synth.py
@@ -62,6 +62,9 @@ s.replace(
     "\g<1>grpc_gcp_config = grpc_gcp.api_config_from_text_pb("
     "\g<1>    pkg_resources.resource_string(__name__, _SPANNER_GRPC_CONFIG))"
     "\g<1>options = [(grpc_gcp.API_CONFIG_CHANNEL_ARG, grpc_gcp_config)]"
+    "\g<1>if 'options' in kwargs:"
+    "\g<1>    options.extend(kwargs['options'])"
+    "\g<1>kwargs['options'] = options"
     "\g<0>",
 )
 s.replace(


### PR DESCRIPTION
Currently the gRPC config options in spanner.grpc.config are not being used at all. There are changes being made by the synth file but they are generating an unused variable. This PR makes use of this variable to pass the config options through to the gRPC channel creation.

Fixes #6 