### PR TITLE
feat: implement query options versioning support

### DIFF
--- a/google/cloud/spanner_v1/_helpers.py
+++ b/google/cloud/spanner_v1/_helpers.py
@@ -75,13 +75,12 @@ def _merge_query_options(base, merge):
         combined = ExecuteSqlRequest.QueryOptions(
             optimizer_version=combined.get("optimizer_version", "")
         )
-    if merge:
-        if type(merge) == dict:
-            merge_ver = merge.get("optimizer_version", "")
-        else:
-            merge_ver = merge.optimizer_version
-        if merge_ver:
-            combined.optimizer_version = merge_ver
+    merge = merge or ExecuteSqlRequest.QueryOptions()
+    if type(merge) == dict:
+        merge = ExecuteSqlRequest.QueryOptions(
+            optimizer_version=merge.get("optimizer_version", "")
+        )
+    combined.MergeFrom(merge)
     if not combined.optimizer_version:
         return None
     return combined

--- a/google/cloud/spanner_v1/_helpers.py
+++ b/google/cloud/spanner_v1/_helpers.py
@@ -26,6 +26,7 @@ from google.api_core import datetime_helpers
 from google.cloud._helpers import _date_from_iso8601_date
 from google.cloud._helpers import _datetime_to_rfc3339
 from google.cloud.spanner_v1.proto import type_pb2
+from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
 
 
 def _try_to_coerce_bytes(bytestring):
@@ -45,6 +46,45 @@ def _try_to_coerce_bytes(bytestring):
             "Ensure that you either send a Unicode string or a "
             "base64-encoded bytes."
         )
+
+
+def _merge_query_options(base, merge):
+    """Merge higher precedence QueryOptions with current QueryOptions.
+
+    :type base:
+        :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+        or :class:`dict` or None
+    :param base: The current QueryOptions that is intended for use.
+
+    :type merge:
+        :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+        or :class:`dict` or None
+    :param merge:
+        The QueryOptions that have a higher priority than base. These options
+        should overwrite the fields in base.
+
+    :rtype:
+        :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+        or None
+    :returns:
+        QueryOptions object formed by merging the two given QueryOptions.
+        If the resultant object only has empty fields, returns None.
+    """
+    combined = base or ExecuteSqlRequest.QueryOptions()
+    if type(combined) == dict:
+        combined = ExecuteSqlRequest.QueryOptions(
+            optimizer_version=combined.get("optimizer_version", "")
+        )
+    if merge:
+        if type(merge) == dict:
+            merge_ver = merge.get("optimizer_version", "")
+        else:
+            merge_ver = merge.optimizer_version
+        if merge_ver:
+            combined.optimizer_version = merge_ver
+    if not combined.optimizer_version:
+        return None
+    return combined
 
 
 # pylint: disable=too-many-return-statements,too-many-branches

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -63,7 +63,7 @@ _EMULATOR_HOST_HTTP_SCHEME = (
     "without a scheme: ex %s=localhost:8080."
 ) % ((EMULATOR_ENV_VAR,) * 3)
 SPANNER_ADMIN_SCOPE = "https://www.googleapis.com/auth/spanner.admin"
-OPTIMIZER_VERSION_VAR = "SPANNER_OPTIMIZER_VERSION"
+OPTIMIZER_VERSION_ENV_VAR = "SPANNER_OPTIMIZER_VERSION"
 _USER_AGENT_DEPRECATED = (
     "The 'user_agent' argument to 'Client' is deprecated / unused. "
     "Please pass an appropriate 'client_info' instead."
@@ -75,7 +75,7 @@ def _get_spanner_emulator_host():
 
 
 def _get_spanner_optimizer_version():
-    return os.getenv(OPTIMIZER_VERSION_VAR, "")
+    return os.getenv(OPTIMIZER_VERSION_ENV_VAR, "")
 
 
 class InstanceConfig(object):

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -50,9 +50,10 @@ from google.cloud.spanner_admin_instance_v1.gapic.instance_admin_client import (
 
 from google.cloud.client import ClientWithProject
 from google.cloud.spanner_v1 import __version__
-from google.cloud.spanner_v1._helpers import _metadata_with_prefix
+from google.cloud.spanner_v1._helpers import _merge_query_options, _metadata_with_prefix
 from google.cloud.spanner_v1.instance import DEFAULT_NODE_COUNT
 from google.cloud.spanner_v1.instance import Instance
+from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
 
 _CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 EMULATOR_ENV_VAR = "SPANNER_EMULATOR_HOST"
@@ -62,6 +63,7 @@ _EMULATOR_HOST_HTTP_SCHEME = (
     "without a scheme: ex %s=localhost:8080."
 ) % ((EMULATOR_ENV_VAR,) * 3)
 SPANNER_ADMIN_SCOPE = "https://www.googleapis.com/auth/spanner.admin"
+OPTIMIZER_VERSION_VAR = "SPANNER_OPTIMIZER_VERSION"
 _USER_AGENT_DEPRECATED = (
     "The 'user_agent' argument to 'Client' is deprecated / unused. "
     "Please pass an appropriate 'client_info' instead."
@@ -70,6 +72,10 @@ _USER_AGENT_DEPRECATED = (
 
 def _get_spanner_emulator_host():
     return os.getenv(EMULATOR_ENV_VAR)
+
+
+def _get_spanner_optimizer_version():
+    return os.getenv(OPTIMIZER_VERSION_VAR, "")
 
 
 class InstanceConfig(object):
@@ -132,10 +138,19 @@ class Client(ClientWithProject):
     :param user_agent:
         (Deprecated) The user agent to be used with API request.
         Not used.
+
     :type client_options: :class:`~google.api_core.client_options.ClientOptions`
         or :class:`dict`
     :param client_options: (Optional) Client options used to set user options
         on the client. API Endpoint should be set through client_options.
+
+    :type query_options:
+        :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+        or :class:`dict`
+    :param query_options:
+        (Optional) Query optimizer configuration to use for the given query.
+        If a dict is provided, it must be of the same form as the protobuf
+        message :class:`~google.cloud.spanner_v1.types.QueryOptions`
 
     :raises: :class:`ValueError <exceptions.ValueError>` if both ``read_only``
              and ``admin`` are :data:`True`
@@ -157,6 +172,7 @@ class Client(ClientWithProject):
         client_info=_CLIENT_INFO,
         user_agent=None,
         client_options=None,
+        query_options=None,
     ):
         # NOTE: This API has no use for the _http argument, but sending it
         #       will have no impact since the _http() @property only lazily
@@ -171,6 +187,13 @@ class Client(ClientWithProject):
             )
         else:
             self._client_options = client_options
+
+        env_query_options = ExecuteSqlRequest.QueryOptions(
+            optimizer_version=_get_spanner_optimizer_version()
+        )
+
+        # Environment flag config has higher precedence than application config.
+        self._query_options = _merge_query_options(query_options, env_query_options)
 
         if user_agent is not None:
             warnings.warn(_USER_AGENT_DEPRECATED, DeprecationWarning, stacklevel=2)

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -372,7 +372,7 @@ class Database(object):
 
         :type query_options:
             :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
-                or :class:`dict`
+            or :class:`dict`
         :param query_options:
                 (Optional) Query optimizer configuration to use for the given query.
                 If a dict is provided, it must be of the same form as the protobuf
@@ -803,7 +803,7 @@ class BatchSnapshot(object):
 
         :type query_options:
             :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
-                or :class:`dict`
+            or :class:`dict`
         :param query_options:
                 (Optional) Query optimizer configuration to use for the given query.
                 If a dict is provided, it must be of the same form as the protobuf

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -30,8 +30,11 @@ from google.api_core.exceptions import PermissionDenied
 import six
 
 # pylint: disable=ungrouped-imports
-from google.cloud.spanner_v1._helpers import _make_value_pb
-from google.cloud.spanner_v1._helpers import _metadata_with_prefix
+from google.cloud.spanner_v1._helpers import (
+    _make_value_pb,
+    _merge_query_options,
+    _metadata_with_prefix,
+)
 from google.cloud.spanner_v1.batch import Batch
 from google.cloud.spanner_v1.gapic.spanner_client import SpannerClient
 from google.cloud.spanner_v1.gapic.transports import spanner_grpc_transport
@@ -350,7 +353,9 @@ class Database(object):
         metadata = _metadata_with_prefix(self.name)
         api.drop_database(self.name, metadata=metadata)
 
-    def execute_partitioned_dml(self, dml, params=None, param_types=None):
+    def execute_partitioned_dml(
+        self, dml, params=None, param_types=None, query_options=None
+    ):
         """Execute a partitionable DML statement.
 
         :type dml: str
@@ -365,9 +370,20 @@ class Database(object):
             (Optional) maps explicit types for one or more param values;
             required if parameters are passed.
 
+        :type query_options:
+            :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+                or :class:`dict`
+        :param query_options:
+                (Optional) Query optimizer configuration to use for the given query.
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.spanner_v1.types.QueryOptions`
+
         :rtype: int
         :returns: Count of rows affected by the DML statement.
         """
+        query_options = _merge_query_options(
+            self._instance._client._query_options, query_options
+        )
         if params is not None:
             if param_types is None:
                 raise ValueError("Specify 'param_types' when passing 'params'.")
@@ -398,6 +414,7 @@ class Database(object):
                 transaction=txn_selector,
                 params=params_pb,
                 param_types=param_types,
+                query_options=query_options,
                 metadata=metadata,
             )
 
@@ -748,6 +765,7 @@ class BatchSnapshot(object):
         param_types=None,
         partition_size_bytes=None,
         max_partitions=None,
+        query_options=None,
     ):
         """Start a partitioned query operation.
 
@@ -783,6 +801,14 @@ class BatchSnapshot(object):
             service uses this as a hint, the actual number of partitions may
             differ.
 
+        :type query_options:
+            :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+                or :class:`dict`
+        :param query_options:
+                (Optional) Query optimizer configuration to use for the given query.
+                If a dict is provided, it must be of the same form as the protobuf
+                message :class:`~google.cloud.spanner_v1.types.QueryOptions`
+
         :rtype: iterable of dict
         :returns:
             mappings of information used peform actual partitioned reads via
@@ -800,6 +826,13 @@ class BatchSnapshot(object):
         if params:
             query_info["params"] = params
             query_info["param_types"] = param_types
+
+        # Query-level options have higher precedence than client-level and
+        # environment-level options
+        default_query_options = self._database._instance._client._query_options
+        query_info["query_options"] = _merge_query_options(
+            default_query_options, query_options
+        )
 
         for partition in partitions:
             yield {"partition": partition, "query": query_info}

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -228,6 +228,7 @@ class Session(object):
 
         :type query_options:
             :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+            or :class:`dict`
         :param query_options: (Optional) Options that are provided for query plan stability.
 
         :rtype: :class:`~google.cloud.spanner_v1.streamed.StreamedResultSet`

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -202,6 +202,7 @@ class Session(object):
         params=None,
         param_types=None,
         query_mode=None,
+        query_options=None,
         retry=google.api_core.gapic_v1.method.DEFAULT,
         timeout=google.api_core.gapic_v1.method.DEFAULT,
     ):
@@ -225,11 +226,21 @@ class Session(object):
         :param query_mode: Mode governing return of results / query plan. See
             https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteSqlRequest.QueryMode1
 
+        :type query_options:
+            :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+        :param query_options: (Optional) Options that are provided for query plan stability.
+
         :rtype: :class:`~google.cloud.spanner_v1.streamed.StreamedResultSet`
         :returns: a result set instance which can be used to consume rows.
         """
         return self.snapshot().execute_sql(
-            sql, params, param_types, query_mode, retry=retry, timeout=timeout
+            sql,
+            params,
+            param_types,
+            query_mode,
+            query_options=query_options,
+            retry=retry,
+            timeout=timeout,
         )
 
     def batch(self):

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -189,6 +189,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         :type query_options:
             :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+            or :class:`dict`
         :param query_options: (Optional) Options that are provided for query plan stability.
 
         :rtype: int

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -17,8 +17,11 @@
 from google.protobuf.struct_pb2 import Struct
 
 from google.cloud._helpers import _pb_timestamp_to_datetime
-from google.cloud.spanner_v1._helpers import _make_value_pb
-from google.cloud.spanner_v1._helpers import _metadata_with_prefix
+from google.cloud.spanner_v1._helpers import (
+    _make_value_pb,
+    _merge_query_options,
+    _metadata_with_prefix,
+)
 from google.cloud.spanner_v1.proto.transaction_pb2 import TransactionSelector
 from google.cloud.spanner_v1.proto.transaction_pb2 import TransactionOptions
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
@@ -162,7 +165,9 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         return None
 
-    def execute_update(self, dml, params=None, param_types=None, query_mode=None):
+    def execute_update(
+        self, dml, params=None, param_types=None, query_mode=None, query_options=None
+    ):
         """Perform an ``ExecuteSql`` API request with DML.
 
         :type dml: str
@@ -182,6 +187,10 @@ class Transaction(_SnapshotBase, _BatchBase):
         :param query_mode: Mode governing return of results / query plan. See
             https://cloud.google.com/spanner/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteSqlRequest.QueryMode1
 
+        :type query_options:
+            :class:`google.cloud.spanner_v1.proto.ExecuteSqlRequest.QueryOptions`
+        :param query_options: (Optional) Options that are provided for query plan stability.
+
         :rtype: int
         :returns: Count of rows affected by the DML statement.
         """
@@ -191,6 +200,11 @@ class Transaction(_SnapshotBase, _BatchBase):
         transaction = self._make_txn_selector()
         api = database.spanner_api
 
+        # Query-level options have higher precedence than client-level and
+        # environment-level options
+        default_query_options = database._instance._client._query_options
+        query_options = _merge_query_options(default_query_options, query_options)
+
         response = api.execute_sql(
             self._session.name,
             dml,
@@ -198,6 +212,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             params=params_pb,
             param_types=param_types,
             query_mode=query_mode,
+            query_options=query_options,
             seqno=self._execute_sql_count,
             metadata=metadata,
         )

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -60,6 +60,15 @@ class Test_merge_query_options(unittest.TestCase):
         result = self._callFUT(base, merge)
         self.assertEqual(result, expected)
 
+    def test_base_object_merge_dict(self):
+        from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
+
+        base = ExecuteSqlRequest.QueryOptions(optimizer_version="1")
+        merge = {"optimizer_version": "3"}
+        expected = ExecuteSqlRequest.QueryOptions(optimizer_version="3")
+        result = self._callFUT(base, merge)
+        self.assertEqual(result, expected)
+
 
 class Test_make_value_pb(unittest.TestCase):
     def _callFUT(self, *args, **kw):

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -39,7 +39,8 @@ class Test_merge_query_options(unittest.TestCase):
     def test_base_empty_and_merge_empty(self):
         from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
 
-        base = merge = ExecuteSqlRequest.QueryOptions()
+        base = ExecuteSqlRequest.QueryOptions()
+        merge = ExecuteSqlRequest.QueryOptions()
         result = self._callFUT(base, merge)
         self.assertIsNone(result)
 

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -16,6 +16,51 @@
 import unittest
 
 
+class Test_merge_query_options(unittest.TestCase):
+    def _callFUT(self, *args, **kw):
+        from google.cloud.spanner_v1._helpers import _merge_query_options
+
+        return _merge_query_options(*args, **kw)
+
+    def test_base_none_and_merge_none(self):
+        base = merge = None
+        result = self._callFUT(base, merge)
+        self.assertIsNone(result)
+
+    def test_base_dict_and_merge_none(self):
+        from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
+
+        base = {"optimizer_version": "2"}
+        merge = None
+        expected = ExecuteSqlRequest.QueryOptions(optimizer_version="2")
+        result = self._callFUT(base, merge)
+        self.assertEqual(result, expected)
+
+    def test_base_empty_and_merge_empty(self):
+        from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
+
+        base = merge = ExecuteSqlRequest.QueryOptions()
+        result = self._callFUT(base, merge)
+        self.assertIsNone(result)
+
+    def test_base_none_merge_object(self):
+        from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
+
+        base = None
+        merge = ExecuteSqlRequest.QueryOptions(optimizer_version="3")
+        result = self._callFUT(base, merge)
+        self.assertEqual(result, merge)
+
+    def test_base_none_merge_dict(self):
+        from google.cloud.spanner_v1.proto.spanner_pb2 import ExecuteSqlRequest
+
+        base = None
+        merge = {"optimizer_version": "3"}
+        expected = ExecuteSqlRequest.QueryOptions(optimizer_version="3")
+        result = self._callFUT(base, merge)
+        self.assertEqual(result, expected)
+
+
 class Test_make_value_pb(unittest.TestCase):
     def _callFUT(self, *args, **kw):
         from google.cloud.spanner_v1._helpers import _make_value_pb

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -362,6 +362,7 @@ class TestSession(unittest.TestCase):
             None,
             None,
             None,
+            query_options=None,
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             retry=google.api_core.gapic_v1.method.DEFAULT,
         )
@@ -386,7 +387,13 @@ class TestSession(unittest.TestCase):
         self.assertIs(found, snapshot().execute_sql.return_value)
 
         snapshot().execute_sql.assert_called_once_with(
-            SQL, params, param_types, "PLAN", timeout=None, retry=None
+            SQL,
+            params,
+            param_types,
+            "PLAN",
+            query_options=None,
+            timeout=None,
+            retry=None,
         )
 
     def test_execute_sql_explicit(self):
@@ -411,6 +418,7 @@ class TestSession(unittest.TestCase):
             params,
             param_types,
             "PLAN",
+            query_options=None,
             timeout=google.api_core.gapic_v1.method.DEFAULT,
             retry=google.api_core.gapic_v1.method.DEFAULT,
         )


### PR DESCRIPTION
Adds support for QueryOptions.

The QueryOptions are set in one of three ways (in ascending order of precedence):

* As an argument to the Client constructor.
* Setting the SPANNER_OPTIMIZER_VERSION env variable.
* On a per-query basis.

If the backend implements query hints, for example, to instruct the backend which query optimizer version to use, these query hints will also automatically be supported.