### PR TITLE
docs: fix incorrect return types

### DIFF
--- a/google/cloud/spanner_admin_database_v1/gapic/database_admin_client.py
+++ b/google/cloud/spanner_admin_database_v1/gapic/database_admin_client.py
@@ -292,7 +292,7 @@ class DatabaseAdminClient(object):
                 that is provided to the method.
 
         Returns:
-            A :class:`~google.cloud.spanner_admin_database_v1.types._OperationFuture` instance.
+            A :class:`~google.api_core.operation.Operation` instance.
 
         Raises:
             google.api_core.exceptions.GoogleAPICallError: If the request
@@ -476,7 +476,7 @@ class DatabaseAdminClient(object):
                 that is provided to the method.
 
         Returns:
-            A :class:`~google.cloud.spanner_admin_database_v1.types._OperationFuture` instance.
+            A :class:`~google.api_core.operation.Operation` instance.
 
         Raises:
             google.api_core.exceptions.GoogleAPICallError: If the request
@@ -988,7 +988,7 @@ class DatabaseAdminClient(object):
                 that is provided to the method.
 
         Returns:
-            A :class:`~google.cloud.spanner_admin_database_v1.types._OperationFuture` instance.
+            A :class:`~google.api_core.operation.Operation` instance.
 
         Raises:
             google.api_core.exceptions.GoogleAPICallError: If the request
@@ -1466,7 +1466,7 @@ class DatabaseAdminClient(object):
                 that is provided to the method.
 
         Returns:
-            A :class:`~google.cloud.spanner_admin_database_v1.types._OperationFuture` instance.
+            A :class:`~google.api_core.operation.Operation` instance.
 
         Raises:
             google.api_core.exceptions.GoogleAPICallError: If the request


### PR DESCRIPTION
Fixing the method doclines from the original issue, and three similar places as well
Fixes #41 