### PR TITLE
fix: add keepalive to gRPC channel

### DIFF
--- a/google/cloud/spanner_v1/gapic/transports/spanner_grpc_transport.py
+++ b/google/cloud/spanner_v1/gapic/transports/spanner_grpc_transport.py
@@ -23,6 +23,7 @@ import google.api_core.grpc_helpers
 from google.cloud.spanner_v1.proto import spanner_pb2_grpc
 
 
+_GRPC_KEEPALIVE_MS = 2 * 60 * 1000
 _SPANNER_GRPC_CONFIG = "spanner.grpc.config"
 
 
@@ -73,6 +74,7 @@ class SpannerGrpcTransport(object):
                 options={
                     "grpc.max_send_message_length": -1,
                     "grpc.max_receive_message_length": -1,
+                    "grpc.keepalive_time_ms": _GRPC_KEEPALIVE_MS,
                 }.items(),
             )
 


### PR DESCRIPTION
This patch adds keepalives to the GRPC channel every 2 minutes. By default, there are no keepalives to the GRPC channel. There have been issues observed with seeing DEADLINE_EXCEEDED errors at 10 minutes despite the timeout being longer eg 1 hour. Adding keepalives will hopefully address this. [This fix has been added to the Java client for similar reasons](https://github.com/googleapis/java-spanner/pull/11).