### PR TITLE
 fix: Pin Sphnix version to last working release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -143,7 +143,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx", "alabaster", "recommonmark")
+    session.install("sphinx==2.4.4", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(


### PR DESCRIPTION
Towards #50

The nox docs session is failing due to the new Sphnix release. This PR pins the install to the previous release until the problem can be debugged.