### PR TITLE
test: use assertIsInstance where possible

### DIFF
--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -120,7 +120,7 @@ class TestBackup(_BaseTest):
 
         backup = backup_class.from_pb(backup_pb, instance)
 
-        self.assertTrue(isinstance(backup, backup_class))
+        self.assertIsInstance(backup, backup_class)
         self.assertEqual(backup._instance, instance)
         self.assertEqual(backup.backup_id, self.BACKUP_ID)
         self.assertEqual(backup._database, "")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -459,7 +459,7 @@ class TestClient(unittest.TestCase):
 
         instance = client.instance(self.INSTANCE_ID)
 
-        self.assertTrue(isinstance(instance, Instance))
+        self.assertIsInstance(instance, Instance)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertIsNone(instance.configuration_name)
         self.assertEqual(instance.display_name, self.INSTANCE_ID)
@@ -479,7 +479,7 @@ class TestClient(unittest.TestCase):
             node_count=self.NODE_COUNT,
         )
 
-        self.assertTrue(isinstance(instance, Instance))
+        self.assertIsInstance(instance, Instance)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.configuration_name, self.CONFIGURATION_NAME)
         self.assertEqual(instance.display_name, self.DISPLAY_NAME)

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -198,7 +198,7 @@ class TestDatabase(_BaseTest):
 
         database = klass.from_pb(database_pb, instance, pool=pool)
 
-        self.assertTrue(isinstance(database, klass))
+        self.assertIsInstance(database, klass)
         self.assertEqual(database._instance, instance)
         self.assertEqual(database.database_id, self.DATABASE_ID)
         self.assertIs(database._pool, pool)
@@ -218,7 +218,7 @@ class TestDatabase(_BaseTest):
 
         database = klass.from_pb(database_pb, instance)
 
-        self.assertTrue(isinstance(database, klass))
+        self.assertIsInstance(database, klass)
         self.assertEqual(database._instance, instance)
         self.assertEqual(database.database_id, DATABASE_ID_HYPHEN)
         self.assertIsInstance(database._pool, BurstyPool)
@@ -1074,7 +1074,7 @@ class TestDatabase(_BaseTest):
 
         session = database.session()
 
-        self.assertTrue(isinstance(session, Session))
+        self.assertIsInstance(session, Session)
         self.assertIs(session.session_id, None)
         self.assertIs(session._database, database)
         self.assertEqual(session.labels, {})
@@ -1090,7 +1090,7 @@ class TestDatabase(_BaseTest):
 
         session = database.session(labels=labels)
 
-        self.assertTrue(isinstance(session, Session))
+        self.assertIsInstance(session, Session)
         self.assertIs(session.session_id, None)
         self.assertIs(session._database, database)
         self.assertEqual(session.labels, labels)

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -159,7 +159,7 @@ class TestInstance(unittest.TestCase):
 
         klass = self._getTargetClass()
         instance = klass.from_pb(instance_pb, client)
-        self.assertTrue(isinstance(instance, klass))
+        self.assertIsInstance(instance, klass)
         self.assertEqual(instance._client, client)
         self.assertEqual(instance.instance_id, self.INSTANCE_ID)
         self.assertEqual(instance.configuration_name, self.CONFIG_NAME)
@@ -469,7 +469,7 @@ class TestInstance(unittest.TestCase):
 
         database = instance.database(DATABASE_ID)
 
-        self.assertTrue(isinstance(database, Database))
+        self.assertIsInstance(database, Database)
         self.assertEqual(database.database_id, DATABASE_ID)
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
@@ -490,7 +490,7 @@ class TestInstance(unittest.TestCase):
             DATABASE_ID, ddl_statements=DDL_STATEMENTS, pool=pool
         )
 
-        self.assertTrue(isinstance(database, Database))
+        self.assertIsInstance(database, Database)
         self.assertEqual(database.database_id, DATABASE_ID)
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), DDL_STATEMENTS)


### PR DESCRIPTION
Using the self.assertIsInstance(..., ...) method will give more detailed error information than self.assertTrue(isinstance(..., ...))