### PR TITLE
feat: add support for retrying aborted partitioned DML statements

### DIFF
--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -400,7 +400,9 @@ class Database(object):
         def execute_pdml():
             with SessionCheckout(self._pool) as session:
 
-                txn = api.begin_transaction(session.name, txn_options, metadata=metadata)
+                txn = api.begin_transaction(
+                    session.name, txn_options, metadata=metadata
+                )
 
                 txn_selector = TransactionSelector(id=txn.id)
 

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -21,9 +21,7 @@ import re
 import threading
 
 import google.auth.credentials
-from google.api_core.retry import Retry
 from google.api_core.retry import if_exception_type
-import google.auth.credentials
 from google.protobuf.struct_pb2 import Struct
 from google.cloud.exceptions import NotFound
 from google.api_core.exceptions import Aborted

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -819,7 +819,9 @@ class TestDatabase(_BaseTest):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
         if retried:
-            expected_retry_transaction = TransactionSelector(id=self.RETRY_TRANSACTION_ID)
+            expected_retry_transaction = TransactionSelector(
+                id=self.RETRY_TRANSACTION_ID
+            )
             api.execute_streaming_sql.assert_called_with(
                 self.SESSION_NAME,
                 dml,
@@ -854,9 +856,7 @@ class TestDatabase(_BaseTest):
         )
 
     def test_execute_partitioned_dml_wo_params_retry_aborted(self):
-        self._execute_partitioned_dml_helper(
-            dml=DML_WO_PARAM, retried=True
-        )
+        self._execute_partitioned_dml_helper(dml=DML_WO_PARAM, retried=True)
 
     def test_session_factory_defaults(self):
         from google.cloud.spanner_v1.session import Session

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -53,6 +53,7 @@ class _BaseTest(unittest.TestCase):
     SESSION_ID = "session_id"
     SESSION_NAME = DATABASE_NAME + "/sessions/" + SESSION_ID
     TRANSACTION_ID = b"transaction_id"
+    RETRY_TRANSACTION_ID = b"transaction_id_retry"
     BACKUP_ID = "backup_id"
     BACKUP_NAME = INSTANCE_NAME + "/backups/" + BACKUP_ID
 
@@ -735,8 +736,9 @@ class TestDatabase(_BaseTest):
         )
 
     def _execute_partitioned_dml_helper(
-        self, dml, params=None, param_types=None, query_options=None
+        self, dml, params=None, param_types=None, query_options=None, retried=False
     ):
+        from google.api_core.exceptions import Aborted
         from google.protobuf.struct_pb2 import Struct
         from google.cloud.spanner_v1.proto.result_set_pb2 import (
             PartialResultSet,
@@ -765,8 +767,13 @@ class TestDatabase(_BaseTest):
         pool.put(session)
         database = self._make_one(self.DATABASE_ID, instance, pool=pool)
         api = database._spanner_api = self._make_spanner_api()
-        api.begin_transaction.return_value = transaction_pb
-        api.execute_streaming_sql.return_value = iterator
+        if retried:
+            retry_transaction_pb = TransactionPB(id=self.RETRY_TRANSACTION_ID)
+            api.begin_transaction.side_effect = [transaction_pb, retry_transaction_pb]
+            api.execute_streaming_sql.side_effect = [Aborted("test"), iterator]
+        else:
+            api.begin_transaction.return_value = transaction_pb
+            api.execute_streaming_sql.return_value = iterator
 
         row_count = database.execute_partitioned_dml(
             dml, params, param_types, query_options
@@ -778,11 +785,15 @@ class TestDatabase(_BaseTest):
             partitioned_dml=TransactionOptions.PartitionedDml()
         )
 
-        api.begin_transaction.assert_called_once_with(
+        api.begin_transaction.assert_called_with(
             session.name,
             txn_options,
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
+        if retried:
+            self.assertEqual(api.begin_transaction.call_count, 2)
+        else:
+            self.assertEqual(api.begin_transaction.call_count, 1)
 
         if params:
             expected_params = Struct(
@@ -798,7 +809,7 @@ class TestDatabase(_BaseTest):
                 expected_query_options, query_options
             )
 
-        api.execute_streaming_sql.assert_called_once_with(
+        api.execute_streaming_sql.assert_any_call(
             self.SESSION_NAME,
             dml,
             transaction=expected_transaction,
@@ -807,6 +818,20 @@ class TestDatabase(_BaseTest):
             query_options=expected_query_options,
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
+        if retried:
+            expected_retry_transaction = TransactionSelector(id=self.RETRY_TRANSACTION_ID)
+            api.execute_streaming_sql.assert_called_with(
+                self.SESSION_NAME,
+                dml,
+                transaction=expected_retry_transaction,
+                params=expected_params,
+                param_types=param_types,
+                query_options=expected_query_options,
+                metadata=[("google-cloud-resource-prefix", database.name)],
+            )
+            self.assertEqual(api.execute_streaming_sql.call_count, 2)
+        else:
+            self.assertEqual(api.execute_streaming_sql.call_count, 1)
 
     def test_execute_partitioned_dml_wo_params(self):
         self._execute_partitioned_dml_helper(dml=DML_WO_PARAM)
@@ -826,6 +851,11 @@ class TestDatabase(_BaseTest):
         self._execute_partitioned_dml_helper(
             dml=DML_W_PARAM,
             query_options=ExecuteSqlRequest.QueryOptions(optimizer_version="3"),
+        )
+
+    def test_execute_partitioned_dml_wo_params_retry_aborted(self):
+        self._execute_partitioned_dml_helper(
+            dml=DML_WO_PARAM, retried=True
         )
 
     def test_session_factory_defaults(self):


### PR DESCRIPTION
Partitioned DML transactions can be aborted by Cloud Spanner. These transactions were not automatically retried by the client library. This PR adds support for automatically retrying aborted partitioned DML statements.