### PR TITLE
docs: re-pin sphinx version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ Return sessions from pool in LIFO order. ([#9454](https://github.com/googleapis/
 - Allow kwargs to be passed to create_channel (via synth). ([#8403](https://github.com/googleapis/google-cloud-python/pull/8403))
 
 ### New Features
-- Add 'options_' argument to clients 'get_iam_policy'; pin black version (via synth). ([#8659](https://github.com/googleapis/google-cloud-python/pull/8659))
+- Add 'options\_' argument to clients' 'get_iam_policy'; pin black version (via synth). ([#8659](https://github.com/googleapis/google-cloud-python/pull/8659))
 - Add 'client_options' support, update list method docstrings (via synth). ([#8522](https://github.com/googleapis/google-cloud-python/pull/8522))
 
 ### Dependencies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
-    "recommonmark",
 ]
 
 # autodoc/autosummary flags

--- a/noxfile.py
+++ b/noxfile.py
@@ -143,7 +143,7 @@ def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx", "alabaster", "recommonmark")
+    session.install("sphinx<3.0.0", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(


### PR DESCRIPTION
Reopens #50

Unfortunately, synthtool has pinned to sphinx<3.0.0 which means any code regen via synth will cause docs to fail. Until it is updated to support it, we also need to pin to sphinx<3.0.0.