### PR TITLE
refactor: PingingPool pings sessions using SELECT 1

### DIFF
--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -387,9 +387,7 @@ class PingingPool(AbstractSessionPool):
         ping_after, session = self._sessions.get(block=True, timeout=timeout)
 
         if _NOW() > ping_after:
-            try:
-                session.ping()
-            except NotFound:
+            if not session.exists():
                 session = self._new_session()
                 session.create()
 

--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -387,6 +387,9 @@ class PingingPool(AbstractSessionPool):
         ping_after, session = self._sessions.get(block=True, timeout=timeout)
 
         if _NOW() > ping_after:
+            # Using session.exists() guarantees the returned session exists.
+            # session.ping() uses a cached result in the backend which could
+            # result in a recently deleted session being returned.
             if not session.exists():
                 session = self._new_session()
                 session.create()

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -153,6 +153,17 @@ class Session(object):
 
         api.delete_session(self.name, metadata=metadata)
 
+    def ping(self):
+        """Ping the session to keep it alive by executing "SELECT 1".
+
+        :raises: ValueError: if :attr:`session_id` is not already set.
+        """
+        if self._session_id is None:
+            raise ValueError("Session ID not set by back-end")
+        api = self._database.spanner_api
+        metadata = _metadata_with_prefix(self._database.name)
+        api.execute_sql(self.name, "SELECT 1", metadata=metadata)
+
     def snapshot(self, **kw):
         """Create a snapshot to perform a set of reads with shared staleness.
 

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -446,7 +446,7 @@ class TestPingingPool(unittest.TestCase):
         SESSIONS = [_Session(database)] * 4
         database._sessions.extend(SESSIONS)
 
-        sessions_created = datetime.datetime.utcnow() - datetime.timedelta(seconds=3000)
+        sessions_created = datetime.datetime.utcnow() - datetime.timedelta(seconds=4000)
 
         with _Monkey(MUT, _NOW=lambda: sessions_created):
             pool.bind(database)
@@ -477,7 +477,7 @@ class TestPingingPool(unittest.TestCase):
 
         self.assertIs(session, SESSIONS[4])
         session.create.assert_called()
-        self.assertFalse(SESSIONS[0]._pinged)
+        self.assertTrue(SESSIONS[0]._pinged)
         self.assertFalse(pool._sessions.full())
 
     def test_get_empty_default_timeout(self):
@@ -532,8 +532,8 @@ class TestPingingPool(unittest.TestCase):
             pool.put(session)
 
         self.assertEqual(len(queue._items), 1)
-        last_used, queued = queue._items[0]
-        self.assertEqual(last_used, now)
+        ping_after, queued = queue._items[0]
+        self.assertEqual(ping_after, now + datetime.timedelta(seconds=3000))
         self.assertIs(queued, session)
 
     def test_clear(self):
@@ -580,7 +580,7 @@ class TestPingingPool(unittest.TestCase):
         database._sessions.extend(SESSIONS)
         pool.bind(database)
 
-        later = datetime.datetime.utcnow() + datetime.timedelta(seconds=3500)
+        later = datetime.datetime.utcnow() + datetime.timedelta(seconds=4000)
         with _Monkey(MUT, _NOW=lambda: later):
             pool.ping()
 
@@ -602,7 +602,7 @@ class TestPingingPool(unittest.TestCase):
         with _Monkey(MUT, _NOW=lambda: later):
             pool.ping()
 
-        self.assertFalse(SESSIONS[0]._pinged)
+        self.assertTrue(SESSIONS[0]._pinged)
         SESSIONS[1].create.assert_called()
 
 

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -433,7 +433,7 @@ class TestPingingPool(unittest.TestCase):
         session = pool.get()
 
         self.assertIs(session, SESSIONS[0])
-        self.assertFalse(session._pinged)
+        self.assertFalse(session._exists_checked)
         self.assertFalse(pool._sessions.full())
 
     def test_get_hit_w_ping(self):
@@ -454,7 +454,7 @@ class TestPingingPool(unittest.TestCase):
         session = pool.get()
 
         self.assertIs(session, SESSIONS[0])
-        self.assertTrue(session._pinged)
+        self.assertTrue(session._exists_checked)
         self.assertFalse(pool._sessions.full())
 
     def test_get_hit_w_ping_expired(self):
@@ -477,7 +477,7 @@ class TestPingingPool(unittest.TestCase):
 
         self.assertIs(session, SESSIONS[4])
         session.create.assert_called()
-        self.assertTrue(SESSIONS[0]._pinged)
+        self.assertTrue(SESSIONS[0]._exists_checked)
         self.assertFalse(pool._sessions.full())
 
     def test_get_empty_default_timeout(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -232,17 +232,17 @@ class TestSession(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
-    def test_ping_miss(self):
-        from google.api_core.exceptions import NotFound
+    def test_ping_error(self):
+        from google.api_core.exceptions import Unknown
 
         gax_api = self._make_spanner_api()
-        gax_api.execute_sql.side_effect = NotFound("testing")
+        gax_api.execute_sql.side_effect = Unknown("testing")
         database = self._make_database()
         database.spanner_api = gax_api
         session = self._make_one(database)
         session._session_id = self.SESSION_ID
 
-        with self.assertRaises(NotFound):
+        with self.assertRaises(Unknown):
             session.ping()
 
         gax_api.execute_sql.assert_called_once_with(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -210,6 +210,47 @@ class TestSession(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+    def test_ping_wo_session_id(self):
+        database = self._make_database()
+        session = self._make_one(database)
+        with self.assertRaises(ValueError):
+            session.ping()
+
+    def test_ping_hit(self):
+        gax_api = self._make_spanner_api()
+        gax_api.execute_sql.return_value = "1"
+        database = self._make_database()
+        database.spanner_api = gax_api
+        session = self._make_one(database)
+        session._session_id = self.SESSION_ID
+
+        session.ping()
+
+        gax_api.execute_sql.assert_called_once_with(
+            self.SESSION_NAME,
+            "SELECT 1",
+            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
+    def test_ping_miss(self):
+        from google.api_core.exceptions import NotFound
+
+        gax_api = self._make_spanner_api()
+        gax_api.execute_sql.side_effect = NotFound("testing")
+        database = self._make_database()
+        database.spanner_api = gax_api
+        session = self._make_one(database)
+        session._session_id = self.SESSION_ID
+
+        with self.assertRaises(NotFound):
+            session.ping()
+
+        gax_api.execute_sql.assert_called_once_with(
+            self.SESSION_NAME,
+            "SELECT 1",
+            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
     def test_delete_wo_session_id(self):
         database = self._make_database()
         session = self._make_one(database)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -232,6 +232,25 @@ class TestSession(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+    def test_ping_miss(self):
+        from google.api_core.exceptions import NotFound
+
+        gax_api = self._make_spanner_api()
+        gax_api.execute_sql.side_effect = NotFound("testing")
+        database = self._make_database()
+        database.spanner_api = gax_api
+        session = self._make_one(database)
+        session._session_id = self.SESSION_ID
+
+        with self.assertRaises(NotFound):
+            session.ping()
+
+        gax_api.execute_sql.assert_called_once_with(
+            self.SESSION_NAME,
+            "SELECT 1",
+            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
     def test_ping_error(self):
         from google.api_core.exceptions import Unknown
 


### PR DESCRIPTION
Currently, PingingPool pings sessions in the background by calling `session.exists()` which calls `GetSession`. 

Using `SELECT 1` is preferred and is used in other client libraries such as [Go](https://github.com/googleapis/google-cloud-go/blob/53898305c6f21b3c3eef34fcff6c61a2cb36f602/spanner/session.go#L227):