### PR TITLE
test: remove unneeded system test skip when using emulator

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -2330,7 +2330,6 @@ class TestSessionAPI(unittest.TestCase, _TestData):
             # NaNs cannot be searched for by equality.
             self.assertTrue(math.isnan(float_array[2]))
 
-    @unittest.skipIf(USE_EMULATOR, "Skipping partitioned queries")
     def test_partition_query(self):
         row_count = 40
         sql = "SELECT * FROM {}".format(self.TABLE)


### PR DESCRIPTION
The functionality in test_partition_query is supported by the emulator. We should not be skipping it.