### PR TITLE
feat: add OpenTelemetry tracing to spanner calls

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ API Documentation
 
   api-reference
   advanced-session-pool-topics
+  opentelemetry-tracing
 
 Changelog
 ---------

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -1,0 +1,36 @@
+Tracing with OpenTelemetry
+==================================
+Python-spanner uses `OpenTelemetry <https://opentelemetry.io/>`_ to automatically generates traces providing insight on calls to Cloud Spanner. 
+For information on the benefits and utility of tracing, see the `Cloud Trace docs <https://cloud.google.com/trace/docs/overview>`_.
+
+To take advantage of these traces, we first need to install opentelemetry:
+
+.. code-block:: sh
+
+    pip install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation
+
+We also need to tell OpenTelemetry which exporter to use. For example, to export python-spanner traces to `Cloud Tracing <https://cloud.google.com/trace>`_, add the following lines to your application:
+
+.. code:: python
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace.sampling import ProbabilitySampler
+    from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+    # BatchExportSpanProcessor exports spans to Cloud Trace 
+    # in a seperate thread to not block on the main thread
+    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+
+    # create and export one trace every 1000 requests
+    sampler = ProbabilitySampler(1/1000)
+    # Uses the default tracer provider
+    trace.set_tracer_provider(TracerProvider(sampler=sampler))
+    trace.get_tracer_provider().add_span_processor(
+        # initialize the cloud tracing exporter
+        BatchExportSpanProcessor(CloudTraceSpanExporter())
+    )
+
+Generated spanner traces should now be available on `Cloud Trace <https://console.cloud.google.com/traces>`_.
+
+Tracing is most effective when many libraries are instrumented to provide insight over the entire lifespan of a request.
+For a list of libraries that can be instrumented, see the `OpenTelemetry Integrations` section of the `OpenTelemetry Python docs <https://opentelemetry-python.readthedocs.io/en/stable/>`_

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -1,6 +1,6 @@
 Tracing with OpenTelemetry
 ==================================
-Python-spanner uses `OpenTelemetry <https://opentelemetry.io/>`_ to automatically generates traces providing insight on calls to Cloud Spanner. 
+This library uses `OpenTelemetry <https://opentelemetry.io/>`_ to automatically generate traces providing insight on calls to Cloud Spanner. 
 For information on the benefits and utility of tracing, see the `Cloud Trace docs <https://cloud.google.com/trace/docs/overview>`_.
 
 To take advantage of these traces, we first need to install opentelemetry:

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -21,12 +21,12 @@ We also need to tell OpenTelemetry which exporter to use. For example, to export
     # in a seperate thread to not block on the main thread
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
-    # create and export one trace every 1000 requests
+    # Create and export one trace every 1000 requests
     sampler = ProbabilitySampler(1/1000)
-    # Uses the default tracer provider
+    # Use the default tracer provider
     trace.set_tracer_provider(TracerProvider(sampler=sampler))
     trace.get_tracer_provider().add_span_processor(
-        # initialize the cloud tracing exporter
+        # Initialize the cloud tracing exporter
         BatchExportSpanProcessor(CloudTraceSpanExporter())
     )
 

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -1,0 +1,65 @@
+# Copyright 2016 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manages OpenTelemetry trace creation and handling"""
+
+from contextlib import contextmanager
+
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud.spanner_v1.gapic import spanner_client
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace.status import Status, StatusCanonicalCode
+    from opentelemetry.instrumentation.utils import http_status_to_canonical_code
+
+    HAS_OPENTELEMETRY_INSTALLED = True
+except ImportError:
+    HAS_OPENTELEMETRY_INSTALLED = False
+
+
+@contextmanager
+def trace_call(name, session, extra_attributes=None):
+    if not HAS_OPENTELEMETRY_INSTALLED:
+        # empty context manager. users will have to check if the generated value is None or a span
+        yield None
+        return
+
+    tracer = trace.get_tracer(__name__)
+
+    # base attributes that we know for every trace created
+    attributes = {
+        "db.type": "spanner",
+        "db.url": spanner_client.SpannerClient.SERVICE_ADDRESS,
+        "db.instance": session._database.name,
+        "net.host.name": spanner_client.SpannerClient.SERVICE_ADDRESS,
+    }
+
+    if extra_attributes:
+        attributes.update(extra_attributes)
+
+    with tracer.start_as_current_span(
+        name, kind=trace.SpanKind.CLIENT, attributes=attributes
+    ) as span:
+        try:
+            yield span
+        except GoogleAPICallError as error:
+            if error.code is not None:
+                span.set_status(Status(http_status_to_canonical_code(error.code)))
+            elif error.grpc_status_code is not None:
+                span.set_status(
+                    # OpenTelemetry's StatusCanonicalCode maps 1-1 with grpc status codes
+                    Status(StatusCanonicalCode(error.grpc_status_code.value[0]))
+                )
+            raise

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -31,7 +31,7 @@ except ImportError:
 
 @contextmanager
 def trace_call(name, session, extra_attributes=None):
-    if not HAS_OPENTELEMETRY_INSTALLED:
+    if not HAS_OPENTELEMETRY_INSTALLED or not session:
         # empty context manager. users will have to check if the generated value is None or a span
         yield None
         return

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google LLC All rights reserved.
+# Copyright 2020 Google LLC All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -32,13 +32,13 @@ except ImportError:
 @contextmanager
 def trace_call(name, session, extra_attributes=None):
     if not HAS_OPENTELEMETRY_INSTALLED or not session:
-        # empty context manager. users will have to check if the generated value is None or a span
+        # Empty context manager. Users will have to check if the generated value is None or a span
         yield None
         return
 
     tracer = trace.get_tracer(__name__)
 
-    # base attributes that we know for every trace created
+    # Set base attributes that we know for every trace created
     attributes = {
         "db.type": "spanner",
         "db.url": spanner_client.SpannerClient.SERVICE_ADDRESS,

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -139,9 +139,11 @@ class Session(object):
         with trace_call("CloudSpanner.GetSession", self) as span:
             try:
                 api.get_session(self.name, metadata=metadata)
-                span.set_attribute("session_found", True)
+                if span:
+                    span.set_attribute("session_found", True)
             except NotFound:
-                span.set_attribute("session_found", False)
+                if span:
+                    span.set_attribute("session_found", False)
                 return False
 
         return True

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -26,6 +26,7 @@ from google.cloud.spanner_v1._helpers import _metadata_with_prefix
 from google.cloud.spanner_v1.batch import Batch
 from google.cloud.spanner_v1.snapshot import Snapshot
 from google.cloud.spanner_v1.transaction import Transaction
+from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
 import random
 
 # pylint: enable=ungrouped-imports
@@ -114,7 +115,11 @@ class Session(object):
         kw = {}
         if self._labels:
             kw = {"session": {"labels": self._labels}}
-        session_pb = api.create_session(self._database.name, metadata=metadata, **kw)
+
+        with trace_call("CloudSpanner.CreateSession", self, self._labels):
+            session_pb = api.create_session(
+                self._database.name, metadata=metadata, **kw
+            )
         self._session_id = session_pb.name.split("/")[-1]
 
     def exists(self):
@@ -130,10 +135,14 @@ class Session(object):
             return False
         api = self._database.spanner_api
         metadata = _metadata_with_prefix(self._database.name)
-        try:
-            api.get_session(self.name, metadata=metadata)
-        except NotFound:
-            return False
+
+        with trace_call("CloudSpanner.GetSession", self) as span:
+            try:
+                api.get_session(self.name, metadata=metadata)
+                span.set_attribute("session_found", True)
+            except NotFound:
+                span.set_attribute("session_found", False)
+                return False
 
         return True
 
@@ -150,8 +159,8 @@ class Session(object):
             raise ValueError("Session ID not set by back-end")
         api = self._database.spanner_api
         metadata = _metadata_with_prefix(self._database.name)
-
-        api.delete_session(self.name, metadata=metadata)
+        with trace_call("CloudSpanner.DeleteSession", self):
+            api.delete_session(self.name, metadata=metadata)
 
     def ping(self):
         """Ping the session to keep it alive by executing "SELECT 1".

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -30,9 +30,10 @@ from google.cloud.spanner_v1._helpers import _metadata_with_prefix
 from google.cloud.spanner_v1._helpers import _SessionWrapper
 from google.cloud.spanner_v1.streamed import StreamedResultSet
 from google.cloud.spanner_v1.types import PartitionOptions
+from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
 
 
-def _restart_on_unavailable(restart):
+def _restart_on_unavailable(restart, trace_name=None, session=None, attributes=None):
     """Restart iteration after :exc:`.ServiceUnavailable`.
 
     :type restart: callable
@@ -40,7 +41,11 @@ def _restart_on_unavailable(restart):
     """
     resume_token = b""
     item_buffer = []
-    iterator = restart()
+    if trace_name and session:
+        with trace_call(trace_name, session, attributes):
+            iterator = restart()
+    else:
+        iterator = restart()
     while True:
         try:
             for item in iterator:
@@ -50,7 +55,11 @@ def _restart_on_unavailable(restart):
                     break
         except ServiceUnavailable:
             del item_buffer[:]
-            iterator = restart(resume_token=resume_token)
+            if trace_name and session:
+                with trace_call(trace_name, session, attributes):
+                    iterator = restart(resume_token=resume_token)
+            else:
+                iterator = restart(resume_token=resume_token)
             continue
 
         if len(item_buffer) == 0:
@@ -143,7 +152,10 @@ class _SnapshotBase(_SessionWrapper):
             metadata=metadata,
         )
 
-        iterator = _restart_on_unavailable(restart)
+        trace_attributes = {"table_id": table, "columns": columns}
+        iterator = _restart_on_unavailable(
+            restart, "CloudSpanner.ReadOnlyTransaction", self._session, trace_attributes
+        )
 
         self._read_request_count += 1
 
@@ -243,7 +255,13 @@ class _SnapshotBase(_SessionWrapper):
             timeout=timeout,
         )
 
-        iterator = _restart_on_unavailable(restart)
+        trace_attributes = {"db.statement": sql}
+        iterator = _restart_on_unavailable(
+            restart,
+            "CloudSpanner.ReadWriteTransaction",
+            self._session,
+            trace_attributes,
+        )
 
         self._read_request_count += 1
         self._execute_sql_count += 1
@@ -309,16 +327,20 @@ class _SnapshotBase(_SessionWrapper):
             partition_size_bytes=partition_size_bytes, max_partitions=max_partitions
         )
 
-        response = api.partition_read(
-            session=self._session.name,
-            table=table,
-            columns=columns,
-            key_set=keyset._to_pb(),
-            transaction=transaction,
-            index=index,
-            partition_options=partition_options,
-            metadata=metadata,
-        )
+        trace_attributes = {"table_id": table, "columns": columns}
+        with trace_call(
+            "CloudSpanner.PartitionReadOnlyTransaction", self._session, trace_attributes
+        ):
+            response = api.partition_read(
+                session=self._session.name,
+                table=table,
+                columns=columns,
+                key_set=keyset._to_pb(),
+                transaction=transaction,
+                index=index,
+                partition_options=partition_options,
+                metadata=metadata,
+            )
 
         return [partition.partition_token for partition in response.partitions]
 
@@ -385,15 +407,21 @@ class _SnapshotBase(_SessionWrapper):
             partition_size_bytes=partition_size_bytes, max_partitions=max_partitions
         )
 
-        response = api.partition_query(
-            session=self._session.name,
-            sql=sql,
-            transaction=transaction,
-            params=params_pb,
-            param_types=param_types,
-            partition_options=partition_options,
-            metadata=metadata,
-        )
+        trace_attributes = {"db.statement": sql}
+        with trace_call(
+            "CloudSpanner.PartitionReadWriteTransaction",
+            self._session,
+            trace_attributes,
+        ):
+            response = api.partition_query(
+                session=self._session.name,
+                sql=sql,
+                transaction=transaction,
+                params=params_pb,
+                param_types=param_types,
+                partition_options=partition_options,
+                metadata=metadata,
+            )
 
         return [partition.partition_token for partition in response.partitions]
 
@@ -515,8 +543,9 @@ class Snapshot(_SnapshotBase):
         api = database.spanner_api
         metadata = _metadata_with_prefix(database.name)
         txn_selector = self._make_txn_selector()
-        response = api.begin_transaction(
-            self._session.name, txn_selector.begin, metadata=metadata
-        )
+        with trace_call("CloudSpanner.BeginTransaction", self._session):
+            response = api.begin_transaction(
+                self._session.name, txn_selector.begin, metadata=metadata
+            )
         self._transaction_id = response.id
         return self._transaction_id

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -41,10 +41,7 @@ def _restart_on_unavailable(restart, trace_name=None, session=None, attributes=N
     """
     resume_token = b""
     item_buffer = []
-    if trace_name and session:
-        with trace_call(trace_name, session, attributes):
-            iterator = restart()
-    else:
+    with trace_call(trace_name, session, attributes):
         iterator = restart()
     while True:
         try:
@@ -55,10 +52,7 @@ def _restart_on_unavailable(restart, trace_name=None, session=None, attributes=N
                     break
         except ServiceUnavailable:
             del item_buffer[:]
-            if trace_name and session:
-                with trace_call(trace_name, session, attributes):
-                    iterator = restart(resume_token=resume_token)
-            else:
+            with trace_call(trace_name, session, attributes):
                 iterator = restart(resume_token=resume_token)
             continue
 

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -279,7 +279,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         trace_attributes = {
             # Get just the queries from the DML statement batch
-            "db.statement": [statement[0] for statement in statements]
+            "db.statement": [statement["sql"] for statement in parsed]
         }
         with trace_call("CloudSpanner.DMLTransaction", self._session, trace_attributes):
             response = api.execute_batch_dml(

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -26,6 +26,7 @@ from google.cloud.spanner_v1.proto.transaction_pb2 import TransactionSelector
 from google.cloud.spanner_v1.proto.transaction_pb2 import TransactionOptions
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
 from google.cloud.spanner_v1.batch import _BatchBase
+from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
 
 
 class Transaction(_SnapshotBase, _BatchBase):
@@ -95,9 +96,10 @@ class Transaction(_SnapshotBase, _BatchBase):
         api = database.spanner_api
         metadata = _metadata_with_prefix(database.name)
         txn_options = TransactionOptions(read_write=TransactionOptions.ReadWrite())
-        response = api.begin_transaction(
-            self._session.name, txn_options, metadata=metadata
-        )
+        with trace_call("CloudSpanner.BeginTransaction", self._session):
+            response = api.begin_transaction(
+                self._session.name, txn_options, metadata=metadata
+            )
         self._transaction_id = response.id
         return self._transaction_id
 
@@ -107,7 +109,8 @@ class Transaction(_SnapshotBase, _BatchBase):
         database = self._session._database
         api = database.spanner_api
         metadata = _metadata_with_prefix(database.name)
-        api.rollback(self._session.name, self._transaction_id, metadata=metadata)
+        with trace_call("CloudSpanner.Rollback", self._session):
+            api.rollback(self._session.name, self._transaction_id, metadata=metadata)
         self.rolled_back = True
         del self._session._transaction
 
@@ -123,12 +126,14 @@ class Transaction(_SnapshotBase, _BatchBase):
         database = self._session._database
         api = database.spanner_api
         metadata = _metadata_with_prefix(database.name)
-        response = api.commit(
-            self._session.name,
-            mutations=self._mutations,
-            transaction_id=self._transaction_id,
-            metadata=metadata,
-        )
+        trace_attributes = {"num_mutations": len(self._mutations)}
+        with trace_call("CloudSpanner.Commit", self._session, trace_attributes):
+            response = api.commit(
+                self._session.name,
+                mutations=self._mutations,
+                transaction_id=self._transaction_id,
+                metadata=metadata,
+            )
         self.committed = _pb_timestamp_to_datetime(response.commit_timestamp)
         del self._session._transaction
         return self.committed
@@ -212,17 +217,21 @@ class Transaction(_SnapshotBase, _BatchBase):
         default_query_options = database._instance._client._query_options
         query_options = _merge_query_options(default_query_options, query_options)
 
-        response = api.execute_sql(
-            self._session.name,
-            dml,
-            transaction=transaction,
-            params=params_pb,
-            param_types=param_types,
-            query_mode=query_mode,
-            query_options=query_options,
-            seqno=seqno,
-            metadata=metadata,
-        )
+        trace_attributes = {"db.statement": dml}
+        with trace_call(
+            "CloudSpanner.ReadWriteTransaction", self._session, trace_attributes
+        ):
+            response = api.execute_sql(
+                self._session.name,
+                dml,
+                transaction=transaction,
+                params=params_pb,
+                param_types=param_types,
+                query_mode=query_mode,
+                query_options=query_options,
+                seqno=seqno,
+                metadata=metadata,
+            )
         return response.stats.row_count_exact
 
     def batch_update(self, statements):
@@ -268,13 +277,18 @@ class Transaction(_SnapshotBase, _BatchBase):
             self._execute_sql_count + 1,
         )
 
-        response = api.execute_batch_dml(
-            session=self._session.name,
-            transaction=transaction,
-            statements=parsed,
-            seqno=seqno,
-            metadata=metadata,
-        )
+        trace_attributes = {
+            # Get just the queries from the DML statement batch
+            "db.statement": [statement[0] for statement in statements]
+        }
+        with trace_call("CloudSpanner.DMLTransaction", self._session, trace_attributes):
+            response = api.execute_batch_dml(
+                session=self._session.name,
+                transaction=transaction,
+                statements=parsed,
+                seqno=seqno,
+                metadata=metadata,
+            )
         row_counts = [
             result_set.stats.row_count_exact for result_set in response.result_sets
         ]

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -279,7 +279,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         trace_attributes = {
             # Get just the queries from the DML statement batch
-            "db.statement": [statement["sql"] for statement in parsed]
+            "db.statement": ";".join([statement["sql"] for statement in parsed])
         }
         with trace_call("CloudSpanner.DMLTransaction", self._session, trace_attributes):
             response = api.execute_batch_dml(

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,6 +66,12 @@ def lint_setup_py(session):
 def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov")
+
+    # Install opentelemetry dependencies
+    session.install(
+        "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
+    )
+
     session.install("-e", ".")
 
     # Run py.test against the unit tests.
@@ -83,13 +89,13 @@ def default(session):
     )
 
 
-@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8"])
+@nox.session(python=["3.5", "3.6", "3.7", "3.8"])
 def unit(session):
     """Run the unit test suite."""
     default(session)
 
 
-@nox.session(python=["2.7", "3.7"])
+@nox.session(python="3.7")
 def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
@@ -114,6 +120,11 @@ def system(session):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install("mock", "pytest")
+
+    # Install opentelemetry dependencies
+    session.install(
+        "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
+    )
 
     session.install("-e", ".")
     session.install("-e", "test_utils/")

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,10 +67,11 @@ def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov")
 
-    # Install opentelemetry dependencies
-    session.install(
-        "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
-    )
+    # Install opentelemetry dependencies if python3+
+    if session.python != "2.7":
+        session.install(
+            "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
+        )
 
     session.install("-e", ".")
 
@@ -89,13 +90,13 @@ def default(session):
     )
 
 
-@nox.session(python=["3.5", "3.6", "3.7", "3.8"])
+@nox.session(python=["2.7", "3.5", "3.6", "3.7", "3.8"])
 def unit(session):
     """Run the unit test suite."""
     default(session)
 
 
-@nox.session(python="3.7")
+@nox.session(python=["2.7", "3.7"])
 def system(session):
     """Run the system test suite."""
     system_test_path = os.path.join("tests", "system.py")
@@ -121,10 +122,11 @@ def system(session):
     # virtualenv's dist-packages.
     session.install("mock", "pytest")
 
-    # Install opentelemetry dependencies
-    session.install(
-        "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
-    )
+    # Install opentelemetry dependencies if not 2.7
+    if session.python != "2.7":
+        session.install(
+            "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
+        )
 
     session.install("-e", ".")
     session.install("-e", "test_utils/")

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,35 @@
+import unittest
+from opentelemetry import trace as trace_api
+from opentelemetry.trace.status import StatusCanonicalCode
+
+from opentelemetry.sdk.trace import TracerProvider, export
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+class OpenTelemetryBase(unittest.TestCase):
+    def setUp(self):
+        self.original_tracer_provider = trace_api.get_tracer_provider()
+        self.tracer_provider = TracerProvider()
+        self.memory_exporter = InMemorySpanExporter()
+        span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
+        self.tracer_provider.add_span_processor(span_processor)
+        trace_api.set_tracer_provider(self.tracer_provider)
+
+    def tearDown(self):
+        trace_api.set_tracer_provider(self.original_tracer_provider)
+
+    def assertNoSpans(self):
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
+    def assertSpanAttributes(
+        self, name, status=StatusCanonicalCode.OK, attributes=None, span=None
+    ):
+        if not span:
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 1)
+            span = span_list[0]
+        print(status, attributes, span.status, span.attributes)
+        self.assertEqual(span.name, name)
+        self.assertEqual(span.status.canonical_code, status)
+        self.assertEqual(span.attributes, attributes)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,35 +1,47 @@
 import unittest
-from opentelemetry import trace as trace_api
-from opentelemetry.trace.status import StatusCanonicalCode
+from unittest import mock
 
-from opentelemetry.sdk.trace import TracerProvider, export
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+try:
+    from opentelemetry import trace as trace_api
+    from opentelemetry.trace.status import StatusCanonicalCode
 
+    from opentelemetry.sdk.trace import TracerProvider, export
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    HAS_OPENTELEMETRY_INSTALLED = True
+except ImportError:
+    HAS_OPENTELEMETRY_INSTALLED = False
+
+    StatusCanonicalCode = mock.Mock()
 
 class OpenTelemetryBase(unittest.TestCase):
     def setUp(self):
-        self.original_tracer_provider = trace_api.get_tracer_provider()
-        self.tracer_provider = TracerProvider()
-        self.memory_exporter = InMemorySpanExporter()
-        span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
-        self.tracer_provider.add_span_processor(span_processor)
-        trace_api.set_tracer_provider(self.tracer_provider)
+        if HAS_OPENTELEMETRY_INSTALLED:
+            self.original_tracer_provider = trace_api.get_tracer_provider()
+            self.tracer_provider = TracerProvider()
+            self.memory_exporter = InMemorySpanExporter()
+            span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
+            self.tracer_provider.add_span_processor(span_processor)
+            trace_api.set_tracer_provider(self.tracer_provider)
 
     def tearDown(self):
-        trace_api.set_tracer_provider(self.original_tracer_provider)
+        if HAS_OPENTELEMETRY_INSTALLED:
+            trace_api.set_tracer_provider(self.original_tracer_provider)
 
     def assertNoSpans(self):
-        span_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(span_list), 0)
+        if HAS_OPENTELEMETRY_INSTALLED:
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 0)
 
     def assertSpanAttributes(
         self, name, status=StatusCanonicalCode.OK, attributes=None, span=None
     ):
-        if not span:
-            span_list = self.memory_exporter.get_finished_spans()
-            self.assertEqual(len(span_list), 1)
-            span = span_list[0]
-        print(status, attributes, span.status, span.attributes)
-        self.assertEqual(span.name, name)
-        self.assertEqual(span.status.canonical_code, status)
-        self.assertEqual(span.attributes, attributes)
+        if HAS_OPENTELEMETRY_INSTALLED:
+            if not span:
+                span_list = self.memory_exporter.get_finished_spans()
+                self.assertEqual(len(span_list), 1)
+                span = span_list[0]
+
+            self.assertEqual(span.name, name)
+            self.assertEqual(span.status.canonical_code, status)
+            self.assertEqual(span.attributes, attributes)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -6,13 +6,16 @@ try:
     from opentelemetry.trace.status import StatusCanonicalCode
 
     from opentelemetry.sdk.trace import TracerProvider, export
-    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
 
     HAS_OPENTELEMETRY_INSTALLED = True
 except ImportError:
     HAS_OPENTELEMETRY_INSTALLED = False
 
     StatusCanonicalCode = mock.Mock()
+
 
 class OpenTelemetryBase(unittest.TestCase):
     def setUp(self):

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+import mock
 
 try:
     from opentelemetry import trace as trace_api

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -1332,8 +1332,10 @@ class TestSessionAPI(OpenTelemetryBase, _TestData):
                 transaction.batch_update([])
 
     def test_transaction_batch_update_w_parent_span(self):
-        import sys
-        from opentelemetry import trace
+        try:
+            from opentelemetry import trace
+        except ImportError:
+            return
 
         tracer = trace.get_tracer(__name__)
 

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -2513,7 +2513,7 @@ class TestSessionAPI(OpenTelemetryBase, _TestData):
                 )
             )
             self.assertEqual(len(rows), 1)
-            (float_array,) = rows[0]
+            float_array = rows[0][0]
             self.assertEqual(float_array[0], float("-inf"))
             self.assertEqual(float_array[1], float("+inf"))
             # NaNs cannot be searched for by equality.

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -52,6 +52,7 @@ from test_utils.retry import RetryInstanceState
 from test_utils.retry import RetryResult
 from test_utils.system import unique_resource_id
 from tests._fixtures import DDL_STATEMENTS
+from tests._helpers import OpenTelemetryBase
 
 
 CREATE_INSTANCE = os.getenv("GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE") is not None
@@ -66,6 +67,12 @@ else:
 EXISTING_INSTANCES = []
 COUNTERS_TABLE = "counters"
 COUNTERS_COLUMNS = ("name", "value")
+
+BASE_ATTRIBUTES = {
+    "db.type": "spanner",
+    "db.url": "spanner.googleapis.com:443",
+    "net.host.name": "spanner.googleapis.com:443",
+}
 
 _STATUS_CODE_TO_GRPC_STATUS_CODE = {
     member.value[0]: member for member in grpc.StatusCode
@@ -726,7 +733,7 @@ SOME_TIME = datetime.datetime(1989, 1, 17, 17, 59, 12, 345612)
 NANO_TIME = DatetimeWithNanoseconds(1995, 8, 31, nanosecond=987654321)
 POS_INF = float("+inf")
 NEG_INF = float("-inf")
-OTHER_NAN, = struct.unpack("<d", b"\x01\x00\x01\x00\x00\x00\xf8\xff")
+(OTHER_NAN,) = struct.unpack("<d", b"\x01\x00\x01\x00\x00\x00\xf8\xff")
 BYTES_1 = b"Ymlu"
 BYTES_2 = b"Ym9vdHM="
 ALL_TYPES_TABLE = "all_types"
@@ -781,7 +788,7 @@ ALL_TYPES_ROWDATA = (
 )
 
 
-class TestSessionAPI(unittest.TestCase, _TestData):
+class TestSessionAPI(OpenTelemetryBase, _TestData):
     DATABASE_NAME = "test_sessions" + unique_resource_id("_")
 
     @classmethod
@@ -798,9 +805,11 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         cls._db.drop()
 
     def setUp(self):
+        super().setUp()
         self.to_delete = []
 
     def tearDown(self):
+        super().tearDown()
         for doomed in self.to_delete:
             doomed.delete()
 
@@ -825,6 +834,40 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         with self._db.snapshot(read_timestamp=batch.committed) as snapshot:
             rows = list(snapshot.read(self.TABLE, self.COLUMNS, self.ALL))
         self._check_rows_data(rows)
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 4)
+        self.assertSpanAttributes(
+            "CloudSpanner.GetSession",
+            attributes=dict(
+                BASE_ATTRIBUTES, **{"db.instance": self._db.name}, session_found=True
+            ),
+            span=span_list[0],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit",
+            attributes=dict(
+                BASE_ATTRIBUTES, **{"db.instance": self._db.name}, num_mutations=2
+            ),
+            span=span_list[1],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.GetSession",
+            attributes=dict(
+                BASE_ATTRIBUTES, **{"db.instance": self._db.name}, session_found=True
+            ),
+            span=span_list[2],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadOnlyTransaction",
+            attributes=dict(
+                BASE_ATTRIBUTES,
+                **{"db.instance": self._db.name},
+                columns=self.COLUMNS,
+                table_id=self.TABLE
+            ),
+            span=span_list[3],
+        )
 
     def test_batch_insert_then_read_string_array_of_string(self):
         TABLE = "string_plus_array_of_string"
@@ -923,6 +966,68 @@ class TestSessionAPI(unittest.TestCase, _TestData):
 
         rows = list(session.read(self.TABLE, self.COLUMNS, self.ALL))
         self.assertEqual(rows, [])
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 8)
+        self.assertSpanAttributes(
+            "CloudSpanner.CreateSession",
+            attributes=dict(BASE_ATTRIBUTES, **{"db.instance": self._db.name}),
+            span=span_list[0],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.GetSession",
+            attributes=dict(
+                BASE_ATTRIBUTES, **{"db.instance": self._db.name}, session_found=True
+            ),
+            span=span_list[1],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit",
+            attributes=dict(
+                BASE_ATTRIBUTES, **{"db.instance": self._db.name}, num_mutations=1
+            ),
+            span=span_list[2],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.BeginTransaction",
+            attributes=dict(BASE_ATTRIBUTES, **{"db.instance": self._db.name}),
+            span=span_list[3],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadOnlyTransaction",
+            attributes=dict(
+                BASE_ATTRIBUTES,
+                **{"db.instance": self._db.name},
+                table_id=self.TABLE,
+                columns=self.COLUMNS
+            ),
+            span=span_list[4],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadOnlyTransaction",
+            attributes=dict(
+                BASE_ATTRIBUTES,
+                **{"db.instance": self._db.name},
+                table_id=self.TABLE,
+                columns=self.COLUMNS
+            ),
+            span=span_list[5],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.Rollback",
+            attributes=dict(BASE_ATTRIBUTES, **{"db.instance": self._db.name}),
+            span=span_list[6],
+        )
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadOnlyTransaction",
+            attributes=dict(
+                BASE_ATTRIBUTES,
+                **{"db.instance": self._db.name},
+                table_id=self.TABLE,
+                columns=self.COLUMNS
+            ),
+            span=span_list[7],
+        )
 
     def _transaction_read_then_raise(self, transaction):
         rows = list(transaction.read(self.TABLE, self.COLUMNS, self.ALL))
@@ -1225,6 +1330,64 @@ class TestSessionAPI(unittest.TestCase, _TestData):
         with session.transaction() as transaction:
             with self.assertRaises(InvalidArgument):
                 transaction.batch_update([])
+
+    def test_transaction_batch_update_w_parent_span(self):
+        import sys
+        from opentelemetry import trace
+
+        tracer = trace.get_tracer(__name__)
+
+        retry = RetryInstanceState(_has_all_ddl)
+        retry(self._db.reload)()
+
+        session = self._db.session()
+        session.create()
+        self.to_delete.append(session)
+
+        with session.batch() as batch:
+            batch.delete(self.TABLE, self.ALL)
+
+        insert_statement = list(self._generate_insert_statements())[0]
+        update_statement = (
+            "UPDATE contacts SET email = @email " "WHERE contact_id = @contact_id;",
+            {"contact_id": 1, "email": "phreddy@example.com"},
+            {"contact_id": Type(code=INT64), "email": Type(code=STRING)},
+        )
+        delete_statement = (
+            "DELETE contacts WHERE contact_id = @contact_id;",
+            {"contact_id": 1},
+            {"contact_id": Type(code=INT64)},
+        )
+
+        def unit_of_work(transaction, self):
+
+            status, row_counts = transaction.batch_update(
+                [insert_statement, update_statement, delete_statement]
+            )
+            self._check_batch_status(status.code)
+            self.assertEqual(len(row_counts), 3)
+            for row_count in row_counts:
+                self.assertEqual(row_count, 1)
+
+        with tracer.start_as_current_span("Test Span"):
+            session.run_in_transaction(unit_of_work, self)
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 6)
+        self.assertEqual(
+            list(map(lambda span: span.name, span_list)),
+            [
+                "CloudSpanner.CreateSession",
+                "CloudSpanner.Commit",
+                "CloudSpanner.BeginTransaction",
+                "CloudSpanner.DMLTransaction",
+                "CloudSpanner.Commit",
+                "Test Span",
+            ],
+        )
+        for span in span_list[2:-1]:
+            self.assertEqual(span.context.trace_id, span_list[-1].context.trace_id)
+            self.assertEqual(span.parent.span_id, span_list[-1].context.span_id)
 
     def test_execute_partitioned_dml(self):
         # [START spanner_test_dml_partioned_dml_update]
@@ -2333,7 +2496,7 @@ class TestSessionAPI(unittest.TestCase, _TestData):
                 )
             )
             self.assertEqual(len(rows), 1)
-            float_array, = rows[0]
+            (float_array,) = rows[0]
             self.assertEqual(float_array[0], float("-inf"))
             self.assertEqual(float_array[1], float("+inf"))
             # NaNs cannot be searched for by equality.

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -3,27 +3,18 @@ import mock
 import unittest
 import sys
 
-from opentelemetry import trace as trace_api
-from opentelemetry.trace.status import StatusCanonicalCode
-from opentelemetry.sdk.trace import TracerProvider, export
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+try:
+    from opentelemetry import trace as trace_api
+    from opentelemetry.trace.status import StatusCanonicalCode
+    from opentelemetry.sdk.trace import TracerProvider, export
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+except ImportError:
+    pass
 
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.spanner_v1 import _opentelemetry_tracing
 
-
-class OpenTelemetryBase(unittest.TestCase):
-    def setUp(self):
-        self.original_tracer_provider = trace_api.get_tracer_provider()
-        self.tracer_provider = TracerProvider()
-        self.memory_exporter = InMemorySpanExporter()
-        span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
-        self.tracer_provider.add_span_processor(span_processor)
-        trace_api.set_tracer_provider(self.tracer_provider)
-
-    def tearDown(self):
-        trace_api.set_tracer_provider(self.original_tracer_provider)
-
+from tests._helpers import OpenTelemetryBase, HAS_OPENTELEMETRY_INSTALLED
 
 def _make_rpc_error(error_cls, trailing_metadata=None):
     import grpc
@@ -38,102 +29,103 @@ def _make_session():
 
     return mock.Mock(autospec=Session, instance=True)
 
+# Skip all of these tests if we don't have OpenTelemetry
+if HAS_OPENTELEMETRY_INSTALLED:
+    class TestNoTracing(unittest.TestCase):
+        def setUp(self):
+            self._temp_opentelemetry = sys.modules["opentelemetry"]
 
-class TestNoTracing(unittest.TestCase):
-    def setUp(self):
-        self._temp_opentelemetry = sys.modules["opentelemetry"]
+            sys.modules["opentelemetry"] = None
+            importlib.reload(_opentelemetry_tracing)
 
-        sys.modules["opentelemetry"] = None
-        importlib.reload(_opentelemetry_tracing)
+        def tearDown(self):
+            sys.modules["opentelemetry"] = self._temp_opentelemetry
+            importlib.reload(_opentelemetry_tracing)
 
-    def tearDown(self):
-        sys.modules["opentelemetry"] = self._temp_opentelemetry
-        importlib.reload(_opentelemetry_tracing)
-
-    def test_no_trace_call(self):
-        with _opentelemetry_tracing.trace_call("Test", _make_session()) as no_span:
-            self.assertIsNone(no_span)
+        def test_no_trace_call(self):
+            with _opentelemetry_tracing.trace_call("Test", _make_session()) as no_span:
+                self.assertIsNone(no_span)
 
 
-class TestTracing(OpenTelemetryBase):
-    def test_trace_call(self):
-        extra_attributes = {
-            "attribute1": "value1",
-            # Since our database is mocked, we have to override the db.instance parameter so it is a string
-            "db.instance": "database_name",
-        }
+    class TestTracing(OpenTelemetryBase):
+        def test_trace_call(self):
+            extra_attributes = {
+                "attribute1": "value1",
+                # Since our database is mocked, we have to override the db.instance parameter so it is a string
+                "db.instance": "database_name",
+            }
 
-        expected_attributes = {
-            "db.type": "spanner",
-            "db.url": "spanner.googleapis.com:443",
-            "net.host.name": "spanner.googleapis.com:443",
-        }
-        expected_attributes.update(extra_attributes)
+            expected_attributes = {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com:443",
+                "net.host.name": "spanner.googleapis.com:443",
+            }
+            expected_attributes.update(extra_attributes)
 
-        with _opentelemetry_tracing.trace_call(
-            "CloudSpanner.Test", _make_session(), extra_attributes
-        ) as span:
-            span.set_attribute("after_setup_attribute", 1)
-
-        expected_attributes["after_setup_attribute"] = 1
-
-        span_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(span_list), 1)
-        span = span_list[0]
-        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
-        self.assertEqual(span.attributes, expected_attributes)
-        self.assertEqual(span.name, "CloudSpanner.Test")
-        self.assertEqual(
-            span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
-        )
-
-    def test_trace_error(self):
-        extra_attributes = {"db.instance": "database_name"}
-
-        expected_attributes = {
-            "db.type": "spanner",
-            "db.url": "spanner.googleapis.com:443",
-            "net.host.name": "spanner.googleapis.com:443",
-        }
-        expected_attributes.update(extra_attributes)
-
-        with self.assertRaises(GoogleAPICallError):
             with _opentelemetry_tracing.trace_call(
                 "CloudSpanner.Test", _make_session(), extra_attributes
             ) as span:
-                from google.api_core.exceptions import InvalidArgument
+                span.set_attribute("after_setup_attribute", 1)
 
-                raise _make_rpc_error(InvalidArgument)
+            expected_attributes["after_setup_attribute"] = 1
 
-        span_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(span_list), 1)
-        span = span_list[0]
-        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
-        self.assertEqual(span.attributes, expected_attributes)
-        self.assertEqual(span.name, "CloudSpanner.Test")
-        self.assertEqual(
-            span.status.canonical_code, StatusCanonicalCode.INVALID_ARGUMENT
-        )
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 1)
+            span = span_list[0]
+            self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+            self.assertEqual(span.attributes, expected_attributes)
+            self.assertEqual(span.name, "CloudSpanner.Test")
+            self.assertEqual(
+                span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
+            )
 
-    def test_trace_grpc_error(self):
-        extra_attributes = {"db.instance": "database_name"}
+        def test_trace_error(self):
+            extra_attributes = {"db.instance": "database_name"}
 
-        expected_attributes = {
-            "db.type": "spanner",
-            "db.url": "spanner.googleapis.com:443",
-            "net.host.name": "spanner.googleapis.com:443",
-        }
-        expected_attributes.update(extra_attributes)
+            expected_attributes = {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com:443",
+                "net.host.name": "spanner.googleapis.com:443",
+            }
+            expected_attributes.update(extra_attributes)
 
-        with self.assertRaises(GoogleAPICallError):
-            with _opentelemetry_tracing.trace_call(
-                "CloudSpanner.Test", _make_session(), extra_attributes
-            ) as span:
-                from google.api_core.exceptions import DataLoss
+            with self.assertRaises(GoogleAPICallError):
+                with _opentelemetry_tracing.trace_call(
+                    "CloudSpanner.Test", _make_session(), extra_attributes
+                ) as span:
+                    from google.api_core.exceptions import InvalidArgument
 
-                raise _make_rpc_error(DataLoss)
+                    raise _make_rpc_error(InvalidArgument)
 
-        span_list = self.memory_exporter.get_finished_spans()
-        self.assertEqual(len(span_list), 1)
-        span = span_list[0]
-        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.DATA_LOSS)
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 1)
+            span = span_list[0]
+            self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+            self.assertEqual(span.attributes, expected_attributes)
+            self.assertEqual(span.name, "CloudSpanner.Test")
+            self.assertEqual(
+                span.status.canonical_code, StatusCanonicalCode.INVALID_ARGUMENT
+            )
+
+        def test_trace_grpc_error(self):
+            extra_attributes = {"db.instance": "database_name"}
+
+            expected_attributes = {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com:443",
+                "net.host.name": "spanner.googleapis.com:443",
+            }
+            expected_attributes.update(extra_attributes)
+
+            with self.assertRaises(GoogleAPICallError):
+                with _opentelemetry_tracing.trace_call(
+                    "CloudSpanner.Test", _make_session(), extra_attributes
+                ) as span:
+                    from google.api_core.exceptions import DataLoss
+
+                    raise _make_rpc_error(DataLoss)
+
+            span_list = self.memory_exporter.get_finished_spans()
+            self.assertEqual(len(span_list), 1)
+            span = span_list[0]
+            self.assertEqual(span.status.canonical_code, StatusCanonicalCode.DATA_LOSS)

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -6,8 +6,6 @@ import sys
 try:
     from opentelemetry import trace as trace_api
     from opentelemetry.trace.status import StatusCanonicalCode
-    from opentelemetry.sdk.trace import TracerProvider, export
-    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 except ImportError:
     pass
 
@@ -15,6 +13,7 @@ from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.spanner_v1 import _opentelemetry_tracing
 
 from tests._helpers import OpenTelemetryBase, HAS_OPENTELEMETRY_INSTALLED
+
 
 def _make_rpc_error(error_cls, trailing_metadata=None):
     import grpc
@@ -29,8 +28,10 @@ def _make_session():
 
     return mock.Mock(autospec=Session, instance=True)
 
+
 # Skip all of these tests if we don't have OpenTelemetry
 if HAS_OPENTELEMETRY_INSTALLED:
+
     class TestNoTracing(unittest.TestCase):
         def setUp(self):
             self._temp_opentelemetry = sys.modules["opentelemetry"]
@@ -45,7 +46,6 @@ if HAS_OPENTELEMETRY_INSTALLED:
         def test_no_trace_call(self):
             with _opentelemetry_tracing.trace_call("Test", _make_session()) as no_span:
                 self.assertIsNone(no_span)
-
 
     class TestTracing(OpenTelemetryBase):
         def test_trace_call(self):
@@ -75,9 +75,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
             self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
             self.assertEqual(span.attributes, expected_attributes)
             self.assertEqual(span.name, "CloudSpanner.Test")
-            self.assertEqual(
-                span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
-            )
+            self.assertEqual(span.status.canonical_code, StatusCanonicalCode.OK)
 
         def test_trace_error(self):
             extra_attributes = {"db.instance": "database_name"}

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -1,0 +1,139 @@
+import importlib
+import mock
+import unittest
+import sys
+
+from opentelemetry import trace as trace_api
+from opentelemetry.trace.status import StatusCanonicalCode
+from opentelemetry.sdk.trace import TracerProvider, export
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from google.api_core.exceptions import GoogleAPICallError
+from google.cloud.spanner_v1 import _opentelemetry_tracing
+
+
+class OpenTelemetryBase(unittest.TestCase):
+    def setUp(self):
+        self.original_tracer_provider = trace_api.get_tracer_provider()
+        self.tracer_provider = TracerProvider()
+        self.memory_exporter = InMemorySpanExporter()
+        span_processor = export.SimpleExportSpanProcessor(self.memory_exporter)
+        self.tracer_provider.add_span_processor(span_processor)
+        trace_api.set_tracer_provider(self.tracer_provider)
+
+    def tearDown(self):
+        trace_api.set_tracer_provider(self.original_tracer_provider)
+
+
+def _make_rpc_error(error_cls, trailing_metadata=None):
+    import grpc
+
+    grpc_error = mock.create_autospec(grpc.Call, instance=True)
+    grpc_error.trailing_metadata.return_value = trailing_metadata
+    return error_cls("error", errors=(grpc_error,))
+
+
+def _make_session():
+    from google.cloud.spanner_v1.session import Session
+
+    return mock.Mock(autospec=Session, instance=True)
+
+
+class TestNoTracing(unittest.TestCase):
+    def setUp(self):
+        self._temp_opentelemetry = sys.modules["opentelemetry"]
+
+        sys.modules["opentelemetry"] = None
+        importlib.reload(_opentelemetry_tracing)
+
+    def tearDown(self):
+        sys.modules["opentelemetry"] = self._temp_opentelemetry
+        importlib.reload(_opentelemetry_tracing)
+
+    def test_no_trace_call(self):
+        with _opentelemetry_tracing.trace_call("Test", _make_session()) as no_span:
+            self.assertIsNone(no_span)
+
+
+class TestTracing(OpenTelemetryBase):
+    def test_trace_call(self):
+        extra_attributes = {
+            "attribute1": "value1",
+            # Since our database is mocked, we have to override the db.instance parameter so it is a string
+            "db.instance": "database_name",
+        }
+
+        expected_attributes = {
+            "db.type": "spanner",
+            "db.url": "spanner.googleapis.com:443",
+            "net.host.name": "spanner.googleapis.com:443",
+        }
+        expected_attributes.update(extra_attributes)
+
+        with _opentelemetry_tracing.trace_call(
+            "CloudSpanner.Test", _make_session(), extra_attributes
+        ) as span:
+            span.set_attribute("after_setup_attribute", 1)
+
+        expected_attributes["after_setup_attribute"] = 1
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.attributes, expected_attributes)
+        self.assertEqual(span.name, "CloudSpanner.Test")
+        self.assertEqual(
+            span.status.canonical_code, trace_api.status.StatusCanonicalCode.OK
+        )
+
+    def test_trace_error(self):
+        extra_attributes = {"db.instance": "database_name"}
+
+        expected_attributes = {
+            "db.type": "spanner",
+            "db.url": "spanner.googleapis.com:443",
+            "net.host.name": "spanner.googleapis.com:443",
+        }
+        expected_attributes.update(extra_attributes)
+
+        with self.assertRaises(GoogleAPICallError):
+            with _opentelemetry_tracing.trace_call(
+                "CloudSpanner.Test", _make_session(), extra_attributes
+            ) as span:
+                from google.api_core.exceptions import InvalidArgument
+
+                raise _make_rpc_error(InvalidArgument)
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.attributes, expected_attributes)
+        self.assertEqual(span.name, "CloudSpanner.Test")
+        self.assertEqual(
+            span.status.canonical_code, StatusCanonicalCode.INVALID_ARGUMENT
+        )
+
+    def test_trace_grpc_error(self):
+        extra_attributes = {"db.instance": "database_name"}
+
+        expected_attributes = {
+            "db.type": "spanner",
+            "db.url": "spanner.googleapis.com:443",
+            "net.host.name": "spanner.googleapis.com:443",
+        }
+        expected_attributes.update(extra_attributes)
+
+        with self.assertRaises(GoogleAPICallError):
+            with _opentelemetry_tracing.trace_call(
+                "CloudSpanner.Test", _make_session(), extra_attributes
+            ) as span:
+                from google.api_core.exceptions import DataLoss
+
+                raise _make_rpc_error(DataLoss)
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.status.canonical_code, StatusCanonicalCode.DATA_LOSS)

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -14,7 +14,8 @@
 
 
 import unittest
-
+from tests._helpers import OpenTelemetryBase
+from opentelemetry.trace.status import StatusCanonicalCode
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -22,6 +23,12 @@ VALUES = [
     [u"phred@exammple.com", u"Phred", u"Phlyntstone", 32],
     [u"bharney@example.com", u"Bharney", u"Rhubble", 31],
 ]
+BASE_ATTRIBUTES = {
+    "db.type": "spanner",
+    "db.url": "spanner.googleapis.com:443",
+    "db.instance": "testing",
+    "net.host.name": "spanner.googleapis.com:443",
+}
 
 
 class _BaseTest(unittest.TestCase):
@@ -164,7 +171,7 @@ class Test_BatchBase(_BaseTest):
             )
 
 
-class TestBatch(_BaseTest):
+class TestBatch(_BaseTest, OpenTelemetryBase):
     def _getTargetClass(self):
         from google.cloud.spanner_v1.batch import Batch
 
@@ -189,6 +196,8 @@ class TestBatch(_BaseTest):
         with self.assertRaises(ValueError):
             batch.commit()
 
+        self.assertNoSpans()
+
     def test_commit_grpc_error(self):
         from google.api_core.exceptions import Unknown
         from google.cloud.spanner_v1.keyset import KeySet
@@ -203,6 +212,12 @@ class TestBatch(_BaseTest):
 
         with self.assertRaises(Unknown):
             batch.commit()
+
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=dict(BASE_ATTRIBUTES, num_mutations=1),
+        )
 
     def test_commit_ok(self):
         import datetime
@@ -231,6 +246,10 @@ class TestBatch(_BaseTest):
         self.assertIsInstance(single_use_txn, TransactionOptions)
         self.assertTrue(single_use_txn.HasField("read_write"))
         self.assertEqual(metadata, [("google-cloud-resource-prefix", database.name)])
+
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit", attributes=dict(BASE_ATTRIBUTES, num_mutations=1)
+        )
 
     def test_context_mgr_already_committed(self):
         import datetime
@@ -275,6 +294,10 @@ class TestBatch(_BaseTest):
         self.assertIsInstance(single_use_txn, TransactionOptions)
         self.assertTrue(single_use_txn.HasField("read_write"))
         self.assertEqual(metadata, [("google-cloud-resource-prefix", database.name)])
+
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit", attributes=dict(BASE_ATTRIBUTES, num_mutations=1)
+        )
 
     def test_context_mgr_failure(self):
         import datetime

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -14,8 +14,7 @@
 
 
 import unittest
-from tests._helpers import OpenTelemetryBase
-from opentelemetry.trace.status import StatusCanonicalCode
+from tests._helpers import OpenTelemetryBase, StatusCanonicalCode
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -15,7 +15,11 @@
 
 import google.api_core.gapic_v1.method
 import mock
-from tests._helpers import OpenTelemetryBase, StatusCanonicalCode, HAS_OPENTELEMETRY_INSTALLED
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCanonicalCode,
+    HAS_OPENTELEMETRY_INSTALLED,
+)
 
 
 def _make_rpc_error(error_cls, trailing_metadata=None):
@@ -43,7 +47,7 @@ class TestSession(OpenTelemetryBase):
     BASE_ATTRIBUTES = {
         "db.type": "spanner",
         "db.url": "spanner.googleapis.com:443",
-        "db.instance": "projects/project-id/instances/instance-id/databases/database-id",
+        "db.instance": DATABASE_NAME,
         "net.host.name": "spanner.googleapis.com:443",
     }
 
@@ -1112,7 +1116,9 @@ class TestSession(OpenTelemetryBase):
                 with mock.patch("opentelemetry.util.time", _ConstantTime()):
                     with mock.patch("time.sleep") as sleep_mock:
                         with self.assertRaises(Aborted):
-                            session.run_in_transaction(unit_of_work, "abc", timeout_secs=1)
+                            session.run_in_transaction(
+                                unit_of_work, "abc", timeout_secs=1
+                            )
             else:
                 with mock.patch("time.sleep") as sleep_mock:
                     with self.assertRaises(Aborted):

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -15,7 +15,11 @@
 
 import google.api_core.gapic_v1.method
 import mock
-from tests._helpers import OpenTelemetryBase, StatusCanonicalCode, HAS_OPENTELEMETRY_INSTALLED
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCanonicalCode,
+    HAS_OPENTELEMETRY_INSTALLED,
+)
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
-import unittest
 import google.api_core.gapic_v1.method
 import mock
-
+from opentelemetry.trace.status import StatusCanonicalCode
+from tests._helpers import OpenTelemetryBase
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -33,13 +33,19 @@ RESUME_TOKEN = b"DEADBEEF"
 TXN_ID = b"DEAFBEAD"
 SECONDS = 3
 MICROS = 123456
+BASE_ATTRIBUTES = {
+    "db.type": "spanner",
+    "db.url": "spanner.googleapis.com:443",
+    "db.instance": "testing",
+    "net.host.name": "spanner.googleapis.com:443",
+}
 
 
-class Test_restart_on_unavailable(unittest.TestCase):
-    def _call_fut(self, restart):
+class Test_restart_on_unavailable(OpenTelemetryBase):
+    def _call_fut(self, restart, span_name=None, session=None, attributes=None):
         from google.cloud.spanner_v1.snapshot import _restart_on_unavailable
 
-        return _restart_on_unavailable(restart)
+        return _restart_on_unavailable(restart, span_name, session, attributes)
 
     def _make_item(self, value, resume_token=b""):
         return mock.Mock(
@@ -51,6 +57,7 @@ class Test_restart_on_unavailable(unittest.TestCase):
         restart = mock.Mock(spec=[], return_value=raw)
         resumable = self._call_fut(restart)
         self.assertEqual(list(resumable), [])
+        self.assertNoSpans()
 
     def test_iteration_w_non_empty_raw(self):
         ITEMS = (self._make_item(0), self._make_item(1))
@@ -59,6 +66,7 @@ class Test_restart_on_unavailable(unittest.TestCase):
         resumable = self._call_fut(restart)
         self.assertEqual(list(resumable), list(ITEMS))
         restart.assert_called_once_with()
+        self.assertNoSpans()
 
     def test_iteration_w_raw_w_resume_tken(self):
         ITEMS = (
@@ -72,6 +80,7 @@ class Test_restart_on_unavailable(unittest.TestCase):
         resumable = self._call_fut(restart)
         self.assertEqual(list(resumable), list(ITEMS))
         restart.assert_called_once_with()
+        self.assertNoSpans()
 
     def test_iteration_w_raw_raising_unavailable_no_token(self):
         ITEMS = (
@@ -85,6 +94,7 @@ class Test_restart_on_unavailable(unittest.TestCase):
         resumable = self._call_fut(restart)
         self.assertEqual(list(resumable), list(ITEMS))
         self.assertEqual(restart.mock_calls, [mock.call(), mock.call(resume_token=b"")])
+        self.assertNoSpans()
 
     def test_iteration_w_raw_raising_unavailable(self):
         FIRST = (self._make_item(0), self._make_item(1, resume_token=RESUME_TOKEN))
@@ -98,6 +108,7 @@ class Test_restart_on_unavailable(unittest.TestCase):
         self.assertEqual(
             restart.mock_calls, [mock.call(), mock.call(resume_token=RESUME_TOKEN)]
         )
+        self.assertNoSpans()
 
     def test_iteration_w_raw_raising_unavailable_after_token(self):
         FIRST = (self._make_item(0), self._make_item(1, resume_token=RESUME_TOKEN))
@@ -110,9 +121,47 @@ class Test_restart_on_unavailable(unittest.TestCase):
         self.assertEqual(
             restart.mock_calls, [mock.call(), mock.call(resume_token=RESUME_TOKEN)]
         )
+        self.assertNoSpans()
+
+    def test_iteration_w_span_creation(self):
+        name = "TestSpan"
+        extra_atts = {"test_att": 1}
+        raw = _MockIterator()
+        restart = mock.Mock(spec=[], return_value=raw)
+        resumable = self._call_fut(restart, name, _Session(_Database()), extra_atts)
+        self.assertEqual(list(resumable), [])
+        self.assertSpanAttributes(name, attributes=dict(BASE_ATTRIBUTES, test_att=1))
+
+    def test_iteration_w_multiple_span_creation(self):
+        FIRST = (self._make_item(0), self._make_item(1, resume_token=RESUME_TOKEN))
+        SECOND = (self._make_item(2),)  # discarded after 503
+        LAST = (self._make_item(3),)
+        before = _MockIterator(*(FIRST + SECOND), fail_after=True)
+        after = _MockIterator(*LAST)
+        restart = mock.Mock(spec=[], side_effect=[before, after])
+        name = "TestSpan"
+        resumable = self._call_fut(restart, name, _Session(_Database()))
+        self.assertEqual(list(resumable), list(FIRST + LAST))
+        self.assertEqual(
+            restart.mock_calls, [mock.call(), mock.call(resume_token=RESUME_TOKEN)]
+        )
+
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 2)
+        for span in span_list:
+            self.assertEqual(span.name, name)
+            self.assertEqual(
+                span.attributes,
+                {
+                    "db.type": "spanner",
+                    "db.url": "spanner.googleapis.com:443",
+                    "db.instance": "testing",
+                    "net.host.name": "spanner.googleapis.com:443",
+                },
+            )
 
 
-class Test_SnapshotBase(unittest.TestCase):
+class Test_SnapshotBase(OpenTelemetryBase):
 
     PROJECT_ID = "project-id"
     INSTANCE_ID = "instance-id"
@@ -166,6 +215,9 @@ class Test_SnapshotBase(unittest.TestCase):
         self.assertIs(base._session, session)
         self.assertEqual(base._execute_sql_count, 0)
 
+        span_list = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 0)
+
     def test__make_txn_selector_virtual(self):
         session = _Session()
         base = self._make_one(session)
@@ -184,6 +236,14 @@ class Test_SnapshotBase(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             list(derived.read(TABLE_NAME, COLUMNS, keyset))
+
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadOnlyTransaction",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=dict(
+                BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
+            ),
+        )
 
     def _read_helper(self, multi_use, first=True, count=0, partition=None):
         from google.protobuf.struct_pb2 import Struct
@@ -280,6 +340,13 @@ class Test_SnapshotBase(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadOnlyTransaction",
+            attributes=dict(
+                BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
+            ),
+        )
+
     def test_read_wo_multi_use(self):
         self._read_helper(multi_use=False)
 
@@ -313,6 +380,12 @@ class Test_SnapshotBase(unittest.TestCase):
 
         self.assertEqual(derived._execute_sql_count, 1)
 
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadWriteTransaction",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=dict(BASE_ATTRIBUTES, **{"db.statement": SQL_QUERY}),
+        )
+
     def test_execute_sql_w_params_wo_param_types(self):
         database = _Database()
         session = _Session(database)
@@ -320,6 +393,8 @@ class Test_SnapshotBase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             derived.execute_sql(SQL_QUERY_WITH_PARAM, PARAMS)
+
+        self.assertNoSpans()
 
     def _execute_sql_helper(
         self,
@@ -440,6 +515,12 @@ class Test_SnapshotBase(unittest.TestCase):
 
         self.assertEqual(derived._execute_sql_count, sql_count + 1)
 
+        self.assertSpanAttributes(
+            "CloudSpanner.ReadWriteTransaction",
+            status=StatusCanonicalCode.OK,
+            attributes=dict(BASE_ATTRIBUTES, **{"db.statement": SQL_QUERY_WITH_PARAM}),
+        )
+
     def test_execute_sql_wo_multi_use(self):
         self._execute_sql_helper(multi_use=False)
 
@@ -534,6 +615,14 @@ class Test_SnapshotBase(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        self.assertSpanAttributes(
+            "CloudSpanner.PartitionReadOnlyTransaction",
+            status=StatusCanonicalCode.OK,
+            attributes=dict(
+                BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
+            ),
+        )
+
     def test_partition_read_single_use_raises(self):
         with self.assertRaises(ValueError):
             self._partition_read_helper(multi_use=False, w_txn=True)
@@ -556,6 +645,14 @@ class Test_SnapshotBase(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             list(derived.partition_read(TABLE_NAME, COLUMNS, keyset))
+
+        self.assertSpanAttributes(
+            "CloudSpanner.PartitionReadOnlyTransaction",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=dict(
+                BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
+            ),
+        )
 
     def test_partition_read_ok_w_index_no_options(self):
         self._partition_read_helper(multi_use=True, w_txn=True, index="index")
@@ -626,6 +723,12 @@ class Test_SnapshotBase(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        self.assertSpanAttributes(
+            "CloudSpanner.PartitionReadWriteTransaction",
+            status=StatusCanonicalCode.OK,
+            attributes=dict(BASE_ATTRIBUTES, **{"db.statement": SQL_QUERY_WITH_PARAM}),
+        )
+
     def test_partition_query_other_error(self):
         database = _Database()
         database.spanner_api = self._make_spanner_api()
@@ -638,6 +741,12 @@ class Test_SnapshotBase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             list(derived.partition_query(SQL_QUERY))
 
+        self.assertSpanAttributes(
+            "CloudSpanner.PartitionReadWriteTransaction",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=dict(BASE_ATTRIBUTES, **{"db.statement": SQL_QUERY}),
+        )
+
     def test_partition_query_w_params_wo_param_types(self):
         database = _Database()
         session = _Session(database)
@@ -647,6 +756,8 @@ class Test_SnapshotBase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             list(derived.partition_query(SQL_QUERY_WITH_PARAM, PARAMS))
+
+        self.assertNoSpans()
 
     def test_partition_query_single_use_raises(self):
         with self.assertRaises(ValueError):
@@ -666,7 +777,7 @@ class Test_SnapshotBase(unittest.TestCase):
         self._partition_query_helper(multi_use=True, w_txn=True, max_partitions=4)
 
 
-class TestSnapshot(unittest.TestCase):
+class TestSnapshot(OpenTelemetryBase):
 
     PROJECT_ID = "project-id"
     INSTANCE_ID = "instance-id"
@@ -933,6 +1044,12 @@ class TestSnapshot(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             snapshot.begin()
 
+        self.assertSpanAttributes(
+            "CloudSpanner.BeginTransaction",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=BASE_ATTRIBUTES,
+        )
+
     def test_begin_ok_exact_staleness(self):
         from google.protobuf.duration_pb2 import Duration
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
@@ -964,6 +1081,12 @@ class TestSnapshot(unittest.TestCase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        self.assertSpanAttributes(
+            "CloudSpanner.BeginTransaction",
+            status=StatusCanonicalCode.OK,
+            attributes=BASE_ATTRIBUTES,
+        )
+
     def test_begin_ok_exact_strong(self):
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
             Transaction as TransactionPB,
@@ -990,6 +1113,12 @@ class TestSnapshot(unittest.TestCase):
             session.name,
             expected_txn_options,
             metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
+        self.assertSpanAttributes(
+            "CloudSpanner.BeginTransaction",
+            status=StatusCanonicalCode.OK,
+            attributes=BASE_ATTRIBUTES,
         )
 
 

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 
-import unittest
-
 import mock
-
+from tests._helpers import OpenTelemetryBase
+from opentelemetry.trace.status import StatusCanonicalCode
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -36,7 +35,7 @@ PARAMS = {"age": 30}
 PARAM_TYPES = {"age": "INT64"}
 
 
-class TestTransaction(unittest.TestCase):
+class TestTransaction(OpenTelemetryBase):
 
     PROJECT_ID = "project-id"
     INSTANCE_ID = "instance-id"
@@ -46,6 +45,13 @@ class TestTransaction(unittest.TestCase):
     SESSION_ID = "session-id"
     SESSION_NAME = DATABASE_NAME + "/sessions/" + SESSION_ID
     TRANSACTION_ID = b"DEADBEEF"
+
+    BASE_ATTRIBUTES = {
+        "db.type": "spanner",
+        "db.url": "spanner.googleapis.com:443",
+        "db.instance": "testing",
+        "net.host.name": "spanner.googleapis.com:443",
+    }
 
     def _getTargetClass(self):
         from google.cloud.spanner_v1.transaction import Transaction
@@ -122,6 +128,8 @@ class TestTransaction(unittest.TestCase):
         with self.assertRaises(ValueError):
             transaction.begin()
 
+        self.assertNoSpans()
+
     def test_begin_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
@@ -129,12 +137,16 @@ class TestTransaction(unittest.TestCase):
         with self.assertRaises(ValueError):
             transaction.begin()
 
+        self.assertNoSpans()
+
     def test_begin_already_committed(self):
         session = _Session()
         transaction = self._make_one(session)
         transaction.committed = object()
         with self.assertRaises(ValueError):
             transaction.begin()
+
+        self.assertNoSpans()
 
     def test_begin_w_other_error(self):
         database = _Database()
@@ -145,6 +157,12 @@ class TestTransaction(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             transaction.begin()
+
+        self.assertSpanAttributes(
+            "CloudSpanner.BeginTransaction",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=TestTransaction.BASE_ATTRIBUTES,
+        )
 
     def test_begin_ok(self):
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
@@ -169,11 +187,17 @@ class TestTransaction(unittest.TestCase):
         self.assertTrue(txn_options.HasField("read_write"))
         self.assertEqual(metadata, [("google-cloud-resource-prefix", database.name)])
 
+        self.assertSpanAttributes(
+            "CloudSpanner.BeginTransaction", attributes=TestTransaction.BASE_ATTRIBUTES
+        )
+
     def test_rollback_not_begun(self):
         session = _Session()
         transaction = self._make_one(session)
         with self.assertRaises(ValueError):
             transaction.rollback()
+
+        self.assertNoSpans()
 
     def test_rollback_already_committed(self):
         session = _Session()
@@ -183,6 +207,8 @@ class TestTransaction(unittest.TestCase):
         with self.assertRaises(ValueError):
             transaction.rollback()
 
+        self.assertNoSpans()
+
     def test_rollback_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
@@ -190,6 +216,8 @@ class TestTransaction(unittest.TestCase):
         transaction.rolled_back = True
         with self.assertRaises(ValueError):
             transaction.rollback()
+
+        self.assertNoSpans()
 
     def test_rollback_w_other_error(self):
         database = _Database()
@@ -204,6 +232,12 @@ class TestTransaction(unittest.TestCase):
             transaction.rollback()
 
         self.assertFalse(transaction.rolled_back)
+
+        self.assertSpanAttributes(
+            "CloudSpanner.Rollback",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=TestTransaction.BASE_ATTRIBUTES,
+        )
 
     def test_rollback_ok(self):
         from google.protobuf.empty_pb2 import Empty
@@ -226,11 +260,17 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(txn_id, self.TRANSACTION_ID)
         self.assertEqual(metadata, [("google-cloud-resource-prefix", database.name)])
 
+        self.assertSpanAttributes(
+            "CloudSpanner.Rollback", attributes=TestTransaction.BASE_ATTRIBUTES
+        )
+
     def test_commit_not_begun(self):
         session = _Session()
         transaction = self._make_one(session)
         with self.assertRaises(ValueError):
             transaction.commit()
+
+        self.assertNoSpans()
 
     def test_commit_already_committed(self):
         session = _Session()
@@ -240,6 +280,8 @@ class TestTransaction(unittest.TestCase):
         with self.assertRaises(ValueError):
             transaction.commit()
 
+        self.assertNoSpans()
+
     def test_commit_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
@@ -247,6 +289,8 @@ class TestTransaction(unittest.TestCase):
         transaction.rolled_back = True
         with self.assertRaises(ValueError):
             transaction.commit()
+
+        self.assertNoSpans()
 
     def test_commit_w_other_error(self):
         database = _Database()
@@ -261,6 +305,12 @@ class TestTransaction(unittest.TestCase):
             transaction.commit()
 
         self.assertIsNone(transaction.committed)
+
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit",
+            status=StatusCanonicalCode.UNKNOWN,
+            attributes=dict(TestTransaction.BASE_ATTRIBUTES, num_mutations=1),
+        )
 
     def _commit_helper(self, mutate=True):
         import datetime
@@ -293,6 +343,14 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(txn_id, self.TRANSACTION_ID)
         self.assertEqual(mutations, transaction._mutations)
         self.assertEqual(metadata, [("google-cloud-resource-prefix", database.name)])
+
+        self.assertSpanAttributes(
+            "CloudSpanner.Commit",
+            attributes=dict(
+                TestTransaction.BASE_ATTRIBUTES,
+                num_mutations=len(transaction._mutations),
+            ),
+        )
 
     def test_commit_no_mutations(self):
         self._commit_helper(mutate=False)

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -14,8 +14,7 @@
 
 
 import mock
-from tests._helpers import OpenTelemetryBase
-from opentelemetry.trace.status import StatusCanonicalCode
+from tests._helpers import OpenTelemetryBase, StatusCanonicalCode
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]


### PR DESCRIPTION
1. Creates spans around batch/snapshot/transaction calls with relevant information that could help debug latency issues + provide insight into spanner calls
2. Removed python2.7 from unit/system tests (since OpenTelemetry does not support 2.7). However since OT is an optional dependency with some extra effort the tests could keep using 2.7, is this desired?

Pool/gRPC metrics are also on my TODO list, they will come in a seperate PR once some issues with the OpenTelemetry Metrics SDK are worked out :)