### PR TITLE
docs: add install reference for cloud trace exporter (opentelemetry)

### DIFF
--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -13,7 +13,7 @@ To take advantage of these traces, we first need to install OpenTelemetry:
     # [Optional] Installs the cloud monitoring exporter, however you can use any exporter of your choice
     pip install opentelemetry-exporter-google-cloud
 
-We also need to tell OpenTelemetry which exporter to use. To export spanner traces to `Cloud Tracing <https://cloud.google.com/trace>`_, add the following lines to your application:
+We also need to tell OpenTelemetry which exporter to use. To export Spanner traces to `Cloud Tracing <https://cloud.google.com/trace>`_, add the following lines to your application:
 
 .. code:: python
 

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -1,15 +1,19 @@
 Tracing with OpenTelemetry
-==================================
+==========================
+
 This library uses `OpenTelemetry <https://opentelemetry.io/>`_ to automatically generate traces providing insight on calls to Cloud Spanner. 
 For information on the benefits and utility of tracing, see the `Cloud Trace docs <https://cloud.google.com/trace/docs/overview>`_.
 
-To take advantage of these traces, we first need to install opentelemetry:
+To take advantage of these traces, we first need to install OpenTelemetry:
 
 .. code-block:: sh
 
     pip install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation
 
-We also need to tell OpenTelemetry which exporter to use. For example, to export python-spanner traces to `Cloud Tracing <https://cloud.google.com/trace>`_, add the following lines to your application:
+    # [Optional] Installs the cloud monitoring exporter, however you can use any exporter of your choice
+    pip install opentelemetry-exporter-google-cloud
+
+We also need to tell OpenTelemetry which exporter to use. To export spanner traces to `Cloud Tracing <https://cloud.google.com/trace>`_, add the following lines to your application:
 
 .. code:: python
 


### PR DESCRIPTION
The example uses the Cloud Trace exporter, but there is no `pip install` mentioned for it in the example.

\+ misc doc fixes