### PR TITLE
build: pin opentelemetry dependencies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,12 +67,6 @@ def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov")
 
-    # Install opentelemetry dependencies if python3+
-    if session.python != "2.7":
-        session.install(
-            "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
-        )
-
     session.install("-e", ".")
 
     # Run py.test against the unit tests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -116,12 +116,6 @@ def system(session):
     # virtualenv's dist-packages.
     session.install("mock", "pytest")
 
-    # Install opentelemetry dependencies if not 2.7
-    if session.python != "2.7":
-        session.install(
-            "opentelemetry-api", "opentelemetry-sdk", "opentelemetry-instrumentation"
-        )
-
     session.install("-e", ".")
     session.install("-e", "test_utils/")
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,13 @@ dependencies = [
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
 ]
-extras = {}
+extras = {
+    "tracing": [
+        "opentelemetry-api==0.11b0",
+        "opentelemetry-sdk==0.11b0",
+        "opentelemetry-instrumentation==0.11b0"
+    ]
+}
 
 
 # Setup boilerplate below this line.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras = {
     "tracing": [
         "opentelemetry-api==0.11b0",
         "opentelemetry-sdk==0.11b0",
-        "opentelemetry-instrumentation==0.11b0"
+        "opentelemetry-instrumentation==0.11b0",
     ]
 }
 


### PR DESCRIPTION
The unit tests on master are failing due to the 0.13b0 release of opentelemetry. This PR pins the dependency to the latest working version.