### PR TITLE
build: ensure tracing dependencies are installed for tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov")
 
-    session.install("-e", ".")
+    session.install("-e", ".[tracing]")
 
     # Run py.test against the unit tests.
     session.run(
@@ -116,7 +116,7 @@ def system(session):
     # virtualenv's dist-packages.
     session.install("mock", "pytest")
 
-    session.install("-e", ".")
+    session.install("-e", ".[tracing]")
     session.install("-e", "test_utils/")
 
     # Run py.test against the system tests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,10 @@ def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("mock", "pytest", "pytest-cov")
 
-    session.install("-e", ".[tracing]")
+    if session.python != "2.7":
+        session.install("-e", ".[tracing]")
+    else:
+        session.install("-e", ".")
 
     # Run py.test against the unit tests.
     session.run(
@@ -116,7 +119,10 @@ def system(session):
     # virtualenv's dist-packages.
     session.install("mock", "pytest")
 
-    session.install("-e", ".[tracing]")
+    if session.python != "2.7":
+        session.install("-e", ".[tracing]")
+    else:
+        session.install("-e", ".")
     session.install("-e", "test_utils/")
 
     # Run py.test against the system tests.


### PR DESCRIPTION
In #133, the tracing dependencies were move to extra requirements in the `setup.py`. These are not installed by default. This updates noxfile.py so that the `tracing` requirements are installed when running tests.