### PR TITLE
fix: Remove stray bigquery lines in .gitignore, build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ pip-log.txt
 
 # Built documentation
 docs/_build
-bigquery/docs/generated
 docs.metadata
 
 # Virtual environment

--- a/test_utils/scripts/update_docs.sh
+++ b/test_utils/scripts/update_docs.sh
@@ -24,7 +24,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Function to build the docs.
 function build_docs {
     rm -rf docs/_build/
-    rm -f docs/bigquery/generated/*.rst
     # -W -> warnings as errors
     # -T -> show full traceback on exception
     # -N -> no color


### PR DESCRIPTION
Remove a few stray lines that mentioned bigquery, likely copied from https://github.com/googleapis/python-bigquery.

@mf2199 noticed these while working on https://github.com/googleapis/python-spanner-django, where we're using a similar setup.