### PR TITLE
feat: add support for Point In Time Recovery (PITR)

### DIFF
--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -107,6 +107,8 @@ class Database(object):
         self._state = None
         self._create_time = None
         self._restore_info = None
+        self._version_retention_period = None
+        self._earliest_version_time = None
 
         if pool is None:
             pool = BurstyPool()
@@ -203,6 +205,25 @@ class Database(object):
         :returns: an object representing the restore info for this database
         """
         return self._restore_info
+
+    @property
+    def version_retention_period(self):
+        """The period in which Cloud Spanner retains all versions of data
+        for the database.
+
+        :rtype: str
+        :returns: a string representing the duration of the version retention period
+        """
+        return self._version_retention_period
+
+    @property
+    def earliest_version_time(self):
+        """The earliest time at which older versions of the data can be read.
+
+        :rtype: :class:`datetime.datetime`
+        :returns: a datetime object representing the earliest version time
+        """
+        return self._earliest_version_time
 
     @property
     def ddl_statements(self):
@@ -313,6 +334,10 @@ class Database(object):
         self._state = DatabasePB.State(response.state)
         self._create_time = response.create_time
         self._restore_info = response.restore_info
+        self._version_retention_period = response.version_retention_period
+        self._earliest_version_time = _pb_timestamp_to_datetime(
+            response.earliest_version_time
+        )
 
     def update_ddl(self, ddl_statements, operation_id=""):
         """Update DDL for this database.

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -335,9 +335,7 @@ class Database(object):
         self._create_time = response.create_time
         self._restore_info = response.restore_info
         self._version_retention_period = response.version_retention_period
-        self._earliest_version_time = _pb_timestamp_to_datetime(
-            response.earliest_version_time
-        )
+        self._earliest_version_time = response.earliest_version_time
 
     def update_ddl(self, ddl_statements, operation_id=""):
         """Update DDL for this database.

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -400,7 +400,7 @@ class Instance(object):
         )
         return page_iter
 
-    def backup(self, backup_id, database="", expire_time=None):
+    def backup(self, backup_id, database="", expire_time=None, version_time=None):
         """Factory to create a backup within this instance.
 
         :type backup_id: str
@@ -415,13 +415,29 @@ class Instance(object):
         :param expire_time:
             Optional. The expire time that will be used when creating the backup.
             Required if the create method needs to be called.
+
+        :type version_time: :class:`datetime.datetime`
+        :param version_time:
+            Optional. The version time that will be used to create the externally
+            consistent copy of the database. If not present, it is the same as
+            the `create_time` of the backup.
         """
         try:
             return Backup(
-                backup_id, self, database=database.name, expire_time=expire_time
+                backup_id,
+                self,
+                database=database.name,
+                expire_time=expire_time,
+                version_time=version_time,
             )
         except AttributeError:
-            return Backup(backup_id, self, database=database, expire_time=expire_time)
+            return Backup(
+                backup_id,
+                self,
+                database=database,
+                expire_time=expire_time,
+                version_time=version_time,
+            )
 
     def list_backups(self, filter_="", page_size=None):
         """List backups for the instance.

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -396,9 +396,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         # We want to make sure the operation completes.
         operation.result(30)  # raises on failure / timeout.
 
-        database_ids = [
-            database.name for database in Config.INSTANCE.list_databases()
-        ]
+        database_ids = [database.name for database in Config.INSTANCE.list_databases()]
         self.assertIn(temp_db.name, database_ids)
 
         temp_db.reload()

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -397,9 +397,9 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         operation.result(30)  # raises on failure / timeout.
 
         database_ids = [
-            database.database_id for database in Config.INSTANCE.list_databases()
+            database.name for database in Config.INSTANCE.list_databases()
         ]
-        self.assertIn(temp_db_id, database_ids)
+        self.assertIn(temp_db.name, database_ids)
 
         temp_db.reload()
         self.assertEqual(temp_db.version_retention_period, retention_period)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -724,7 +724,9 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         self.to_drop.append(database)
         operation = database.restore(source=backup)
         restored_db = operation.result()
-        self.assertEqual(self.database_version_time, restored_db.restore_info.backup_info.create_time)
+        self.assertEqual(
+            self.database_version_time, restored_db.restore_info.backup_info.create_time
+        )
 
         metadata = operation.metadata
         self.assertEqual(self.database_version_time, metadata.backup_info.create_time)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -611,22 +611,6 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         op1.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
         op2.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
-        # Add retention period for backups
-        retention_period = "7d"
-        ddl_statements = DDL_STATEMENTS + [
-            "ALTER DATABASE {}"
-            " SET OPTIONS (version_retention_period = '{}')".format(
-                cls.DATABASE_NAME, retention_period
-            )
-        ]
-        db = Config.INSTANCE.database(
-            cls.DATABASE_NAME, pool=pool, ddl_statements=ddl_statements
-        )
-        operation = db.update_ddl(ddl_statements)
-        # We want to make sure the operation completes.
-        operation.result(240)  # raises on failure / timeout.
-        db.reload()
-
         current_config = Config.INSTANCE.configuration_name
         same_config_instance_id = "same-config" + unique_resource_id("-")
         create_time = str(int(time.time()))
@@ -738,7 +722,11 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         database = instance.database(restored_id)
         self.to_drop.append(database)
         operation = database.restore(source=backup)
-        operation.result()
+        restored_db = operation.result()
+        self.assertEqual(version_time, restored_db.restore_info.backup_info.create_time)
+
+        metadata = operation.metadata
+        self.assertEqual(version_time, metadata.backup_info.create_time)
 
         database.drop()
         backup.delete()

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -613,6 +613,22 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         op1.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
         op2.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
+        # Add retention period for backups
+        retention_period = "7d"
+        ddl_statements = DDL_STATEMENTS + [
+            "ALTER DATABASE {}"
+            " SET OPTIONS (version_retention_period = '{}')".format(
+                cls.DATABASE_NAME, retention_period
+            )
+        ]
+        db = Config.INSTANCE.database(
+            cls.DATABASE_NAME, pool=pool, ddl_statements=ddl_statements
+        )
+        operation = db.update_ddl(ddl_statements)
+        # We want to make sure the operation completes.
+        operation.result(240)  # raises on failure / timeout.
+        db.reload()
+
         current_config = Config.INSTANCE.configuration_name
         same_config_instance_id = "same-config" + unique_resource_id("-")
         create_time = str(int(time.time()))
@@ -685,9 +701,16 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         backup_id = "backup_id" + unique_resource_id("_")
         expire_time = datetime.utcnow() + timedelta(days=3)
         expire_time = expire_time.replace(tzinfo=UTC)
+        version_time = datetime.utcnow() - timedelta(seconds=5)
+        version_time = version_time.replace(tzinfo=UTC)
 
         # Create backup.
-        backup = instance.backup(backup_id, database=self._db, expire_time=expire_time)
+        backup = instance.backup(
+            backup_id,
+            database=self._db,
+            expire_time=expire_time,
+            version_time=version_time,
+        )
         operation = backup.create()
         self.to_delete.append(backup)
 
@@ -702,6 +725,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         self.assertEqual(self._db.name, backup._database)
         self.assertEqual(expire_time, backup.expire_time)
         self.assertIsNotNone(backup.create_time)
+        self.assertEqual(version_time, backup.version_time)
         self.assertIsNotNone(backup.size_bytes)
         self.assertIsNotNone(backup.state)
 
@@ -721,6 +745,80 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         database.drop()
         backup.delete()
         self.assertFalse(backup.exists())
+
+    def test_backup_version_time_defaults_to_create_time(self):
+        from datetime import datetime
+        from datetime import timedelta
+        from pytz import UTC
+
+        instance = Config.INSTANCE
+        backup_id = "backup_id" + unique_resource_id("_")
+        expire_time = datetime.utcnow() + timedelta(days=3)
+        expire_time = expire_time.replace(tzinfo=UTC)
+
+        # Create backup.
+        backup = instance.backup(backup_id, database=self._db, expire_time=expire_time,)
+        operation = backup.create()
+        self.to_delete.append(backup)
+
+        # Check metadata.
+        metadata = operation.metadata
+        self.assertEqual(backup.name, metadata.name)
+        self.assertEqual(self._db.name, metadata.database)
+        operation.result()
+
+        # Check backup object.
+        backup.reload()
+        self.assertEqual(self._db.name, backup._database)
+        self.assertIsNotNone(backup.create_time)
+        self.assertEqual(backup.create_time, backup.version_time)
+
+        backup.delete()
+        self.assertFalse(backup.exists())
+
+    def test_create_backup_invalid_version_time_past(self):
+        from datetime import datetime
+        from datetime import timedelta
+        from pytz import UTC
+
+        backup_id = "backup_id" + unique_resource_id("_")
+        expire_time = datetime.utcnow() + timedelta(days=3)
+        expire_time = expire_time.replace(tzinfo=UTC)
+        version_time = datetime.utcnow() - timedelta(days=10)
+        version_time = version_time.replace(tzinfo=UTC)
+
+        backup = Config.INSTANCE.backup(
+            backup_id,
+            database=self._db,
+            expire_time=expire_time,
+            version_time=version_time,
+        )
+
+        with self.assertRaises(exceptions.InvalidArgument):
+            op = backup.create()
+            op.result()
+
+    def test_create_backup_invalid_version_time_future(self):
+        from datetime import datetime
+        from datetime import timedelta
+        from pytz import UTC
+
+        backup_id = "backup_id" + unique_resource_id("_")
+        expire_time = datetime.utcnow() + timedelta(days=3)
+        expire_time = expire_time.replace(tzinfo=UTC)
+        version_time = datetime.utcnow() + timedelta(days=2)
+        version_time = version_time.replace(tzinfo=UTC)
+
+        backup = Config.INSTANCE.backup(
+            backup_id,
+            database=self._db,
+            expire_time=expire_time,
+            version_time=version_time,
+        )
+
+        with self.assertRaises(exceptions.InvalidArgument):
+            op = backup.create()
+            op.result()
 
     def test_restore_to_diff_instance(self):
         from datetime import datetime
@@ -818,9 +916,14 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         instance = Config.INSTANCE
         expire_time_1 = datetime.utcnow() + timedelta(days=21)
         expire_time_1 = expire_time_1.replace(tzinfo=UTC)
+        version_time_1 = datetime.utcnow() - timedelta(minutes=5)
+        version_time_1 = version_time_1.replace(tzinfo=UTC)
 
         backup1 = Config.INSTANCE.backup(
-            backup_id_1, database=self._dbs[0], expire_time=expire_time_1
+            backup_id_1,
+            database=self._dbs[0],
+            expire_time=expire_time_1,
+            version_time=version_time_1,
         )
 
         expire_time_2 = datetime.utcnow() + timedelta(days=1)
@@ -855,6 +958,13 @@ class TestBackupAPI(unittest.TestCase, _TestData):
 
         # List backups filtered by create time.
         filter_ = 'create_time > "{0}"'.format(
+            create_time_compare.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        )
+        for backup in instance.list_backups(filter_=filter_):
+            self.assertEqual(backup.name, backup2.name)
+
+        # List backups filtered by version time.
+        filter_ = 'version_time > "{0}"'.format(
             create_time_compare.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         )
         for backup in instance.list_backups(filter_=filter_):

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -598,6 +598,8 @@ class TestBackupAPI(unittest.TestCase, _TestData):
 
     @classmethod
     def setUpClass(cls):
+        from datetime import datetime
+
         pool = BurstyPool(labels={"testcase": "database_api"})
         ddl_statements = EMULATOR_DDL_STATEMENTS if USE_EMULATOR else DDL_STATEMENTS
         db1 = Config.INSTANCE.database(
@@ -610,6 +612,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         op2 = db2.create()
         op1.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
         op2.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        cls.database_version_time = datetime.utcnow().replace(tzinfo=UTC)
 
         current_config = Config.INSTANCE.configuration_name
         same_config_instance_id = "same-config" + unique_resource_id("-")
@@ -683,15 +686,13 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         backup_id = "backup_id" + unique_resource_id("_")
         expire_time = datetime.utcnow() + timedelta(days=3)
         expire_time = expire_time.replace(tzinfo=UTC)
-        version_time = datetime.utcnow() - timedelta(seconds=5)
-        version_time = version_time.replace(tzinfo=UTC)
 
         # Create backup.
         backup = instance.backup(
             backup_id,
             database=self._db,
             expire_time=expire_time,
-            version_time=version_time,
+            version_time=self.database_version_time,
         )
         operation = backup.create()
         self.to_delete.append(backup)
@@ -707,7 +708,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         self.assertEqual(self._db.name, backup._database)
         self.assertEqual(expire_time, backup.expire_time)
         self.assertIsNotNone(backup.create_time)
-        self.assertEqual(version_time, backup.version_time)
+        self.assertEqual(self.database_version_time, backup.version_time)
         self.assertIsNotNone(backup.size_bytes)
         self.assertIsNotNone(backup.state)
 
@@ -723,10 +724,10 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         self.to_drop.append(database)
         operation = database.restore(source=backup)
         restored_db = operation.result()
-        self.assertEqual(version_time, restored_db.restore_info.backup_info.create_time)
+        self.assertEqual(self.database_version_time, restored_db.restore_info.backup_info.create_time)
 
         metadata = operation.metadata
-        self.assertEqual(version_time, metadata.backup_info.create_time)
+        self.assertEqual(self.database_version_time, metadata.backup_info.create_time)
 
         database.drop()
         backup.delete()
@@ -902,14 +903,12 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         instance = Config.INSTANCE
         expire_time_1 = datetime.utcnow() + timedelta(days=21)
         expire_time_1 = expire_time_1.replace(tzinfo=UTC)
-        version_time_1 = datetime.utcnow() - timedelta(minutes=5)
-        version_time_1 = version_time_1.replace(tzinfo=UTC)
 
         backup1 = Config.INSTANCE.backup(
             backup_id_1,
             database=self._dbs[0],
             expire_time=expire_time_1,
-            version_time=version_time_1,
+            version_time=self.database_version_time,
         )
 
         expire_time_2 = datetime.utcnow() + timedelta(days=1)

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -266,6 +266,9 @@ class TestBackup(_BaseTest):
 
     def test_create_success(self):
         from google.cloud.spanner_admin_database_v1 import Backup
+        from datetime import datetime
+        from datetime import timedelta
+        from pytz import UTC
 
         op_future = object()
         client = _Client()
@@ -273,12 +276,22 @@ class TestBackup(_BaseTest):
         api.create_backup.return_value = op_future
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        timestamp = self._make_timestamp()
+        version_timestamp = datetime.utcnow() - timedelta(minutes=5)
+        version_timestamp = version_timestamp.replace(tzinfo=UTC)
+        expire_timestamp = self._make_timestamp()
         backup = self._make_one(
-            self.BACKUP_ID, instance, database=self.DATABASE_NAME, expire_time=timestamp
+            self.BACKUP_ID,
+            instance,
+            database=self.DATABASE_NAME,
+            expire_time=expire_timestamp,
+            version_time=version_timestamp,
         )
 
-        backup_pb = Backup(database=self.DATABASE_NAME, expire_time=timestamp,)
+        backup_pb = Backup(
+            database=self.DATABASE_NAME,
+            expire_time=expire_timestamp,
+            version_time=version_timestamp,
+        )
 
         future = backup.create()
         self.assertIs(future, op_future)
@@ -437,6 +450,7 @@ class TestBackup(_BaseTest):
             name=self.BACKUP_NAME,
             database=self.DATABASE_NAME,
             expire_time=timestamp,
+            version_time=timestamp,
             create_time=timestamp,
             size_bytes=10,
             state=1,
@@ -452,6 +466,7 @@ class TestBackup(_BaseTest):
         self.assertEqual(backup.database, self.DATABASE_NAME)
         self.assertEqual(backup.expire_time, timestamp)
         self.assertEqual(backup.create_time, timestamp)
+        self.assertEqual(backup.version_time, timestamp)
         self.assertEqual(backup.size_bytes, 10)
         self.assertEqual(backup.state, Backup.State.CREATING)
         self.assertEqual(backup.referencing_databases, [])

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -249,6 +249,20 @@ class TestDatabase(_BaseTest):
         )
         self.assertEqual(database.restore_info, restore_info)
 
+    def test_version_retention_period(self):
+        instance = _Instance(self.INSTANCE_NAME)
+        pool = _Pool()
+        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
+        version_retention_period = database._version_retention_period = "1d"
+        self.assertEqual(database.version_retention_period, version_retention_period)
+
+    def test_earliest_version_time(self):
+        instance = _Instance(self.INSTANCE_NAME)
+        pool = _Pool()
+        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
+        earliest_version_time = database._earliest_version_time = self._make_timestamp()
+        self.assertEqual(database.earliest_version_time, earliest_version_time)
+
     def test_spanner_api_property_w_scopeless_creds(self):
 
         client = _Client()
@@ -581,6 +595,8 @@ class TestDatabase(_BaseTest):
             state=2,
             create_time=_datetime_to_pb_timestamp(timestamp),
             restore_info=restore_info,
+            version_retention_period="1d",
+            earliest_version_time=_datetime_to_pb_timestamp(timestamp),
         )
         api.get_database.return_value = db_pb
         instance = _Instance(self.INSTANCE_NAME, client=client)
@@ -591,6 +607,8 @@ class TestDatabase(_BaseTest):
         self.assertEqual(database._state, Database.State.READY)
         self.assertEqual(database._create_time, timestamp)
         self.assertEqual(database._restore_info, restore_info)
+        self.assertEqual(database._version_retention_period, "1d")
+        self.assertEqual(database._earliest_version_time, timestamp)
         self.assertEqual(database._ddl_statements, tuple(DDL_STATEMENTS))
 
         api.get_database_ddl.assert_called_once_with(


### PR DESCRIPTION
Implements support for PITR.

With this functionality users will be able to:
- set the retention period for their databases.
- set version time of the database when creating a backup

Creating a backup with a specific version time is shown below:
```
backup = instance.backup(backup_id, expire_time=expire_time, version_time=version_time)
backup.create()
```