### PR TITLE
test: skip failing list_backup_operations sample test

### DIFF
--- a/samples/samples/backup_sample_test.py
+++ b/samples/samples/backup_sample_test.py
@@ -79,6 +79,12 @@ def test_restore_database(capsys):
     assert BACKUP_ID in out
 
 
+@pytest.mark.skip(
+    reason=(
+        "failing due to a production bug"
+        "https://github.com/googleapis/python-spanner/issues/149"
+    )
+)
 def test_list_backup_operations(capsys, spanner_instance):
     backup_sample.list_backup_operations(INSTANCE_ID, DATABASE_ID)
     out, _ = capsys.readouterr()


### PR DESCRIPTION
There's a production issue that causes `list_backup_operations` to fail when filtering with metadata. Skipping this test until it is fixed. Unskipping this test will be tracked by #149 