### PR TITLE
fix: handle Unmergable errors when merging struct responses

### DIFF
--- a/google/cloud/spanner_v1/streamed.py
+++ b/google/cloud/spanner_v1/streamed.py
@@ -286,7 +286,13 @@ def _merge_struct(lhs, rhs, type_):
         lhs.append(first)
     else:
         last = lhs.pop()
-        lhs.append(_merge_by_type(last, first, candidate_type))
+        try:
+            merged = _merge_by_type(last, first, candidate_type)
+        except Unmergeable:
+            lhs.append(last)
+            lhs.append(first)
+        else:
+            lhs.append(merged)
     return Value(list_value=ListValue(values=lhs + rhs))
 
 

--- a/tests/unit/test_streamed.py
+++ b/tests/unit/test_streamed.py
@@ -448,6 +448,26 @@ class TestStreamedResultSet(unittest.TestCase):
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
+    def test__merge_chunk_array_of_struct_unmergeable_split(self):
+        iterator = _MockCancellableIterator()
+        streamed = self._make_one(iterator)
+        struct_type = self._make_struct_type(
+            [("name", "STRING"), ("height", "FLOAT64"), ("eye_color", "STRING")]
+        )
+        FIELDS = [self._make_array_field("test", element_type=struct_type)]
+        streamed._metadata = self._make_result_set_metadata(FIELDS)
+        partial = self._make_list_value([u"Phred Phlyntstone", 1.65])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value(["brown"])
+        chunk = self._make_list_value(value_pbs=[rest])
+
+        merged = streamed._merge_chunk(chunk)
+
+        struct = self._make_list_value([u"Phred Phlyntstone", 1.65, "brown"])
+        expected = self._make_list_value(value_pbs=[struct])
+        self.assertEqual(merged, expected)
+        self.assertIsNone(streamed._pending_chunk)
+
     def test_merge_values_empty_and_empty(self):
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)


### PR DESCRIPTION
This PR fixes a bug in the `StreamedResultSet` logic for merging chunked values where the chunked value is an array of structs and the chunk boundary splits a struct element in two and the halves aren't correctly merged.

This bug results in the struct element incorrectly being split into two partial struct elements.

**Expected:**
```
('foo', 0.5, DatetimeWithNanoseconds(2020, 1, 1, 0, 0, tzinfo=<UTC>))
```

**Actual:**
```
('foo', 0.5)
('2020-01-01T00:00:00Z',)
```

This bug is caused by an unhandled `Unmergable` error in `_merge_struct`. This PR adds the same handling used for `_merge_array` and a unit test to prove the fix works.