### PR TITLE
fix: Add sqlparse dependency

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("asyncmock", "pytest-asyncio")
 
-    session.install("mock", "pytest", "pytest-cov", "sqlparse")
+    session.install("mock", "pytest", "pytest-cov")
     session.install("-e", ".")
 
     # Run py.test against the unit tests.

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,9 @@ dependencies = [
     "google-api-core[grpc] >= 1.22.0, < 2.0.0dev",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
-    "proto-plus==1.11.0",
     "libcst >= 0.2.5",
+    "proto-plus == 1.11.0",
+    "sqlparse >= 0.3.0",
 ]
 extras = {
     "tracing": [


### PR DESCRIPTION
#160 added `sqlparse` as a test dependency only, but included [non-test code that imports it](https://github.com/googleapis/python-spanner/blob/3db4e5f8d729fb35d416691489d13c2fd306361a/google/cloud/spanner_dbapi/parse_utils.py#L22). Running the tests outside of nox gives this error: `E   ModuleNotFoundError: No module named 'sqlparse'`.

This PR makes `sqlparse` a regular non-test dependency.

The version number comes from https://github.com/googleapis/python-spanner-django/commit/2b096c50949db674e2c017cb4e05e9f71bc0e405.