### PR TITLE
fix!: convert operations pbs into Operation objects when listing oper…

### DIFF
--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -14,6 +14,7 @@
 
 """User friendly container for Cloud Spanner Instance."""
 
+import google.api_core.operation
 import re
 
 from google.cloud.spanner_admin_instance_v1 import Instance as InstancePB
@@ -465,7 +466,7 @@ class Instance(object):
         page_iter = self._client.database_admin_api.list_backup_operations(
             request=request, metadata=metadata
         )
-        return page_iter
+        return map(self._item_to_operation, page_iter)
 
     def list_database_operations(self, filter_="", page_size=None):
         """List database operations for the instance.
@@ -493,4 +494,18 @@ class Instance(object):
         page_iter = self._client.database_admin_api.list_database_operations(
             request=request, metadata=metadata
         )
-        return page_iter
+        return map(self._item_to_operation, page_iter)
+
+    def _item_to_operation(self, operation_pb):
+        """Convert an operation protobuf to the native object.
+        :type operation_pb: :class:`~google.longrunning.operations.Operation`
+        :param operation_pb: An operation returned from the API.
+        :rtype: :class:`~google.api_core.operation.Operation`
+        :returns: The next operation in the page.
+        """
+        operations_client = self._client.database_admin_api.transport.operations_client
+        metadata_type = _type_string_to_type_pb(operation_pb.metadata.type_url)
+        response_type = _OPERATION_RESPONSE_TYPES[metadata_type]
+        return google.api_core.operation.from_gapic(
+            operation_pb, operations_client, response_type, metadata_type=metadata_type
+        )

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -673,6 +673,7 @@ class TestInstance(unittest.TestCase):
         )
 
     def test_list_backup_operations_defaults(self):
+        from google.api_core.operation import Operation
         from google.cloud.spanner_admin_database_v1 import CreateBackupMetadata
         from google.cloud.spanner_admin_database_v1 import DatabaseAdminClient
         from google.cloud.spanner_admin_database_v1 import ListBackupOperationsRequest
@@ -702,7 +703,7 @@ class TestInstance(unittest.TestCase):
             api._transport.list_backup_operations
         ] = mock.Mock(return_value=operations_pb)
 
-        instance.list_backup_operations()
+        ops = instance.list_backup_operations()
 
         expected_metadata = (
             ("google-cloud-resource-prefix", instance.name),
@@ -714,8 +715,10 @@ class TestInstance(unittest.TestCase):
             retry=mock.ANY,
             timeout=mock.ANY,
         )
+        self.assertTrue(all([type(op) == Operation for op in ops]))
 
     def test_list_backup_operations_w_options(self):
+        from google.api_core.operation import Operation
         from google.cloud.spanner_admin_database_v1 import CreateBackupMetadata
         from google.cloud.spanner_admin_database_v1 import DatabaseAdminClient
         from google.cloud.spanner_admin_database_v1 import ListBackupOperationsRequest
@@ -745,7 +748,7 @@ class TestInstance(unittest.TestCase):
             api._transport.list_backup_operations
         ] = mock.Mock(return_value=operations_pb)
 
-        instance.list_backup_operations(filter_="filter", page_size=10)
+        ops = instance.list_backup_operations(filter_="filter", page_size=10)
 
         expected_metadata = (
             ("google-cloud-resource-prefix", instance.name),
@@ -759,8 +762,10 @@ class TestInstance(unittest.TestCase):
             retry=mock.ANY,
             timeout=mock.ANY,
         )
+        self.assertTrue(all([type(op) == Operation for op in ops]))
 
     def test_list_database_operations_defaults(self):
+        from google.api_core.operation import Operation
         from google.cloud.spanner_admin_database_v1 import CreateDatabaseMetadata
         from google.cloud.spanner_admin_database_v1 import DatabaseAdminClient
         from google.cloud.spanner_admin_database_v1 import ListDatabaseOperationsRequest
@@ -803,7 +808,7 @@ class TestInstance(unittest.TestCase):
             api._transport.list_database_operations
         ] = mock.Mock(return_value=databases_pb)
 
-        instance.list_database_operations()
+        ops = instance.list_database_operations()
 
         expected_metadata = (
             ("google-cloud-resource-prefix", instance.name),
@@ -815,8 +820,10 @@ class TestInstance(unittest.TestCase):
             retry=mock.ANY,
             timeout=mock.ANY,
         )
+        self.assertTrue(all([type(op) == Operation for op in ops]))
 
     def test_list_database_operations_w_options(self):
+        from google.api_core.operation import Operation
         from google.cloud.spanner_admin_database_v1 import DatabaseAdminClient
         from google.cloud.spanner_admin_database_v1 import ListDatabaseOperationsRequest
         from google.cloud.spanner_admin_database_v1 import (
@@ -864,7 +871,7 @@ class TestInstance(unittest.TestCase):
             api._transport.list_database_operations
         ] = mock.Mock(return_value=databases_pb)
 
-        instance.list_database_operations(filter_="filter", page_size=10)
+        ops = instance.list_database_operations(filter_="filter", page_size=10)
 
         expected_metadata = (
             ("google-cloud-resource-prefix", instance.name),
@@ -878,6 +885,7 @@ class TestInstance(unittest.TestCase):
             retry=mock.ANY,
             timeout=mock.ANY,
         )
+        self.assertTrue(all([type(op) == Operation for op in ops]))
 
     def test_type_string_to_type_pb_hit(self):
         from google.cloud.spanner_admin_database_v1 import (


### PR DESCRIPTION
…ations

The migration to v2.0.0 accidentally changed the return type of `instance.list_*_operations` methods. This was not caught due to lack of test coverage and a sample that was being skipped due to a backend bug. Unfortunately, correcting the return type back is a breaking change.