### PR TITLE
feat: add support to log commit stats

### DIFF
--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -656,7 +656,7 @@ class BatchCheckout(object):
             if exc_type is None:
                 self._batch.commit(return_commit_stats=self._database.log_commit_stats)
         finally:
-            if self._database.log_commit_stats:
+            if self._database.log_commit_stats and self._batch.commit_stats:
                 self._database.logger.info(
                     "CommitStats: {}".format(self._batch.commit_stats),
                     extra={"commit_stats": self._batch.commit_stats},

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -237,12 +237,6 @@ class Database(object):
 
             ch = logging.StreamHandler()
             ch.setLevel(logging.INFO)
-
-            formatter = logging.Formatter(
-                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-            )
-            ch.setFormatter(formatter)
-
             self._logger.addHandler(ch)
         return self._logger
 
@@ -657,11 +651,7 @@ class BatchCheckout(object):
                 self._batch.commit(return_commit_stats=self._database.log_commit_stats)
         finally:
             if self._database.log_commit_stats:
-                self._database.logger.info(
-                    "Transaction mutation count: {}".format(
-                        self._batch.commit_stats.mutation_count
-                    )
-                )
+                self._database.logger.info(self._batch.commit_stats)
             self._database._pool.put(self._session)
 
 

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -657,7 +657,10 @@ class BatchCheckout(object):
                 self._batch.commit(return_commit_stats=self._database.log_commit_stats)
         finally:
             if self._database.log_commit_stats:
-                self._database.logger.info(self._batch.commit_stats)
+                self._database.logger.info(
+                    "CommitStats: {}".format(self._batch.commit_stats),
+                    extra={"commit_stats": self._batch.commit_stats},
+                )
             self._database._pool.put(self._session)
 
 

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -96,6 +96,12 @@ class Database(object):
     :param pool: (Optional) session pool to be used by database.  If not
                  passed, the database will construct an instance of
                  :class:`~google.cloud.spanner_v1.pool.BurstyPool`.
+
+    :type logger: `logging.Logger`
+    :param logger: (Optional) a custom logger that is used if `log_commit_stats`
+                   is `True` to log commit statistics. If not passed, a logger
+                   will be created when needed that will log the commit statistics
+                   to stdout.
     """
 
     _spanner_api = None

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -17,6 +17,7 @@
 import copy
 import functools
 import grpc
+import logging
 import re
 import threading
 
@@ -99,7 +100,9 @@ class Database(object):
 
     _spanner_api = None
 
-    def __init__(self, database_id, instance, ddl_statements=(), pool=None):
+    def __init__(
+        self, database_id, instance, ddl_statements=(), pool=None, logger=None
+    ):
         self.database_id = database_id
         self._instance = instance
         self._ddl_statements = _check_ddl_statements(ddl_statements)
@@ -107,6 +110,8 @@ class Database(object):
         self._state = None
         self._create_time = None
         self._restore_info = None
+        self.log_commit_stats = False
+        self._logger = logger
 
         if pool is None:
             pool = BurstyPool()
@@ -215,6 +220,31 @@ class Database(object):
         :returns: the statements
         """
         return self._ddl_statements
+
+    @property
+    def logger(self):
+        """Logger used by the database.
+
+        The default logger will log commit stats at the log level INFO using
+        `sys.stderr`.
+
+        :rtype: :class:`logging.Logger` or `None`
+        :returns: the logger
+        """
+        if self._logger is None:
+            self._logger = logging.getLogger(self.name)
+            self._logger.setLevel(logging.INFO)
+
+            ch = logging.StreamHandler()
+            ch.setLevel(logging.INFO)
+
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+            ch.setFormatter(formatter)
+
+            self._logger.addHandler(ch)
+        return self._logger
 
     @property
     def spanner_api(self):
@@ -624,8 +654,14 @@ class BatchCheckout(object):
         """End ``with`` block."""
         try:
             if exc_type is None:
-                self._batch.commit()
+                self._batch.commit(return_commit_stats=self._database.log_commit_stats)
         finally:
+            if self._database.log_commit_stats:
+                self._database.logger.info(
+                    "Transaction mutation count: {}".format(
+                        self._batch.commit_stats.mutation_count
+                    )
+                )
             self._database._pool.put(self._session)
 
 

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -357,7 +357,7 @@ class Instance(object):
 
         api.delete_instance(name=self.name, metadata=metadata)
 
-    def database(self, database_id, ddl_statements=(), pool=None):
+    def database(self, database_id, ddl_statements=(), pool=None, logger=None):
         """Factory to create a database within this instance.
 
         :type database_id: str
@@ -374,7 +374,9 @@ class Instance(object):
         :rtype: :class:`~google.cloud.spanner_v1.database.Database`
         :returns: a database owned by this instance.
         """
-        return Database(database_id, self, ddl_statements=ddl_statements, pool=pool)
+        return Database(
+            database_id, self, ddl_statements=ddl_statements, pool=pool, logger=logger
+        )
 
     def list_databases(self, page_size=None):
         """List databases for the instance.

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -371,6 +371,12 @@ class Instance(object):
                     :class:`~google.cloud.spanner_v1.pool.AbstractSessionPool`.
         :param pool: (Optional) session pool to be used by database.
 
+        :type logger: `logging.Logger`
+        :param logger: (Optional) a custom logger that is used if `log_commit_stats`
+                       is `True` to log commit statistics. If not passed, a logger
+                       will be created when needed that will log the commit statistics
+                       to stdout.
+
         :rtype: :class:`~google.cloud.spanner_v1.database.Database`
         :returns: a database owned by this instance.
         """

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -349,7 +349,7 @@ class Session(object):
                 raise
 
             try:
-                txn.commit()
+                txn.commit(return_commit_stats=self._database.log_commit_stats)
             except Aborted as exc:
                 del self._transaction
                 _delay_until_retry(exc, deadline, attempts)
@@ -357,6 +357,12 @@ class Session(object):
                 del self._transaction
                 raise
             else:
+                if self._database.log_commit_stats:
+                    self._database.logger.info(
+                        "Transaction mutation count: {}".format(
+                            txn.commit_stats.mutation_count
+                        )
+                    )
                 return return_value
 
 

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -357,7 +357,7 @@ class Session(object):
                 del self._transaction
                 raise
             else:
-                if self._database.log_commit_stats:
+                if self._database.log_commit_stats and txn.commit_stats:
                     self._database.logger.info(
                         "CommitStats: {}".format(txn.commit_stats),
                         extra={"commit_stats": txn.commit_stats},

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -358,7 +358,10 @@ class Session(object):
                 raise
             else:
                 if self._database.log_commit_stats:
-                    self._database.logger.info(txn.commit_stats)
+                    self._database.logger.info(
+                        "CommitStats: {}".format(txn.commit_stats),
+                        extra={"commit_stats": txn.commit_stats},
+                    )
                 return return_value
 
 

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -358,11 +358,7 @@ class Session(object):
                 raise
             else:
                 if self._database.log_commit_stats:
-                    self._database.logger.info(
-                        "Transaction mutation count: {}".format(
-                            txn.commit_stats.mutation_count
-                        )
-                    )
+                    self._database.logger.info(txn.commit_stats)
                 return return_value
 
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -339,17 +339,17 @@ class _FauxSpannerAPI:
         self.__dict__.update(**kwargs)
 
     def commit(
-        self,
-        session,
-        mutations,
-        transaction_id="",
-        single_use_transaction=None,
-        metadata=None,
+        self, request=None, metadata=None,
     ):
         from google.api_core.exceptions import Unknown
 
-        assert transaction_id == ""
-        self._committed = (session, mutations, single_use_transaction, metadata)
+        assert request.transaction_id == b""
+        self._committed = (
+            request.session,
+            request.mutations,
+            request.single_use_transaction,
+            metadata,
+        )
         if self._rpc_error:
             raise Unknown("error")
         return self._commit_response

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1368,16 +1368,13 @@ class TestBatchCheckout(_BaseTest):
             session=self.SESSION_NAME,
             mutations=[],
             single_use_transaction=expected_txn_options,
-            return_commit_stats=True
-
+            return_commit_stats=True,
         )
         api.commit.assert_called_once_with(
             request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
-        database.logger.info.assert_called_once_with(
-            "Transaction mutation count: 4"
-        )
+        database.logger.info.assert_called_once_with("Transaction mutation count: 4")
 
     def test_context_mgr_failure(self):
         from google.cloud.spanner_v1.batch import Batch
@@ -1972,6 +1969,7 @@ class _Database(object):
         self.database_id = name.rsplit("/", 1)[1]
         self._instance = instance
         from logging import Logger
+
         self.logger = mock.create_autospec(Logger, instance=True)
 
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1374,7 +1374,9 @@ class TestBatchCheckout(_BaseTest):
             request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
-        database.logger.info.assert_called_once_with(commit_stats)
+        database.logger.info.assert_called_once_with(
+            "CommitStats: mutation_count: 4\n", extra={"commit_stats": commit_stats}
+        )
 
     def test_context_mgr_failure(self):
         from google.cloud.spanner_v1.batch import Batch

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -104,6 +104,8 @@ class TestDatabase(_BaseTest):
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
         self.assertIsInstance(database._pool, BurstyPool)
+        self.assertFalse(database.log_commit_stats)
+        self.assertIsNone(database._logger)
         # BurstyPool does not create sessions during 'bind()'.
         self.assertTrue(database._pool._sessions.empty())
 
@@ -144,6 +146,18 @@ class TestDatabase(_BaseTest):
         self.assertEqual(database.database_id, self.DATABASE_ID)
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), DDL_STATEMENTS)
+
+    def test_ctor_w_explicit_logger(self):
+        from logging import Logger
+
+        instance = _Instance(self.INSTANCE_NAME)
+        logger = mock.create_autospec(Logger, instance=True)
+        database = self._make_one(self.DATABASE_ID, instance, logger=logger)
+        self.assertEqual(database.database_id, self.DATABASE_ID)
+        self.assertIs(database._instance, instance)
+        self.assertEqual(list(database.ddl_statements), [])
+        self.assertFalse(database.log_commit_stats)
+        self.assertEqual(database._logger, logger)
 
     def test_from_pb_bad_database_name(self):
         from google.cloud.spanner_admin_database_v1 import Database
@@ -248,6 +262,24 @@ class TestDatabase(_BaseTest):
             RestoreInfo, instance=True
         )
         self.assertEqual(database.restore_info, restore_info)
+
+    def test_logger_property_default(self):
+        import logging
+
+        instance = _Instance(self.INSTANCE_NAME)
+        pool = _Pool()
+        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
+        logger = logging.getLogger(database.name)
+        self.assertEqual(database.logger, logger)
+
+    def test_logger_property_custom(self):
+        import logging
+
+        instance = _Instance(self.INSTANCE_NAME)
+        pool = _Pool()
+        database = self._make_one(self.DATABASE_ID, instance, pool=pool)
+        logger = database._logger = mock.create_autospec(logging.Logger, instance=True)
+        self.assertEqual(database.logger, logger)
 
     def test_spanner_api_property_w_scopeless_creds(self):
 
@@ -1263,6 +1295,7 @@ class TestBatchCheckout(_BaseTest):
 
     def test_context_mgr_success(self):
         import datetime
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import TransactionOptions
         from google.cloud._helpers import UTC
@@ -1290,11 +1323,60 @@ class TestBatchCheckout(_BaseTest):
 
         expected_txn_options = TransactionOptions(read_write={})
 
-        api.commit.assert_called_once_with(
+        request = CommitRequest(
             session=self.SESSION_NAME,
             mutations=[],
             single_use_transaction=expected_txn_options,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
+    def test_context_mgr_w_commit_stats(self):
+        import datetime
+        from google.cloud.spanner_v1 import CommitRequest
+        from google.cloud.spanner_v1 import CommitResponse
+        from google.cloud.spanner_v1 import TransactionOptions
+        from google.cloud._helpers import UTC
+        from google.cloud._helpers import _datetime_to_pb_timestamp
+        from google.cloud.spanner_v1.batch import Batch
+
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now_pb = _datetime_to_pb_timestamp(now)
+        commit_stats = CommitResponse.CommitStats(mutation_count=4)
+        response = CommitResponse(commit_timestamp=now_pb, commit_stats=commit_stats)
+        database = _Database(self.DATABASE_NAME)
+        database.log_commit_stats = True
+        api = database.spanner_api = self._make_spanner_client()
+        api.commit.return_value = response
+        pool = database._pool = _Pool()
+        session = _Session(database)
+        pool.put(session)
+        checkout = self._make_one(database)
+
+        with checkout as batch:
+            self.assertIsNone(pool._session)
+            self.assertIsInstance(batch, Batch)
+            self.assertIs(batch._session, session)
+
+        self.assertIs(pool._session, session)
+        self.assertEqual(batch.committed, now)
+
+        expected_txn_options = TransactionOptions(read_write={})
+
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=[],
+            single_use_transaction=expected_txn_options,
+            return_commit_stats=True
+
+        )
+        api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+
+        database.logger.info.assert_called_once_with(
+            "Transaction mutation count: 4"
         )
 
     def test_context_mgr_failure(self):
@@ -1883,10 +1965,14 @@ class _Backup(object):
 
 
 class _Database(object):
+    log_commit_stats = False
+
     def __init__(self, name, instance=None):
         self.name = name
         self.database_id = name.rsplit("/", 1)[1]
         self._instance = instance
+        from logging import Logger
+        self.logger = mock.create_autospec(Logger, instance=True)
 
 
 class _Pool(object):

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1374,7 +1374,7 @@ class TestBatchCheckout(_BaseTest):
             request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
-        database.logger.info.assert_called_once_with("Transaction mutation count: 4")
+        database.logger.info.assert_called_once_with(commit_stats)
 
     def test_context_mgr_failure(self):
         from google.cloud.spanner_v1.batch import Batch

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -484,10 +484,12 @@ class TestInstance(unittest.TestCase):
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
         self.assertIsInstance(database._pool, BurstyPool)
+        self.assertIsNone(database._logger)
         pool = database._pool
         self.assertIs(pool._database, database)
 
     def test_database_factory_explicit(self):
+        from logging import Logger
         from google.cloud.spanner_v1.database import Database
         from tests._fixtures import DDL_STATEMENTS
 
@@ -495,9 +497,10 @@ class TestInstance(unittest.TestCase):
         instance = self._make_one(self.INSTANCE_ID, client, self.CONFIG_NAME)
         DATABASE_ID = "database-id"
         pool = _Pool()
+        logger = mock.create_autospec(Logger, instance=True)
 
         database = instance.database(
-            DATABASE_ID, ddl_statements=DDL_STATEMENTS, pool=pool
+            DATABASE_ID, ddl_statements=DDL_STATEMENTS, pool=pool, logger=logger
         )
 
         self.assertIsInstance(database, Database)
@@ -505,6 +508,7 @@ class TestInstance(unittest.TestCase):
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), DDL_STATEMENTS)
         self.assertIs(database._pool, pool)
+        self.assertIs(database._logger, logger)
         self.assertIs(pool._bound, database)
 
     def test_list_databases(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1378,7 +1378,9 @@ class TestSession(OpenTelemetryBase):
         gax_api.commit.assert_called_once_with(
             request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
-        database.logger.info.assert_called_once_with(commit_stats)
+        database.logger.info.assert_called_once_with(
+            "CommitStats: mutation_count: 4\n", extra={"commit_stats": commit_stats}
+        )
 
     def test_delay_helper_w_no_delay(self):
         from google.cloud.spanner_v1.session import _delay_until_retry

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1336,7 +1336,7 @@ class TestSession(OpenTelemetryBase):
         now = datetime.datetime.utcnow().replace(tzinfo=UTC)
         now_pb = _datetime_to_pb_timestamp(now)
         commit_stats = CommitResponse.CommitStats(mutation_count=4)
-        response = CommitResponse(commit_timestamp=now_pb)
+        response = CommitResponse(commit_timestamp=now_pb, commit_stats=commit_stats)
         gax_api = self._make_spanner_api()
         gax_api.begin_transaction.return_value = transaction_pb
         gax_api.commit.return_value = response

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1313,7 +1313,7 @@ class TestSession(OpenTelemetryBase):
             * 3,
         )
 
-    def test_run_in_transaction_w_commit_stats(self):
+    def test_run_in_transaction_w_commit_stats_success(self):
         import datetime
         from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
@@ -1381,6 +1381,66 @@ class TestSession(OpenTelemetryBase):
         database.logger.info.assert_called_once_with(
             "CommitStats: mutation_count: 4\n", extra={"commit_stats": commit_stats}
         )
+
+    def test_run_in_transaction_w_commit_stats_error(self):
+        from google.api_core.exceptions import Unknown
+        from google.cloud.spanner_v1 import CommitRequest
+        from google.cloud.spanner_v1 import (
+            Transaction as TransactionPB,
+            TransactionOptions,
+        )
+        from google.cloud.spanner_v1.transaction import Transaction
+
+        TABLE_NAME = "citizens"
+        COLUMNS = ["email", "first_name", "last_name", "age"]
+        VALUES = [
+            ["phred@exammple.com", "Phred", "Phlyntstone", 32],
+            ["bharney@example.com", "Bharney", "Rhubble", 31],
+        ]
+        TRANSACTION_ID = b"FACEDACE"
+        transaction_pb = TransactionPB(id=TRANSACTION_ID)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.side_effect = Unknown("testing")
+        database = self._make_database()
+        database.log_commit_stats = True
+        database.spanner_api = gax_api
+        session = self._make_one(database)
+        session._session_id = self.SESSION_ID
+
+        called_with = []
+
+        def unit_of_work(txn, *args, **kw):
+            called_with.append((txn, args, kw))
+            txn.insert(TABLE_NAME, COLUMNS, VALUES)
+            return 42
+
+        with self.assertRaises(Unknown):
+            session.run_in_transaction(unit_of_work, "abc", some_arg="def")
+
+        self.assertIsNone(session._transaction)
+        self.assertEqual(len(called_with), 1)
+        txn, args, kw = called_with[0]
+        self.assertIsInstance(txn, Transaction)
+        self.assertEqual(args, ("abc",))
+        self.assertEqual(kw, {"some_arg": "def"})
+
+        expected_options = TransactionOptions(read_write=TransactionOptions.ReadWrite())
+        gax_api.begin_transaction.assert_called_once_with(
+            session=self.SESSION_NAME,
+            options=expected_options,
+            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            return_commit_stats=True,
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        database.logger.info.assert_not_called()
 
     def test_delay_helper_w_no_delay(self):
         from google.cloud.spanner_v1.session import _delay_until_retry

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -65,6 +65,7 @@ class TestSession(OpenTelemetryBase):
 
         database = mock.create_autospec(Database, instance=True)
         database.name = name
+        database.log_commit_stats = False
         return database
 
     @staticmethod
@@ -769,6 +770,7 @@ class TestSession(OpenTelemetryBase):
 
     def test_run_in_transaction_w_args_w_kwargs_wo_abort(self):
         import datetime
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import (
             Transaction as TransactionPB,
@@ -820,15 +822,18 @@ class TestSession(OpenTelemetryBase):
             options=expected_options,
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
-        gax_api.commit.assert_called_once_with(
+        request = CommitRequest(
             session=self.SESSION_NAME,
             mutations=txn._mutations,
             transaction_id=TRANSACTION_ID,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
     def test_run_in_transaction_w_commit_error(self):
         from google.api_core.exceptions import Unknown
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1.transaction import Transaction
 
         TABLE_NAME = "citizens"
@@ -867,16 +872,19 @@ class TestSession(OpenTelemetryBase):
         self.assertEqual(kw, {})
 
         gax_api.begin_transaction.assert_not_called()
-        gax_api.commit.assert_called_once_with(
+        request = CommitRequest(
             session=self.SESSION_NAME,
             mutations=txn._mutations,
             transaction_id=TRANSACTION_ID,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
     def test_run_in_transaction_w_abort_no_retry_metadata(self):
         import datetime
         from google.api_core.exceptions import Aborted
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import (
             Transaction as TransactionPB,
@@ -934,13 +942,16 @@ class TestSession(OpenTelemetryBase):
             ]
             * 2,
         )
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=txn._mutations,
+            transaction_id=TRANSACTION_ID,
+        )
         self.assertEqual(
             gax_api.commit.call_args_list,
             [
                 mock.call(
-                    session=self.SESSION_NAME,
-                    mutations=txn._mutations,
-                    transaction_id=TRANSACTION_ID,
+                    request=request,
                     metadata=[("google-cloud-resource-prefix", database.name)],
                 )
             ]
@@ -952,6 +963,7 @@ class TestSession(OpenTelemetryBase):
         from google.api_core.exceptions import Aborted
         from google.protobuf.duration_pb2 import Duration
         from google.rpc.error_details_pb2 import RetryInfo
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import (
             Transaction as TransactionPB,
@@ -1022,13 +1034,16 @@ class TestSession(OpenTelemetryBase):
             ]
             * 2,
         )
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=txn._mutations,
+            transaction_id=TRANSACTION_ID,
+        )
         self.assertEqual(
             gax_api.commit.call_args_list,
             [
                 mock.call(
-                    session=self.SESSION_NAME,
-                    mutations=txn._mutations,
-                    transaction_id=TRANSACTION_ID,
+                    request=request,
                     metadata=[("google-cloud-resource-prefix", database.name)],
                 )
             ]
@@ -1040,6 +1055,7 @@ class TestSession(OpenTelemetryBase):
         from google.api_core.exceptions import Aborted
         from google.protobuf.duration_pb2 import Duration
         from google.rpc.error_details_pb2 import RetryInfo
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import (
             Transaction as TransactionPB,
@@ -1110,11 +1126,13 @@ class TestSession(OpenTelemetryBase):
             ]
             * 2,
         )
-        gax_api.commit.assert_called_once_with(
+        request = CommitRequest(
             session=self.SESSION_NAME,
             mutations=txn._mutations,
             transaction_id=TRANSACTION_ID,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
     def test_run_in_transaction_w_abort_w_retry_metadata_deadline(self):
@@ -1122,6 +1140,7 @@ class TestSession(OpenTelemetryBase):
         from google.api_core.exceptions import Aborted
         from google.protobuf.duration_pb2 import Duration
         from google.rpc.error_details_pb2 import RetryInfo
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import (
             Transaction as TransactionPB,
@@ -1197,15 +1216,18 @@ class TestSession(OpenTelemetryBase):
             options=expected_options,
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
-        gax_api.commit.assert_called_once_with(
+        request = CommitRequest(
             session=self.SESSION_NAME,
             mutations=txn._mutations,
             transaction_id=TRANSACTION_ID,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
     def test_run_in_transaction_w_timeout(self):
         from google.api_core.exceptions import Aborted
+        from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import (
             Transaction as TransactionPB,
             TransactionOptions,
@@ -1275,18 +1297,88 @@ class TestSession(OpenTelemetryBase):
             ]
             * 3,
         )
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=txn._mutations,
+            transaction_id=TRANSACTION_ID,
+        )
         self.assertEqual(
             gax_api.commit.call_args_list,
             [
                 mock.call(
-                    session=self.SESSION_NAME,
-                    mutations=txn._mutations,
-                    transaction_id=TRANSACTION_ID,
+                    request=request,
                     metadata=[("google-cloud-resource-prefix", database.name)],
                 )
             ]
             * 3,
         )
+
+    def test_run_in_transaction_w_commit_stats(self):
+        import datetime
+        from google.cloud.spanner_v1 import CommitRequest
+        from google.cloud.spanner_v1 import CommitResponse
+        from google.cloud.spanner_v1 import (
+            Transaction as TransactionPB,
+            TransactionOptions,
+        )
+        from google.cloud._helpers import UTC
+        from google.cloud._helpers import _datetime_to_pb_timestamp
+        from google.cloud.spanner_v1.transaction import Transaction
+
+        TABLE_NAME = "citizens"
+        COLUMNS = ["email", "first_name", "last_name", "age"]
+        VALUES = [
+            ["phred@exammple.com", "Phred", "Phlyntstone", 32],
+            ["bharney@example.com", "Bharney", "Rhubble", 31],
+        ]
+        TRANSACTION_ID = b"FACEDACE"
+        transaction_pb = TransactionPB(id=TRANSACTION_ID)
+        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now_pb = _datetime_to_pb_timestamp(now)
+        commit_stats = CommitResponse.CommitStats(mutation_count=4)
+        response = CommitResponse(commit_timestamp=now_pb)
+        gax_api = self._make_spanner_api()
+        gax_api.begin_transaction.return_value = transaction_pb
+        gax_api.commit.return_value = response
+        database = self._make_database()
+        database.log_commit_stats = True
+        database.spanner_api = gax_api
+        session = self._make_one(database)
+        session._session_id = self.SESSION_ID
+
+        called_with = []
+
+        def unit_of_work(txn, *args, **kw):
+            called_with.append((txn, args, kw))
+            txn.insert(TABLE_NAME, COLUMNS, VALUES)
+            return 42
+
+        return_value = session.run_in_transaction(unit_of_work, "abc", some_arg="def")
+
+        self.assertIsNone(session._transaction)
+        self.assertEqual(len(called_with), 1)
+        txn, args, kw = called_with[0]
+        self.assertIsInstance(txn, Transaction)
+        self.assertEqual(return_value, 42)
+        self.assertEqual(args, ("abc",))
+        self.assertEqual(kw, {"some_arg": "def"})
+
+        expected_options = TransactionOptions(read_write=TransactionOptions.ReadWrite())
+        gax_api.begin_transaction.assert_called_once_with(
+            session=self.SESSION_NAME,
+            options=expected_options,
+            metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        request = CommitRequest(
+            session=self.SESSION_NAME,
+            mutations=txn._mutations,
+            transaction_id=TRANSACTION_ID,
+            return_commit_stats=True,
+        )
+        gax_api.commit.assert_called_once_with(
+            request=request, metadata=[("google-cloud-resource-prefix", database.name)],
+        )
+        database.logger.info.assert_called_once_with("Transaction mutation count: 4")
 
     def test_delay_helper_w_no_delay(self):
         from google.cloud.spanner_v1.session import _delay_until_retry

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1378,7 +1378,7 @@ class TestSession(OpenTelemetryBase):
         gax_api.commit.assert_called_once_with(
             request=request, metadata=[("google-cloud-resource-prefix", database.name)],
         )
-        database.logger.info.assert_called_once_with("Transaction mutation count: 4")
+        database.logger.info.assert_called_once_with(commit_stats)
 
     def test_delay_helper_w_no_delay(self):
         from google.cloud.spanner_v1.session import _delay_until_retry


### PR DESCRIPTION
This PR adds support for logging commit statistics when requested by the user via `log_commit_stats`.

Commit statistics will be logged at the INFO log level.

The default logger will log commit stats using `sys.stderr`, however the user can pass their own logger when constructing the database if needed.

A sample of how to use the feature is given below:
```
database = instance.database(database_id, logger=custom_logger)
database.log_commit_stats = True
```

Once `log_commit_stats` is set, commit stats will be logged via the database logger any time commit is called by the library.