### PR TITLE
test(dbapi): add retry to autocommit sample to reduce flakiness

### DIFF
--- a/samples/samples/autocommit_test.py
+++ b/samples/samples/autocommit_test.py
@@ -6,10 +6,12 @@
 
 import uuid
 
+from google.api_core.exceptions import Aborted
 from google.cloud import spanner
 from google.cloud.spanner_dbapi import connect
 import mock
 import pytest
+from test_utils.retry import RetryErrors
 
 import autocommit
 
@@ -49,6 +51,7 @@ def database(spanner_instance):
     db.drop()
 
 
+@RetryErrors(exception=Aborted, max_tries=2)
 def test_enable_autocommit_mode(capsys, database):
     connection = connect(INSTANCE_ID, DATABASE_ID)
     cursor = connection.cursor()


### PR DESCRIPTION
Fixes #211 

The autocommit sample for `dbapi` fails when the transaction is aborted as the implementation cannot contain retry logic. This means the test must retry on `Aborted` errors instead.