### PR TITLE
test: make system test timeout configurable and default to 60 seconds

### DIFF
--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -55,7 +55,7 @@ from tests._helpers import OpenTelemetryBase, HAS_OPENTELEMETRY_INSTALLED
 CREATE_INSTANCE = os.getenv("GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE") is not None
 USE_EMULATOR = os.getenv("SPANNER_EMULATOR_HOST") is not None
 SKIP_BACKUP_TESTS = os.getenv("SKIP_BACKUP_TESTS") is not None
-SPANNER_RPC_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_RPC_TIMEOUT_IN_SECONDS", 30))
+SPANNER_OPERATION_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_OPERATION_TIMEOUT_IN_SECONDS", 60))
 
 if CREATE_INSTANCE:
     INSTANCE_ID = "google-cloud" + unique_resource_id("-")
@@ -150,7 +150,7 @@ def setUpModule():
             INSTANCE_ID, config_name, labels=labels
         )
         created_op = Config.INSTANCE.create()
-        created_op.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # block until completion
+        created_op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # block until completion
 
     else:
         Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID)
@@ -209,7 +209,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         self.instances_to_delete.append(instance)
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
         # Create a new instance instance and make sure it is the same.
         instance_alt = Config.CLIENT.instance(
@@ -228,7 +228,7 @@ class TestInstanceAdminAPI(unittest.TestCase):
         operation = Config.INSTANCE.update()
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
         # Create a new instance instance and reload it.
         instance_alt = Config.CLIENT.instance(INSTANCE_ID, None)
@@ -309,7 +309,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
             cls.DATABASE_NAME, ddl_statements=ddl_statements, pool=pool
         )
         operation = cls._db.create()
-        operation.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
     @classmethod
     def tearDownClass(cls):
@@ -338,7 +338,7 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         self.to_delete.append(temp_db)
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
         database_ids = [database.name for database in Config.INSTANCE.list_databases()]
         self.assertIn(temp_db.name, database_ids)
@@ -484,8 +484,8 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         cls._dbs = [db1, db2]
         op1 = db1.create()
         op2 = db2.create()
-        op1.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
-        op2.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        op1.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        op2.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
         current_config = Config.INSTANCE.configuration_name
         same_config_instance_id = "same-config" + unique_resource_id("-")
@@ -495,7 +495,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
             same_config_instance_id, current_config, labels=labels
         )
         op = cls._same_config_instance.create()
-        op.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)
+        op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)
         cls._instances = [cls._same_config_instance]
 
         retry = RetryErrors(exceptions.ServiceUnavailable)
@@ -514,7 +514,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
                 diff_config_instance_id, diff_configs[0], labels=labels
             )
             op = cls._diff_config_instance.create()
-            op.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)
+            op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)
             cls._instances.append(cls._diff_config_instance)
 
     @classmethod
@@ -676,7 +676,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
             return
         new_db = self._diff_config_instance.database("diff_config")
         op = new_db.create()
-        op.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)
+        op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)
         self.to_drop.append(new_db)
         with self.assertRaises(exceptions.InvalidArgument):
             new_db.restore(source=backup1)
@@ -867,7 +867,7 @@ class TestSessionAPI(OpenTelemetryBase, _TestData):
             cls.DATABASE_NAME, ddl_statements=ddl_statements, pool=pool
         )
         operation = cls._db.create()
-        operation.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
     @classmethod
     def tearDownClass(cls):
@@ -1789,7 +1789,7 @@ class TestSessionAPI(OpenTelemetryBase, _TestData):
         self.to_delete.append(_DatabaseDropper(temp_db))
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
         committed = self._set_up_table(row_count, database=temp_db)
 
         with temp_db.snapshot(read_timestamp=committed) as snapshot:

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -55,7 +55,9 @@ from tests._helpers import OpenTelemetryBase, HAS_OPENTELEMETRY_INSTALLED
 CREATE_INSTANCE = os.getenv("GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE") is not None
 USE_EMULATOR = os.getenv("SPANNER_EMULATOR_HOST") is not None
 SKIP_BACKUP_TESTS = os.getenv("SKIP_BACKUP_TESTS") is not None
-SPANNER_OPERATION_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_OPERATION_TIMEOUT_IN_SECONDS", 60))
+SPANNER_OPERATION_TIMEOUT_IN_SECONDS = int(
+    os.getenv("SPANNER_OPERATION_TIMEOUT_IN_SECONDS", 60)
+)
 
 if CREATE_INSTANCE:
     INSTANCE_ID = "google-cloud" + unique_resource_id("-")
@@ -150,7 +152,9 @@ def setUpModule():
             INSTANCE_ID, config_name, labels=labels
         )
         created_op = Config.INSTANCE.create()
-        created_op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # block until completion
+        created_op.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # block until completion
 
     else:
         Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID)
@@ -209,7 +213,9 @@ class TestInstanceAdminAPI(unittest.TestCase):
         self.instances_to_delete.append(instance)
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
 
         # Create a new instance instance and make sure it is the same.
         instance_alt = Config.CLIENT.instance(
@@ -228,7 +234,9 @@ class TestInstanceAdminAPI(unittest.TestCase):
         operation = Config.INSTANCE.update()
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
 
         # Create a new instance instance and reload it.
         instance_alt = Config.CLIENT.instance(INSTANCE_ID, None)
@@ -309,7 +317,9 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
             cls.DATABASE_NAME, ddl_statements=ddl_statements, pool=pool
         )
         operation = cls._db.create()
-        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
 
     @classmethod
     def tearDownClass(cls):
@@ -338,7 +348,9 @@ class TestDatabaseAPI(unittest.TestCase, _TestData):
         self.to_delete.append(temp_db)
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
 
         database_ids = [database.name for database in Config.INSTANCE.list_databases()]
         self.assertIn(temp_db.name, database_ids)
@@ -867,7 +879,9 @@ class TestSessionAPI(OpenTelemetryBase, _TestData):
             cls.DATABASE_NAME, ddl_statements=ddl_statements, pool=pool
         )
         operation = cls._db.create()
-        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
 
     @classmethod
     def tearDownClass(cls):
@@ -1789,7 +1803,9 @@ class TestSessionAPI(OpenTelemetryBase, _TestData):
         self.to_delete.append(_DatabaseDropper(temp_db))
 
         # We want to make sure the operation completes.
-        operation.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
         committed = self._set_up_table(row_count, database=temp_db)
 
         with temp_db.snapshot(read_timestamp=committed) as snapshot:

--- a/tests/system/test_system_dbapi.py
+++ b/tests/system/test_system_dbapi.py
@@ -39,7 +39,9 @@ from .test_system import (
 )
 
 
-SPANNER_OPERATION_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_OPERATION_TIMEOUT_IN_SECONDS", 60))
+SPANNER_OPERATION_TIMEOUT_IN_SECONDS = int(
+    os.getenv("SPANNER_OPERATION_TIMEOUT_IN_SECONDS", 60)
+)
 
 
 def setUpModule():
@@ -94,7 +96,9 @@ def setUpModule():
             INSTANCE_ID, config_name, labels=labels
         )
         created_op = Config.INSTANCE.create()
-        created_op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # block until completion
+        created_op.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # block until completion
 
     else:
         Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID)

--- a/tests/system/test_system_dbapi.py
+++ b/tests/system/test_system_dbapi.py
@@ -129,7 +129,9 @@ class TestTransactionsManagement(unittest.TestCase):
             ddl_statements=cls.DDL_STATEMENTS,
             pool=BurstyPool(labels={"testcase": "database_api"}),
         )
-        cls._db.create().result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
+        cls._db.create().result(
+            SPANNER_RPC_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/system/test_system_dbapi.py
+++ b/tests/system/test_system_dbapi.py
@@ -39,6 +39,9 @@ from .test_system import (
 )
 
 
+SPANNER_RPC_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_RPC_TIMEOUT_IN_SECONDS", 30))
+
+
 def setUpModule():
     if USE_EMULATOR:
         from google.auth.credentials import AnonymousCredentials
@@ -91,7 +94,7 @@ def setUpModule():
             INSTANCE_ID, config_name, labels=labels
         )
         created_op = Config.INSTANCE.create()
-        created_op.result(30)  # block until completion
+        created_op.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # block until completion
 
     else:
         Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID)
@@ -126,7 +129,7 @@ class TestTransactionsManagement(unittest.TestCase):
             ddl_statements=cls.DDL_STATEMENTS,
             pool=BurstyPool(labels={"testcase": "database_api"}),
         )
-        cls._db.create().result(30)  # raises on failure / timeout.
+        cls._db.create().result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # raises on failure / timeout.
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/system/test_system_dbapi.py
+++ b/tests/system/test_system_dbapi.py
@@ -39,7 +39,7 @@ from .test_system import (
 )
 
 
-SPANNER_RPC_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_RPC_TIMEOUT_IN_SECONDS", 30))
+SPANNER_OPERATION_TIMEOUT_IN_SECONDS = int(os.getenv("SPANNER_OPERATION_TIMEOUT_IN_SECONDS", 60))
 
 
 def setUpModule():
@@ -94,7 +94,7 @@ def setUpModule():
             INSTANCE_ID, config_name, labels=labels
         )
         created_op = Config.INSTANCE.create()
-        created_op.result(SPANNER_RPC_TIMEOUT_IN_SECONDS)  # block until completion
+        created_op.result(SPANNER_OPERATION_TIMEOUT_IN_SECONDS)  # block until completion
 
     else:
         Config.INSTANCE = Config.CLIENT.instance(INSTANCE_ID)
@@ -130,7 +130,7 @@ class TestTransactionsManagement(unittest.TestCase):
             pool=BurstyPool(labels={"testcase": "database_api"}),
         )
         cls._db.create().result(
-            SPANNER_RPC_TIMEOUT_IN_SECONDS
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
         )  # raises on failure / timeout.
 
     @classmethod


### PR DESCRIPTION
b/173067462

It seems 30 seconds are too short for mtls test (which uses the system test, and runs on an internal platform). This makes the mtls test very flaky. This PR introduces a `SPANNER_OPERATION_TIMEOUT_IN_SECONDS` env var to make the timeout configurable. 

The default value is now 60 seconds.
