### PR TITLE
test: fix credential scope assertions

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -88,7 +88,7 @@ class TestClient(unittest.TestCase):
 
         self.assertIs(client._credentials, expected_creds)
         if expected_scopes is not None:
-            creds.with_scopes.assert_called_once_with(expected_scopes)
+            creds.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
 
         self.assertEqual(client.project, self.PROJECT)
         self.assertIs(client._client_info, expected_client_info)
@@ -235,7 +235,7 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes)
+        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_instance_admin_api_emulator_env(self, mock_em):
@@ -333,7 +333,7 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes)
+        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_database_admin_api_emulator_env(self, mock_em):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -88,7 +88,9 @@ class TestClient(unittest.TestCase):
 
         self.assertIs(client._credentials, expected_creds)
         if expected_scopes is not None:
-            creds.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
+            creds.with_scopes.assert_called_once_with(
+                expected_scopes, default_scopes=None
+            )
 
         self.assertEqual(client.project, self.PROJECT)
         self.assertIs(client._client_info, expected_client_info)
@@ -235,7 +237,9 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
+        credentials.with_scopes.assert_called_once_with(
+            expected_scopes, default_scopes=None
+        )
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_instance_admin_api_emulator_env(self, mock_em):
@@ -333,7 +337,9 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
+        credentials.with_scopes.assert_called_once_with(
+            expected_scopes, default_scopes=None
+        )
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_database_admin_api_emulator_env(self, mock_em):


### PR DESCRIPTION
The assertions for credential scope in the `client` unit tests were broken by [a PR in the auth library](https://github.com/googleapis/google-auth-library-python/pull/665). This does raise the question of whether we should be asserting the scopes like this in this library.

This PR fixes the assertions. Removal of these assertions can be done in a separate PR if it is decided they don't belong in this library.