### PR TITLE
test: fix PITR restored database version time assertion

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,53 @@
+import base64
+import time
+from google.cloud import spanner
+from google.auth.credentials import AnonymousCredentials
+
+instance_id = 'test-instance'
+database_id = 'test-db'
+
+spanner_client = spanner.Client(
+    project='test-project',
+    client_options={"api_endpoint": 'localhost:9010'},
+    credentials=AnonymousCredentials()
+)
+
+instance = spanner_client.instance(instance_id)
+op = instance.create()
+op.result()
+
+database = instance.database(database_id, ddl_statements=[
+    "CREATE TABLE Test (id STRING(36) NOT NULL, megafield BYTES(MAX)) PRIMARY KEY (id)"
+])
+op = database.create()
+op.result()
+
+# This must be large enough that the SDK will split the megafield payload across two query chunks
+# and try to recombine them, causing the error:
+data = base64.standard_b64encode(("a" * 1000000).encode("utf8"))
+
+try:
+    with database.batch() as batch:
+        batch.insert(
+            table="Test",
+            columns=("id", "megafield"),
+            values=[
+                (1, data),
+            ],
+        )
+
+    with database.snapshot() as snapshot:
+        toc = time.time()
+        results = snapshot.execute_sql(
+            "SELECT * FROM Test"
+        )
+        tic = time.time()
+
+        print("TIME: ", tic - toc)
+
+        for row in results:
+            print("Id: ", row[0])
+            print("Megafield: ", row[1][:100])
+finally:
+    database.drop()
+    instance.delete()

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -729,7 +729,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         )
 
         metadata = operation.metadata
-        self.assertEqual(self.database_version_time, metadata.backup_info.create_time)
+        self.assertEqual(self.database_version_time, metadata.backup_info.version_time)
 
         database.drop()
         backup.delete()

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -725,7 +725,8 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         operation = database.restore(source=backup)
         restored_db = operation.result()
         self.assertEqual(
-            self.database_version_time, restored_db.restore_info.backup_info.version_time
+            self.database_version_time,
+            restored_db.restore_info.backup_info.version_time,
         )
 
         metadata = operation.metadata

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -725,7 +725,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         operation = database.restore(source=backup)
         restored_db = operation.result()
         self.assertEqual(
-            self.database_version_time, restored_db.restore_info.backup_info.create_time
+            self.database_version_time, restored_db.restore_info.backup_info.version_time
         )
 
         metadata = operation.metadata


### PR DESCRIPTION
This PR fixes the assertion to use `metadata.backup_info.version_time` instead of `metadata.backup_info.create_time`. It looks it was passing before the backend correctly supported it and I forgot to re-run the tests before merging #148 (whoops!) and so it is currently failing and preventing #205 from being merged:
https://source.cloud.google.com/results/invocations/8f0f5dab-1b35-4ce3-bb72-0ce9e79ab89d/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-spanner%2Fpresubmit%2Fpresubmit/log
