### PR TITLE
perf: improve streaming performance

### DIFF
--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -146,13 +146,6 @@ class Test_make_value_pb(unittest.TestCase):
         self.assertIsInstance(value_pb, Value)
         self.assertEqual(value_pb.number_value, 3.14159)
 
-    def test_w_float_str(self):
-        from google.protobuf.struct_pb2 import Value
-
-        value_pb = self._callFUT(3.14159)
-        self.assertIsInstance(value_pb, Value)
-        self.assertEqual(value_pb.number_value, 3.14159)
-
     def test_w_float_nan(self):
         from google.protobuf.struct_pb2 import Value
 
@@ -307,174 +300,6 @@ class Test_make_list_value_pbs(unittest.TestCase):
             self.assertEqual(len(found.values), 2)
             self.assertEqual(found.values[0].string_value, str(expected[0]))
             self.assertEqual(found.values[1].string_value, expected[1])
-
-
-class Test_parse_value(unittest.TestCase):
-    def _callFUT(self, *args, **kw):
-        from google.cloud.spanner_v1._helpers import _parse_value
-
-        return _parse_value(*args, **kw)
-
-    def test_w_null(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.STRING)
-        value = expected_value = None
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_string(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.STRING)
-        value = expected_value = u"Value"
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_bytes(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.BYTES)
-        value = "Value"
-        expected_value = b"Value"
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_bool(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.BOOL)
-        value = expected_value = True
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_int(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.INT64)
-        value = "12345"
-        expected_value = 12345
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_float(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.FLOAT64)
-        value = "3.14159"
-        expected_value = 3.14159
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_date(self):
-        import datetime
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        value = "2020-09-22"
-        expected_value = datetime.date(2020, 9, 22)
-        field_type = Type(code=TypeCode.DATE)
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_timestamp_wo_nanos(self):
-        import pytz
-        from google.api_core import datetime_helpers
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.TIMESTAMP)
-        value = "2016-12-20T21:13:47.123456Z"
-        expected_value = datetime_helpers.DatetimeWithNanoseconds(
-            2016, 12, 20, 21, 13, 47, microsecond=123456, tzinfo=pytz.UTC
-        )
-
-        parsed = self._callFUT(value, field_type)
-        self.assertIsInstance(parsed, datetime_helpers.DatetimeWithNanoseconds)
-        self.assertEqual(parsed, expected_value)
-
-    def test_w_timestamp_w_nanos(self):
-        import pytz
-        from google.api_core import datetime_helpers
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.TIMESTAMP)
-        value = "2016-12-20T21:13:47.123456789Z"
-        expected_value = datetime_helpers.DatetimeWithNanoseconds(
-            2016, 12, 20, 21, 13, 47, nanosecond=123456789, tzinfo=pytz.UTC
-        )
-
-        parsed = self._callFUT(value, field_type)
-        self.assertIsInstance(parsed, datetime_helpers.DatetimeWithNanoseconds)
-        self.assertEqual(parsed, expected_value)
-
-    def test_w_array_empty(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(
-            code=TypeCode.ARRAY, array_element_type=Type(code=TypeCode.INT64)
-        )
-        value = []
-
-        self.assertEqual(self._callFUT(value, field_type), [])
-
-    def test_w_array_non_empty(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(
-            code=TypeCode.ARRAY, array_element_type=Type(code=TypeCode.INT64)
-        )
-        values = ["32", "19", "5"]
-        expected_values = [32, 19, 5]
-
-        self.assertEqual(self._callFUT(values, field_type), expected_values)
-
-    def test_w_struct(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import StructType
-        from google.cloud.spanner_v1 import TypeCode
-
-        struct_type_pb = StructType(
-            fields=[
-                StructType.Field(name="name", type_=Type(code=TypeCode.STRING)),
-                StructType.Field(name="age", type_=Type(code=TypeCode.INT64)),
-            ]
-        )
-        field_type = Type(code=TypeCode.STRUCT, struct_type=struct_type_pb)
-        values = [u"phred", "32"]
-        expected_values = [u"phred", 32]
-
-        self.assertEqual(self._callFUT(values, field_type), expected_values)
-
-    def test_w_numeric(self):
-        import decimal
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.NUMERIC)
-        expected_value = decimal.Decimal("99999999999999999999999999999.999999999")
-        value = "99999999999999999999999999999.999999999"
-
-        self.assertEqual(self._callFUT(value, field_type), expected_value)
-
-    def test_w_unknown_type(self):
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.TYPE_CODE_UNSPECIFIED)
-        value_pb = object()
-
-        with self.assertRaises(ValueError):
-            self._callFUT(value_pb, field_type)
 
 
 class Test_parse_value_pb(unittest.TestCase):
@@ -672,17 +497,6 @@ class Test_parse_value_pb(unittest.TestCase):
 
         field_type = Type(code=TypeCode.TYPE_CODE_UNSPECIFIED)
         value_pb = Value(string_value="Borked")
-
-        with self.assertRaises(ValueError):
-            self._callFUT(value_pb, field_type)
-
-    def test_w_empty_value(self):
-        from google.protobuf.struct_pb2 import Value
-        from google.cloud.spanner_v1 import Type
-        from google.cloud.spanner_v1 import TypeCode
-
-        field_type = Type(code=TypeCode.STRING)
-        value_pb = Value()
 
         with self.assertRaises(ValueError):
             self._callFUT(value_pb, field_type)

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -393,6 +393,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
         from google.cloud.spanner_v1._helpers import _make_value_pb
 
         VALUES = [[u"bharney", 31], [u"phred", 32]]
+        VALUE_PBS = [[_make_value_pb(item) for item in row] for row in VALUES]
         struct_type_pb = StructType(
             fields=[
                 StructType.Field(name="name", type_=Type(code=TypeCode.STRING)),
@@ -408,7 +409,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
             PartialResultSet(stats=stats_pb),
         ]
         for i in range(len(result_sets)):
-            result_sets[i].values.extend(VALUES[i])
+            result_sets[i].values.extend(VALUE_PBS[i])
         KEYS = [["bharney@example.com"], ["phred@example.com"]]
         keyset = KeySet(keys=KEYS)
         INDEX = "email-address-index"
@@ -561,6 +562,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
         )
 
         VALUES = [[u"bharney", u"rhubbyl", 31], [u"phred", u"phlyntstone", 32]]
+        VALUE_PBS = [[_make_value_pb(item) for item in row] for row in VALUES]
         MODE = 2  # PROFILE
         struct_type_pb = StructType(
             fields=[
@@ -578,7 +580,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
             PartialResultSet(stats=stats_pb),
         ]
         for i in range(len(result_sets)):
-            result_sets[i].values.extend(VALUES[i])
+            result_sets[i].values.extend(VALUE_PBS[i])
         iterator = _MockIterator(*result_sets)
         database = _Database()
         api = database.spanner_api = self._make_spanner_api()

--- a/tests/unit/test_streamed.py
+++ b/tests/unit/test_streamed.py
@@ -90,6 +90,16 @@ class TestStreamedResultSet(unittest.TestCase):
         return _make_value_pb(value)
 
     @staticmethod
+    def _make_list_value(values=(), value_pbs=None):
+        from google.protobuf.struct_pb2 import ListValue
+        from google.protobuf.struct_pb2 import Value
+        from google.cloud.spanner_v1._helpers import _make_list_value_pb
+
+        if value_pbs is not None:
+            return Value(list_value=ListValue(values=value_pbs))
+        return Value(list_value=_make_list_value_pb(values))
+
+    @staticmethod
     def _make_result_set_metadata(fields=(), transaction_id=None):
         from google.cloud.spanner_v1 import ResultSetMetadata
         from google.cloud.spanner_v1 import StructType
@@ -161,11 +171,11 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_scalar_field("age", TypeCode.INT64)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = 42
-        chunk = 13
+        streamed._pending_chunk = self._make_value(42)
+        chunk = self._make_value(13)
 
         merged = streamed._merge_chunk(chunk)
-        self.assertEqual(merged, 4213)
+        self.assertEqual(merged.string_value, "4213")
         self.assertIsNone(streamed._pending_chunk)
 
     def test__merge_chunk_float64_nan_string(self):
@@ -176,11 +186,11 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_scalar_field("weight", TypeCode.FLOAT64)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = u"Na"
-        chunk = u"N"
+        streamed._pending_chunk = self._make_value(u"Na")
+        chunk = self._make_value(u"N")
 
         merged = streamed._merge_chunk(chunk)
-        self.assertTrue(isnan(merged))
+        self.assertEqual(merged.string_value, u"NaN")
 
     def test__merge_chunk_float64_w_empty(self):
         from google.cloud.spanner_v1 import TypeCode
@@ -189,11 +199,11 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_scalar_field("weight", TypeCode.FLOAT64)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = 3.14159
-        chunk = ""
+        streamed._pending_chunk = self._make_value(3.14159)
+        chunk = self._make_value("")
 
         merged = streamed._merge_chunk(chunk)
-        self.assertEqual(merged, 3.14159)
+        self.assertEqual(merged.number_value, 3.14159)
 
     def test__merge_chunk_float64_w_float64(self):
         from google.cloud.spanner_v1.streamed import Unmergeable
@@ -203,8 +213,8 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_scalar_field("weight", TypeCode.FLOAT64)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = 3.14159
-        chunk = 2.71828
+        streamed._pending_chunk = self._make_value(3.14159)
+        chunk = self._make_value(2.71828)
 
         with self.assertRaises(Unmergeable):
             streamed._merge_chunk(chunk)
@@ -216,12 +226,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_scalar_field("name", TypeCode.STRING)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = u"phred"
-        chunk = u"wylma"
+        streamed._pending_chunk = self._make_value(u"phred")
+        chunk = self._make_value(u"wylma")
 
         merged = streamed._merge_chunk(chunk)
 
-        self.assertEqual(merged, u"phredwylma")
+        self.assertEqual(merged.string_value, u"phredwylma")
         self.assertIsNone(streamed._pending_chunk)
 
     def test__merge_chunk_string_w_bytes(self):
@@ -231,11 +241,11 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_scalar_field("image", TypeCode.BYTES)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = (
+        streamed._pending_chunk = self._make_value(
             u"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA"
             u"6fptVAAAACXBIWXMAAAsTAAALEwEAmpwYAAAA\n"
         )
-        chunk = (
+        chunk = self._make_value(
             u"B3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0FNUExF"
             u"MG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n"
         )
@@ -243,10 +253,10 @@ class TestStreamedResultSet(unittest.TestCase):
         merged = streamed._merge_chunk(chunk)
 
         self.assertEqual(
-            merged,
-            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACXBIWXMAAAsTAAAL"
-            b"EwEAmpwYAAAA\nB3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0"
-            b"FNUExFMG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n",
+            merged.string_value,
+            u"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACXBIWXMAAAsTAAAL"
+            u"EwEAmpwYAAAA\nB3RJTUUH4QQGFwsBTL3HMwAAABJpVFh0Q29tbWVudAAAAAAAU0"
+            u"FNUExFMG3E+AAAAApJREFUCNdj\nYAAAAAIAAeIhvDMAAAAASUVORK5CYII=\n",
         )
         self.assertIsNone(streamed._pending_chunk)
 
@@ -257,12 +267,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_array_field("name", element_type_code=TypeCode.BOOL)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [True, True]
-        chunk = [False, False, False]
+        streamed._pending_chunk = self._make_list_value([True, True])
+        chunk = self._make_list_value([False, False, False])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [True, True, False, False, False]
+        expected = self._make_list_value([True, True, False, False, False])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -273,12 +283,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_array_field("name", element_type_code=TypeCode.INT64)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [0, 1, 2]
-        chunk = [3, 4, 5]
+        streamed._pending_chunk = self._make_list_value([0, 1, 2])
+        chunk = self._make_list_value([3, 4, 5])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [0, 1, 23, 4, 5]
+        expected = self._make_list_value([0, 1, 23, 4, 5])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -294,12 +304,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_array_field("name", element_type_code=TypeCode.FLOAT64)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [PI, SQRT_2]
-        chunk = ["", EULER, LOG_10]
+        streamed._pending_chunk = self._make_list_value([PI, SQRT_2])
+        chunk = self._make_list_value(["", EULER, LOG_10])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [PI, SQRT_2, EULER, LOG_10]
+        expected = self._make_list_value([PI, SQRT_2, EULER, LOG_10])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -310,12 +320,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_array_field("name", element_type_code=TypeCode.STRING)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [u"A", u"B", u"C"]
-        chunk = []
+        streamed._pending_chunk = self._make_list_value([u"A", u"B", u"C"])
+        chunk = self._make_list_value([])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [u"A", u"B", u"C"]
+        expected = self._make_list_value([u"A", u"B", u"C"])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -326,12 +336,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_array_field("name", element_type_code=TypeCode.STRING)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [u"A", u"B", u"C"]
-        chunk = [None, u"D", u"E"]
+        streamed._pending_chunk = self._make_list_value([u"A", u"B", u"C"])
+        chunk = self._make_list_value([None, u"D", u"E"])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [u"A", u"B", u"C", None, u"D", u"E"]
+        expected = self._make_list_value([u"A", u"B", u"C", None, u"D", u"E"])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -342,12 +352,12 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [self._make_array_field("name", element_type_code=TypeCode.STRING)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [u"A", u"B", u"C"]
-        chunk = [u"D", u"E"]
+        streamed._pending_chunk = self._make_list_value([u"A", u"B", u"C"])
+        chunk = self._make_list_value([u"D", u"E"])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [u"A", u"B", u"CD", u"E"]
+        expected = self._make_list_value([u"A", u"B", u"CD", u"E"])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -364,17 +374,22 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [StructType.Field(name="loloi", type_=array_type)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [[0, 1], [2]]
-        chunk = [[3], [4, 5]]
+        streamed._pending_chunk = self._make_list_value(
+            value_pbs=[self._make_list_value([0, 1]), self._make_list_value([2])]
+        )
+        chunk = self._make_list_value(
+            value_pbs=[self._make_list_value([3]), self._make_list_value([4, 5])]
+        )
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [
-            [0, 1],
-            [23],
-            [4, 5],
-        ]
-
+        expected = self._make_list_value(
+            value_pbs=[
+                self._make_list_value([0, 1]),
+                self._make_list_value([23]),
+                self._make_list_value([4, 5]),
+            ]
+        )
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -391,23 +406,28 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed = self._make_one(iterator)
         FIELDS = [StructType.Field(name="lolos", type_=array_type)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = [
-            [u"A", u"B"],
-            [u"C"],
-        ]
-        chunk = [
-            [u"D"],
-            [u"E", u"F"],
-        ]
+        streamed._pending_chunk = self._make_list_value(
+            value_pbs=[
+                self._make_list_value([u"A", u"B"]),
+                self._make_list_value([u"C"]),
+            ]
+        )
+        chunk = self._make_list_value(
+            value_pbs=[
+                self._make_list_value([u"D"]),
+                self._make_list_value([u"E", u"F"]),
+            ]
+        )
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [
-            [u"A", u"B"],
-            [u"CD"],
-            [u"E", u"F"],
-        ]
-
+        expected = self._make_list_value(
+            value_pbs=[
+                self._make_list_value([u"A", u"B"]),
+                self._make_list_value([u"CD"]),
+                self._make_list_value([u"E", u"F"]),
+            ]
+        )
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -421,15 +441,15 @@ class TestStreamedResultSet(unittest.TestCase):
         )
         FIELDS = [self._make_array_field("test", element_type=struct_type)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        partial = [u"Phred "]
-        streamed._pending_chunk = [partial]
-        rest = [u"Phlyntstone", 31]
-        chunk = [rest]
+        partial = self._make_list_value([u"Phred "])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value([u"Phlyntstone", 31])
+        chunk = self._make_list_value(value_pbs=[rest])
 
         merged = streamed._merge_chunk(chunk)
 
-        struct = [u"Phred Phlyntstone", 31]
-        expected = [struct]
+        struct = self._make_list_value([u"Phred Phlyntstone", 31])
+        expected = self._make_list_value(value_pbs=[struct])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -443,14 +463,14 @@ class TestStreamedResultSet(unittest.TestCase):
         )
         FIELDS = [self._make_array_field("test", element_type=struct_type)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        partial = [u"Phred "]
-        streamed._pending_chunk = [partial]
-        rest = []
-        chunk = [rest]
+        partial = self._make_list_value([u"Phred "])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value([])
+        chunk = self._make_list_value(value_pbs=[rest])
 
         merged = streamed._merge_chunk(chunk)
 
-        expected = [partial]
+        expected = self._make_list_value(value_pbs=[partial])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -468,15 +488,15 @@ class TestStreamedResultSet(unittest.TestCase):
         )
         FIELDS = [self._make_array_field("test", element_type=struct_type)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        partial = [u"Phred Phlyntstone", True]
-        streamed._pending_chunk = [partial]
-        rest = [True]
-        chunk = [rest]
+        partial = self._make_list_value([u"Phred Phlyntstone", True])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value([True])
+        chunk = self._make_list_value(value_pbs=[rest])
 
         merged = streamed._merge_chunk(chunk)
 
-        struct = [u"Phred Phlyntstone", True, True]
-        expected = [struct]
+        struct = self._make_list_value([u"Phred Phlyntstone", True, True])
+        expected = self._make_list_value(value_pbs=[struct])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -488,15 +508,15 @@ class TestStreamedResultSet(unittest.TestCase):
         )
         FIELDS = [self._make_array_field("test", element_type=struct_type)]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        partial = [u"Phred Phlyntstone", 1.65]
-        streamed._pending_chunk = [partial]
-        rest = ["brown"]
-        chunk = [rest]
+        partial = self._make_list_value([u"Phred Phlyntstone", 1.65])
+        streamed._pending_chunk = self._make_list_value(value_pbs=[partial])
+        rest = self._make_list_value(["brown"])
+        chunk = self._make_list_value(value_pbs=[rest])
 
         merged = streamed._merge_chunk(chunk)
 
-        struct = [u"Phred Phlyntstone", 1.65, "brown"]
-        expected = [struct]
+        struct = self._make_list_value([u"Phred Phlyntstone", 1.65, "brown"])
+        expected = self._make_list_value(value_pbs=[struct])
         self.assertEqual(merged, expected)
         self.assertIsNone(streamed._pending_chunk)
 
@@ -527,8 +547,8 @@ class TestStreamedResultSet(unittest.TestCase):
             self._make_scalar_field("married", TypeCode.BOOL),
         ]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        VALUES = [u"Phred Phlyntstone", "42"]
         BARE = [u"Phred Phlyntstone", 42]
+        VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
         self.assertEqual(list(streamed), [])
@@ -545,8 +565,8 @@ class TestStreamedResultSet(unittest.TestCase):
             self._make_scalar_field("married", TypeCode.BOOL),
         ]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        VALUES = [u"Phred Phlyntstone", "42", True]
         BARE = [u"Phred Phlyntstone", 42, True]
+        VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
         self.assertEqual(list(streamed), [BARE])
@@ -563,15 +583,6 @@ class TestStreamedResultSet(unittest.TestCase):
             self._make_scalar_field("married", TypeCode.BOOL),
         ]
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        VALUES = [
-            u"Phred Phlyntstone",
-            "42",
-            True,
-            u"Bharney Rhubble",
-            "39",
-            True,
-            u"Wylma Phlyntstone",
-        ]
         BARE = [
             u"Phred Phlyntstone",
             42,
@@ -581,6 +592,7 @@ class TestStreamedResultSet(unittest.TestCase):
             True,
             u"Wylma Phlyntstone",
         ]
+        VALUES = [self._make_value(bare) for bare in BARE]
         streamed._current_row = []
         streamed._merge_values(VALUES)
         self.assertEqual(list(streamed), [BARE[0:3], BARE[3:6]])
@@ -616,8 +628,8 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [u"Phred Phlyntstone"]
         streamed._current_row[:] = BEFORE
-        TO_MERGE = ["42"]
         MERGED = [42]
+        TO_MERGE = [self._make_value(item) for item in MERGED]
         streamed._merge_values(TO_MERGE)
         self.assertEqual(list(streamed), [])
         self.assertEqual(streamed._current_row, BEFORE + MERGED)
@@ -635,8 +647,8 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [u"Phred Phlyntstone"]
         streamed._current_row[:] = BEFORE
-        TO_MERGE = ["42", True]
         MERGED = [42, True]
+        TO_MERGE = [self._make_value(item) for item in MERGED]
         streamed._merge_values(TO_MERGE)
         self.assertEqual(list(streamed), [BEFORE + MERGED])
         self.assertEqual(streamed._current_row, [])
@@ -654,8 +666,8 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed._metadata = self._make_result_set_metadata(FIELDS)
         BEFORE = [self._make_value(u"Phred Phlyntstone")]
         streamed._current_row[:] = BEFORE
-        TO_MERGE = ["42", True, u"Bharney Rhubble", "39", True, u"Wylma Phlyntstone"]
         MERGED = [42, True, u"Bharney Rhubble", 39, True, u"Wylma Phlyntstone"]
+        TO_MERGE = [self._make_value(item) for item in MERGED]
         VALUES = BEFORE + MERGED
         streamed._merge_values(TO_MERGE)
         self.assertEqual(list(streamed), [VALUES[0:3], VALUES[3:6]])
@@ -720,7 +732,8 @@ class TestStreamedResultSet(unittest.TestCase):
         ]
         metadata = self._make_result_set_metadata(FIELDS, transaction_id=TXN_ID)
         BARE = [u"Phred Phlyntstone", 42]
-        result_set = self._make_partial_result_set(BARE, metadata=metadata)
+        VALUES = [self._make_value(bare) for bare in BARE]
+        result_set = self._make_partial_result_set(VALUES, metadata=metadata)
         iterator = _MockCancellableIterator(result_set)
         source = mock.Mock(_transaction_id=None, spec=["_transaction_id"])
         streamed = self._make_one(iterator, source=source)
@@ -768,7 +781,7 @@ class TestStreamedResultSet(unittest.TestCase):
         streamed._consume_next()
         self.assertEqual(list(streamed), [])
         self.assertEqual(streamed._current_row, [])
-        self.assertEqual(streamed._pending_chunk, VALUES[0].string_value)
+        self.assertEqual(streamed._pending_chunk, VALUES[0])
 
     def test_consume_next_w_pending_chunk(self):
         from google.cloud.spanner_v1 import TypeCode
@@ -792,7 +805,7 @@ class TestStreamedResultSet(unittest.TestCase):
         iterator = _MockCancellableIterator(result_set)
         streamed = self._make_one(iterator)
         streamed._metadata = self._make_result_set_metadata(FIELDS)
-        streamed._pending_chunk = u"Phred "
+        streamed._pending_chunk = self._make_value(u"Phred ")
         streamed._consume_next()
         self.assertEqual(
             list(streamed),

--- a/tests/unit/test_streamed.py
+++ b/tests/unit/test_streamed.py
@@ -180,7 +180,6 @@ class TestStreamedResultSet(unittest.TestCase):
 
     def test__merge_chunk_float64_nan_string(self):
         from google.cloud.spanner_v1 import TypeCode
-        from math import isnan
 
         iterator = _MockCancellableIterator()
         streamed = self._make_one(iterator)


### PR DESCRIPTION
This PR fixes performance issues that were introduced during the mirgration to v2 and optimizes several streaming methods. 

From v2 onwards, the library uses `proto-plus` to produce user friendly Python object to represent proto messages. Unfortunately, it significantly impacted the performance of streaming for cases with many columns as the library must unnecessarily parse the types many times. By reverting the streaming changes to use the raw protobuf messages, the streaming speed is greatly improved.

Fixes #207, fixes #234