### PR TITLE
samples: parameterises create backup version time

### DIFF
--- a/samples/samples/backup_sample.py
+++ b/samples/samples/backup_sample.py
@@ -26,17 +26,11 @@ from google.cloud import spanner
 
 
 # [START spanner_create_backup]
-def create_backup(instance_id, database_id, backup_id):
+def create_backup(instance_id, database_id, backup_id, version_time):
     """Creates a backup for a database."""
     spanner_client = spanner.Client()
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
-
-    # Sets the version time as the current server time
-    version_time = None
-    with database.snapshot() as snapshot:
-        results = snapshot.execute_sql("SELECT CURRENT_TIMESTAMP()")
-        version_time = list(results)[0][0]
 
     # Create a backup
     expire_time = datetime.utcnow() + timedelta(days=14)

--- a/samples/samples/backup_sample_test.py
+++ b/samples/samples/backup_sample_test.py
@@ -67,7 +67,12 @@ def database(spanner_instance):
 
 
 def test_create_backup(capsys, database):
-    backup_sample.create_backup(INSTANCE_ID, DATABASE_ID, BACKUP_ID)
+    version_time = None
+    with database.snapshot() as snapshot:
+        results = snapshot.execute_sql("SELECT CURRENT_TIMESTAMP()")
+        version_time = list(results)[0][0]
+
+    backup_sample.create_backup(INSTANCE_ID, DATABASE_ID, BACKUP_ID, version_time)
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
 


### PR DESCRIPTION
Instead of hardcoding the version time in the create backup sample, parameterises it.