### PR TITLE
feat: add support for custom timeout and retry parameters in execute_update method in transactions

### DIFF
--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Spanner read-write transaction support."""
 
 from google.protobuf.struct_pb2 import Struct
@@ -192,6 +191,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         param_types=None,
         query_mode=None,
         query_options=None,
+        *,
         retry=gapic_v1.method.DEFAULT,
         timeout=None,
     ):
@@ -221,7 +221,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         :param query_options: (Optional) Options that are provided for query plan stability.
 
         :type retry: :class:`~google.api_core.retry.Retry`
-        :param retry: (Optional) Designation of what errors, if any, should be retried.
+        :param retry: (Optional) The retry settings for this request.
 
         :type timeout: float
         :param timeout: (Optional) The timeout for this request.

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -194,7 +194,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         query_options=None,
         *,
         retry=gapic_v1.method.DEFAULT,
-        timeout=None,
+        timeout=gapic_v1.method.DEFAULT,
     ):
         """Perform an ``ExecuteSql`` API request with DML.
 

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -29,6 +29,8 @@ from google.cloud.spanner_v1 import TransactionOptions
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
 from google.cloud.spanner_v1.batch import _BatchBase
 from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
+from google.api_core import retry as retries
+from google.api_core import gapic_v1
 
 
 class Transaction(_SnapshotBase, _BatchBase):
@@ -185,8 +187,14 @@ class Transaction(_SnapshotBase, _BatchBase):
         return {}
 
     def execute_update(
-        self, dml, params=None, param_types=None, query_mode=None, query_options=None
-    ):
+        self,
+        dml,
+        params=None,
+        param_types=None,
+        query_mode=None,
+        query_options=None,
+        retry=gapic_v1.method.DEFAULT,
+        timeout=None):
         """Perform an ``ExecuteSql`` API request with DML.
 
         :type dml: str
@@ -245,7 +253,8 @@ class Transaction(_SnapshotBase, _BatchBase):
         with trace_call(
             "CloudSpanner.ReadWriteTransaction", self._session, trace_attributes
         ):
-            response = api.execute_sql(request=request, metadata=metadata)
+            response = api.execute_sql(
+                request=request, metadata=metadata, retry=retry, timeout=timeout)
         return response.stats.row_count_exact
 
     def batch_update(self, statements):

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Spanner read-write transaction support."""
 
 from google.protobuf.struct_pb2 import Struct

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -29,7 +29,6 @@ from google.cloud.spanner_v1 import TransactionOptions
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
 from google.cloud.spanner_v1.batch import _BatchBase
 from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
-from google.api_core import retry as retries
 from google.api_core import gapic_v1
 
 
@@ -194,7 +193,8 @@ class Transaction(_SnapshotBase, _BatchBase):
         query_mode=None,
         query_options=None,
         retry=gapic_v1.method.DEFAULT,
-        timeout=None):
+        timeout=None,
+    ):
         """Perform an ``ExecuteSql`` API request with DML.
 
         :type dml: str
@@ -219,6 +219,12 @@ class Transaction(_SnapshotBase, _BatchBase):
             :class:`~google.cloud.spanner_v1.ExecuteSqlRequest.QueryOptions`
             or :class:`dict`
         :param query_options: (Optional) Options that are provided for query plan stability.
+
+        :type retry: :class:`~google.api_core.retry.Retry`
+        :param retry: (Optional) Designation of what errors, if any, should be retried.
+
+        :type timeout: float
+        :param timeout: (Optional) The timeout for this request.
 
         :rtype: int
         :returns: Count of rows affected by the DML statement.
@@ -254,7 +260,8 @@ class Transaction(_SnapshotBase, _BatchBase):
             "CloudSpanner.ReadWriteTransaction", self._session, trace_attributes
         ):
             response = api.execute_sql(
-                request=request, metadata=metadata, retry=retry, timeout=timeout)
+                request=request, metadata=metadata, retry=retry, timeout=timeout
+            )
         return response.stats.row_count_exact
 
     def batch_update(self, statements):

--- a/samples/samples/backup_sample.py
+++ b/samples/samples/backup_sample.py
@@ -32,9 +32,14 @@ def create_backup(instance_id, database_id, backup_id):
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
 
+    # Sets the version time as the current server time
+    version_time = None
+    with database.snapshot() as snapshot:
+        results = snapshot.execute_sql("SELECT CURRENT_TIMESTAMP()")
+        version_time = list(results)[0][0]
+
     # Create a backup
     expire_time = datetime.utcnow() + timedelta(days=14)
-    version_time = database.earliest_version_time
     backup = instance.backup(backup_id, database=database, expire_time=expire_time, version_time=version_time)
     operation = backup.create()
 

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -412,7 +412,11 @@ class TestTransaction(OpenTelemetryBase):
             transaction.execute_update(DML_QUERY_WITH_PARAM, PARAMS)
 
     def _execute_update_helper(
-        self, count=0, query_options=None, retry=gapic_v1.method.DEFAULT, timeout=None
+        self,
+        count=0,
+        query_options=None,
+        retry=gapic_v1.method.DEFAULT,
+        timeout=gapic_v1.method.DEFAULT,
     ):
         from google.protobuf.struct_pb2 import Struct
         from google.cloud.spanner_v1 import (

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -17,7 +17,6 @@ import mock
 from tests._helpers import OpenTelemetryBase, StatusCanonicalCode
 from google.cloud.spanner_v1 import Type
 from google.cloud.spanner_v1 import TypeCode
-from google.api_core import retry as retries
 from google.api_core import gapic_v1
 
 TABLE_NAME = "citizens"
@@ -412,7 +411,9 @@ class TestTransaction(OpenTelemetryBase):
         with self.assertRaises(ValueError):
             transaction.execute_update(DML_QUERY_WITH_PARAM, PARAMS)
 
-    def _execute_update_helper(self, count=0, query_options=None, retry=gapic_v1.method.DEFAULT, timeout=None):
+    def _execute_update_helper(
+        self, count=0, query_options=None, retry=gapic_v1.method.DEFAULT, timeout=None
+    ):
         from google.protobuf.struct_pb2 import Struct
         from google.cloud.spanner_v1 import (
             ResultSet,

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -17,6 +17,8 @@ import mock
 from tests._helpers import OpenTelemetryBase, StatusCanonicalCode
 from google.cloud.spanner_v1 import Type
 from google.cloud.spanner_v1 import TypeCode
+from google.api_core import retry as retries
+from google.api_core import gapic_v1
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -410,7 +412,7 @@ class TestTransaction(OpenTelemetryBase):
         with self.assertRaises(ValueError):
             transaction.execute_update(DML_QUERY_WITH_PARAM, PARAMS)
 
-    def _execute_update_helper(self, count=0, query_options=None):
+    def _execute_update_helper(self, count=0, query_options=None, retry=gapic_v1.method.DEFAULT, timeout=None):
         from google.protobuf.struct_pb2 import Struct
         from google.cloud.spanner_v1 import (
             ResultSet,
@@ -439,6 +441,8 @@ class TestTransaction(OpenTelemetryBase):
             PARAM_TYPES,
             query_mode=MODE,
             query_options=query_options,
+            retry=retry,
+            timeout=timeout,
         )
 
         self.assertEqual(row_count, 1)
@@ -466,6 +470,8 @@ class TestTransaction(OpenTelemetryBase):
         )
         api.execute_sql.assert_called_once_with(
             request=expected_request,
+            retry=retry,
+            timeout=timeout,
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
@@ -476,6 +482,15 @@ class TestTransaction(OpenTelemetryBase):
 
     def test_execute_update_w_count(self):
         self._execute_update_helper(count=1)
+
+    def test_execute_update_w_timeout_param(self):
+        self._execute_update_helper(timeout=2.0)
+
+    def test_execute_update_w_retry_param(self):
+        self._execute_update_helper(retry=gapic_v1.method.DEFAULT)
+
+    def test_execute_update_w_timeout_and_retry_params(self):
+        self._execute_update_helper(retry=gapic_v1.method.DEFAULT, timeout=2.0)
 
     def test_execute_update_error(self):
         database = _Database()


### PR DESCRIPTION
feat: Added support for custom timeout and retry parameters in transactions.

Fixes #71 🦕
