### PR TITLE
feat(db_api): support executing several DDLs separated by semicolon

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -175,7 +175,9 @@ class Cursor(object):
             classification = parse_utils.classify_stmt(sql)
             if classification == parse_utils.STMT_DDL:
                 for ddl in sql.split(";"):
-                    self.connection._ddl_statements.append(ddl)
+                    ddl = ddl.strip()
+                    if ddl:
+                        self.connection._ddl_statements.append(ddl)
                 return
 
             # For every other operation, we've got to ensure that

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -174,7 +174,8 @@ class Cursor(object):
         try:
             classification = parse_utils.classify_stmt(sql)
             if classification == parse_utils.STMT_DDL:
-                self.connection._ddl_statements.append(sql)
+                for ddl in sql.split(";"):
+                    self.connection._ddl_statements.append(ddl)
                 return
 
             # For every other operation, we've got to ensure that

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -862,3 +862,31 @@ class TestCursor(unittest.TestCase):
                     cursor.fetchmany(len(row))
 
                 run_mock.assert_called_with(statement, retried=True)
+
+    def test_ddls_with_semicolon(self):
+        """
+        Check that one script with several DDL statements separated
+        with semicolons is splitted into several DDLs.
+        """
+        from google.cloud.spanner_dbapi.connection import connect
+
+        EXP_DDLS = [
+            "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ()",
+            "DROP TABLE table_name",
+        ]
+
+        with mock.patch(
+            "google.cloud.spanner_v1.instance.Instance.exists", return_value=True,
+        ):
+            with mock.patch(
+                "google.cloud.spanner_v1.database.Database.exists", return_value=True,
+            ):
+                connection = connect("test-instance", "test-database")
+
+        cursor = connection.cursor()
+        cursor.execute(
+            "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ();"
+            "DROP TABLE table_name;"
+        )
+
+        self.assertEqual(connection._ddl_statements, EXP_DDLS)

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -872,6 +872,7 @@ class TestCursor(unittest.TestCase):
 
         EXP_DDLS = [
             "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ()",
+            "DROP INDEX index_name",
             "DROP TABLE table_name",
         ]
 
@@ -886,6 +887,7 @@ class TestCursor(unittest.TestCase):
         cursor = connection.cursor()
         cursor.execute(
             "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ();"
+            "DROP INDEX index_name;\n"
             "DROP TABLE table_name;"
         )
 


### PR DESCRIPTION
With this change users will be able to put several DDLs into one `execute()` call, like:

```python
cursor.execute("CREATE TABLE ...;CREATE INDEX...")
```