### PR TITLE
refactor: remove encryption_config property from Backup

### DIFF
--- a/google/cloud/spanner_v1/backup.py
+++ b/google/cloud/spanner_v1/backup.py
@@ -185,14 +185,6 @@ class Backup(object):
         """
         return self._encryption_info
 
-    @property
-    def encryption_config(self):
-        """Encryption config for this database.
-        :rtype: :class:`~google.cloud.spanner_admin_instance_v1.types.CreateBackupEncryptionConfig`
-        :returns: an object representing the encryption config for this database
-        """
-        return self._encryption_config
-
     @classmethod
     def from_pb(cls, backup_pb, instance):
         """Create an instance of this class from a protobuf message.
@@ -245,9 +237,9 @@ class Backup(object):
         if not self._database:
             raise ValueError("database not set")
         if (
-            self.encryption_config
-            and self.encryption_config.kms_key_name
-            and self.encryption_config.encryption_type
+            self._encryption_config
+            and self._encryption_config.kms_key_name
+            and self._encryption_config.encryption_type
             != CreateBackupEncryptionConfig.EncryptionType.CUSTOMER_MANAGED_ENCRYPTION
         ):
             raise ValueError("kms_key_name only used with CUSTOMER_MANAGED_ENCRYPTION")

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -741,6 +741,7 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         from google.cloud.spanner_admin_database_v1 import (
             CreateBackupEncryptionConfig,
             EncryptionConfig,
+            EncryptionInfo,
             RestoreDatabaseEncryptionConfig,
         )
         from datetime import datetime
@@ -780,7 +781,9 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         self.assertEqual(self.database_version_time, backup.version_time)
         self.assertIsNotNone(backup.size_bytes)
         self.assertIsNotNone(backup.state)
-        self.assertEqual(encryption_config, backup.encryption_config)
+        self.assertEqual(
+            EncryptionInfo.Type.GOOGLE_DEFAULT_ENCRYPTION, backup.encryption_info
+        )
 
         # Update with valid argument.
         valid_expire_time = datetime.utcnow() + timedelta(days=7)

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -782,7 +782,8 @@ class TestBackupAPI(unittest.TestCase, _TestData):
         self.assertIsNotNone(backup.size_bytes)
         self.assertIsNotNone(backup.state)
         self.assertEqual(
-            EncryptionInfo.Type.GOOGLE_DEFAULT_ENCRYPTION, backup.encryption_info
+            EncryptionInfo.Type.GOOGLE_DEFAULT_ENCRYPTION,
+            backup.encryption_info.encryption_type,
         )
 
         # Update with valid argument.

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -84,7 +84,7 @@ class TestBackup(_BaseTest):
         self.assertEqual(backup._database, self.DATABASE_NAME)
         self.assertIsNotNone(backup._expire_time)
         self.assertIs(backup._expire_time, timestamp)
-        self.assertEqual(backup.encryption_config, encryption_config)
+        self.assertEqual(backup._encryption_config, encryption_config)
 
     def test_ctor_w_encryption_config_dict(self):
         from google.cloud.spanner_admin_database_v1 import CreateBackupEncryptionConfig
@@ -107,7 +107,7 @@ class TestBackup(_BaseTest):
         self.assertEqual(backup._database, self.DATABASE_NAME)
         self.assertIsNotNone(backup._expire_time)
         self.assertIs(backup._expire_time, timestamp)
-        self.assertEqual(backup.encryption_config, expected_encryption_config)
+        self.assertEqual(backup._encryption_config, expected_encryption_config)
 
     def test_from_pb_project_mismatch(self):
         from google.cloud.spanner_admin_database_v1 import Backup
@@ -223,7 +223,7 @@ class TestBackup(_BaseTest):
             encryption_type=CreateBackupEncryptionConfig.EncryptionType.CUSTOMER_MANAGED_ENCRYPTION,
             kms_key_name="kms_key_name",
         )
-        self.assertEqual(backup.encryption_config, expected)
+        self.assertEqual(backup._encryption_config, expected)
 
     def test_create_grpc_error(self):
         from google.api_core.exceptions import GoogleAPICallError


### PR DESCRIPTION
The `Backup` proto message does not contain an `encryption_config` field. Since all the other properties on the handwritten `Backup` wrapper map to a proto field, there is a risk of confusing users by having `encryption_config` as a property as it will not be updated by the backend when `reload()` is called. To prevent this confusion, this PR removes this property.