### PR TITLE
fix(db_api): revert Mutations API usage

### DIFF
--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -237,10 +237,10 @@ def parse_insert(insert_sql, params):
             Params: ['a', 'b', 'c', 'd']
         it produces:
             {
-                'homogenous': True,
-                'table': 'T',
-                'columns': ['f1', 'f2'],
-                'values': [('a', 'b',), ('c', 'd',)],
+                'sql_params_list': [
+                    ('INSERT INTO T (f1, f2) VALUES (%s, %s)', ('a', 'b')),
+                    ('INSERT INTO T (f1, f2) VALUES (%s, %s)', ('c', 'd'))
+                ],
             }
 
     Case d)
@@ -249,7 +249,7 @@ def parse_insert(insert_sql, params):
         it produces:
             {
                 'sql_params_list': [
-                    ('INSERT INTO T (f1, f2) VALUES (%s, LOWER(%s))', ('a', 'b',))
+                    ('INSERT INTO T (f1, f2) VALUES (%s, LOWER(%s))', ('a', 'b',)),
                     ('INSERT INTO T (f1, f2) VALUES (UPPER(%s), %s)', ('c', 'd',))
                 ],
             }

--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -306,15 +306,19 @@ def parse_insert(insert_sql, params):
         # Case c)
 
         columns = [mi.strip(" `") for mi in match.group("columns").split(",")]
+        sql_params_list = []
+        insert_sql_preamble = "INSERT INTO %s (%s) VALUES %s" % (
+            match.group("table_name"),
+            match.group("columns"),
+            values.argv[0],
+        )
         values_pyformat = [str(arg) for arg in values.argv]
         rows_list = rows_for_insert_or_update(columns, params, values_pyformat)
+        insert_sql_preamble = sanitize_literals_for_upload(insert_sql_preamble)
+        for row in rows_list:
+            sql_params_list.append((insert_sql_preamble, row))
 
-        return {
-            "homogenous": True,
-            "table": match.group("table_name"),
-            "columns": columns,
-            "values": rows_list,
-        }
+        return {"sql_params_list": sql_params_list}
 
     # Case d)
     # insert_sql is of the form:

--- a/tests/unit/spanner_dbapi/test_parse_utils.py
+++ b/tests/unit/spanner_dbapi/test_parse_utils.py
@@ -72,20 +72,32 @@ class TestParseUtils(unittest.TestCase):
                 "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
                 [1, 2, 3, 4, 5, 6],
                 {
-                    "homogenous": True,
-                    "table": "django_migrations",
-                    "columns": ["app", "name", "applied"],
-                    "values": [(1, 2, 3), (4, 5, 6)],
+                    "sql_params_list": [
+                        (
+                            "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
+                            (1, 2, 3),
+                        ),
+                        (
+                            "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
+                            (4, 5, 6),
+                        ),
+                    ]
                 },
             ),
             (
                 "INSERT INTO django_migrations(app, name, applied) VALUES (%s, %s, %s)",
                 [1, 2, 3, 4, 5, 6],
                 {
-                    "homogenous": True,
-                    "table": "django_migrations",
-                    "columns": ["app", "name", "applied"],
-                    "values": [(1, 2, 3), (4, 5, 6)],
+                    "sql_params_list": [
+                        (
+                            "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
+                            (1, 2, 3),
+                        ),
+                        (
+                            "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
+                            (4, 5, 6),
+                        ),
+                    ]
                 },
             ),
             (
@@ -106,23 +118,25 @@ class TestParseUtils(unittest.TestCase):
             ),
             (
                 "INSERT INTO ap (n, ct, cn) "
-                "VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s),(%s,%s, %s)",
+                "VALUES (%s, %s, %s), (%s, %s, %s), (%s, %s, %s),(%s,      %s, %s)",
                 (1, 2, 3, 4, 5, 6, 7, 8, 9),
                 {
-                    "homogenous": True,
-                    "table": "ap",
-                    "columns": ["n", "ct", "cn"],
-                    "values": [(1, 2, 3), (4, 5, 6), (7, 8, 9)],
+                    "sql_params_list": [
+                        ("INSERT INTO ap (n, ct, cn) VALUES (%s, %s, %s)", (1, 2, 3)),
+                        ("INSERT INTO ap (n, ct, cn) VALUES (%s, %s, %s)", (4, 5, 6)),
+                        ("INSERT INTO ap (n, ct, cn) VALUES (%s, %s, %s)", (7, 8, 9)),
+                    ]
                 },
             ),
             (
                 "INSERT INTO `no` (`yes`) VALUES (%s)",
                 (1, 4, 5),
                 {
-                    "homogenous": True,
-                    "table": "`no`",
-                    "columns": ["yes"],
-                    "values": [(1,), (4,), (5,)],
+                    "sql_params_list": [
+                        ("INSERT INTO `no` (`yes`) VALUES (%s)", (1,)),
+                        ("INSERT INTO `no` (`yes`) VALUES (%s)", (4,)),
+                        ("INSERT INTO `no` (`yes`) VALUES (%s)", (5,)),
+                    ]
                 },
             ),
             (


### PR DESCRIPTION
This PR reverts changes made in #233.

I've executed SQLAlchemy tests several times - looks like with #233 changes reverted everything is working fine now. I've mentioned that DLL `test_create` is failing when 223 is reverted, but it's no more actual, so we can safely revert it I assume - I only have those 3 tests mentioned in [the comment](https://github.com/cloudspannerecosystem/python-spanner-sqlalchemy/pull/33#issuecomment-802853769) failing, which is expected for now.