### PR TITLE
fix(db_api): ensure DDL statements are being executed

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -243,7 +243,10 @@ class Connection:
         """
         if self._autocommit:
             warnings.warn(AUTOCOMMIT_MODE_WARNING, UserWarning, stacklevel=2)
-        elif self.inside_transaction:
+            return
+
+        self.run_prior_DDL_statements()
+        if self.inside_transaction:
             try:
                 self._transaction.commit()
                 self._release_session()

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -178,6 +178,8 @@ class Cursor(object):
                     ddl = ddl.strip()
                     if ddl:
                         self.connection._ddl_statements.append(ddl)
+                if self.connection.autocommit:
+                    self.connection.run_prior_DDL_statements()
                 return
 
             # For every other operation, we've got to ensure that

--- a/tests/system/test_system_dbapi.py
+++ b/tests/system/test_system_dbapi.py
@@ -378,6 +378,62 @@ SELECT * FROM contacts WHERE contact_id = 1
         self.assertEqual(res[0], 1)
         conn.close()
 
+    def test_DDL_autocommit(self):
+        """Check that DDLs in autocommit mode are immediately executed."""
+        conn = Connection(Config.INSTANCE, self._db)
+        conn.autocommit = True
+
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE Singers (
+                SingerId     INT64 NOT NULL,
+                Name    STRING(1024),
+            ) PRIMARY KEY (SingerId)
+        """
+        )
+        conn.close()
+
+        # if previous DDL wasn't committed, the next INSERT
+        # will fail with a ProgrammingError
+        conn = Connection(Config.INSTANCE, self._db)
+
+        cur = conn.cursor()
+        cur.execute("""INSERT INTO Singers (SingerId, Name) VALUES (1, "Name")""")
+
+        conn.commit()
+
+        cur.execute("DROP TABLE Singers")
+        conn.commit()
+
+    def test_DDL_commit(self):
+        """Check that DDLs in commit mode are executed on calling `commit()`."""
+        conn = Connection(Config.INSTANCE, self._db)
+        cur = conn.cursor()
+
+        cur.execute(
+            """
+        CREATE TABLE Singers (
+            SingerId     INT64 NOT NULL,
+            Name    STRING(1024),
+        ) PRIMARY KEY (SingerId)
+        """
+        )
+        conn.commit()
+        conn.close()
+
+        # if previous DDL wasn't committed, the next INSERT
+        # will fail with a ProgrammingError
+        conn = Connection(Config.INSTANCE, self._db)
+        cur = conn.cursor()
+
+        cur.execute(
+            """
+        INSERT INTO Singers (SingerId, Name) VALUES (1, "Name")
+        """
+        )
+        conn.commit()
+
 
 def clear_table(transaction):
     """Clear the test table."""

--- a/tests/system/test_system_dbapi.py
+++ b/tests/system/test_system_dbapi.py
@@ -394,14 +394,10 @@ SELECT * FROM contacts WHERE contact_id = 1
         )
         conn.close()
 
-        # if previous DDL wasn't committed, the next INSERT
-        # will fail with a ProgrammingError
+        # if previous DDL wasn't committed, the next DROP TABLE
+        # statement will fail with a ProgrammingError
         conn = Connection(Config.INSTANCE, self._db)
-
         cur = conn.cursor()
-        cur.execute("""INSERT INTO Singers (SingerId, Name) VALUES (1, "Name")""")
-
-        conn.commit()
 
         cur.execute("DROP TABLE Singers")
         conn.commit()
@@ -422,16 +418,12 @@ SELECT * FROM contacts WHERE contact_id = 1
         conn.commit()
         conn.close()
 
-        # if previous DDL wasn't committed, the next INSERT
-        # will fail with a ProgrammingError
+        # if previous DDL wasn't committed, the next DROP TABLE
+        # statement will fail with a ProgrammingError
         conn = Connection(Config.INSTANCE, self._db)
         cur = conn.cursor()
 
-        cur.execute(
-            """
-        INSERT INTO Singers (SingerId, Name) VALUES (1, "Name")
-        """
-        )
+        cur.execute("DROP TABLE Singers")
         conn.commit()
 
 


### PR DESCRIPTION
This PR ensures that DDL statements are being executed. 

Currently, DDL statements aren't executed until a non-DDL statement is executed. This leads to unexpected behavior. This fix will execute DDL statements immediately when `autocommit=True` and when `commit()` is called for `autocommit=False`.

Note that DDL statements will still be executed when a non-DDL statements is executed in `autocommit=False`. e.g.
```
cur.execute(
"""
CREATE TABLE Singers (
    SingerId     INT64 NOT NULL,
    Name    STRING(1024),
) PRIMARY KEY (SingerId)
"""
)

# CREATE TABLE statement will be execute here; before the INSERT statement.

cur.execute(
"""
INSERT INTO Singers (SingerId, Name) VALUES (1, "Name")
"""
)
```