### PR TITLE
docs: fix snapshot usage

### DIFF
--- a/docs/snapshot-usage.rst
+++ b/docs/snapshot-usage.rst
@@ -65,16 +65,16 @@ Read Table Data
 
 To read data for selected rows from a table in the database, call
 :meth:`~google.cloud.spanner_v1.snapshot.Snapshot.read` which will return
-all rows specified in ``key_set``, or fail if the result set is too large,
+all rows specified in ``keyset``, or fail if the result set is too large,
 
 .. code:: python
 
     with database.snapshot() as snapshot:
         result = snapshot.read(
             table='table-name', columns=['first_name', 'last_name', 'age'],
-            key_set=['phred@example.com', 'bharney@example.com'])
+            keyset=spanner.KeySet([['phred@example.com'], ['bharney@example.com']]))
 
-        for row in result.rows:
+        for row in result:
             print(row)
 
 .. note::

--- a/docs/snapshot-usage.rst
+++ b/docs/snapshot-usage.rst
@@ -100,7 +100,7 @@ result set is too large,
             'WHERE p.employee_id == e.employee_id')
         result = snapshot.execute_sql(QUERY)
 
-        for row in list(result):
+        for row in result:
             print(row)
 
 .. note::


### PR DESCRIPTION
Fix a wrong keyword argument `key_set`.
Correctly, it is `keyset`, and the value must be a instance of `spanner.KeySet()`.

`snapshot.read()` and `snapshot.execute_sql()` returns an iterable.
It does not have `rows` attribute.
