### PR TITLE
fix: support INSERT from SELECT clause with args

### DIFF
--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -276,7 +276,7 @@ def parse_insert(insert_sql, params):
     if not after_values_sql:
         # Case b)
         insert_sql = sanitize_literals_for_upload(insert_sql)
-        return {"sql_params_list": [(insert_sql, None)]}
+        return {"sql_params_list": [(insert_sql, params)]}
 
     if not params:
         # Case a) perhaps?

--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -224,11 +224,11 @@ def parse_insert(insert_sql, params):
             }
 
     Case b)
-            SQL: 'INSERT INTO T (s, c) SELECT st, zc FROM cus ORDER BY fn, ln',
+        SQL: 'INSERT INTO T (s, c) SELECT st, zc FROM cus WHERE col IN (%s, %s)',
         it produces:
             {
                 'sql_params_list': [
-                    ('INSERT INTO T (s, c) SELECT st, zc FROM cus ORDER BY fn, ln', None),
+                    ('INSERT INTO T (s, c) SELECT st, zc FROM cus ORDER BY fn, ln', ('a', 'b')),
                 ]
             }
 

--- a/tests/unit/spanner_dbapi/test_parse_utils.py
+++ b/tests/unit/spanner_dbapi/test_parse_utils.py
@@ -425,3 +425,19 @@ class TestParseUtils(unittest.TestCase):
             with self.subTest(name=name):
                 got = escape_name(name)
                 self.assertEqual(got, want)
+
+    def test_insert_from_select(self):
+        """Check that INSERT from SELECT clause can be executed with arguments."""
+        from google.cloud.spanner_dbapi.parse_utils import parse_insert
+
+        SQL = """
+INSERT INTO tab_name (id, data)
+SELECT tab_name.id + %s AS anon_1, tab_name.data
+FROM tab_name
+WHERE tab_name.data IN (%s, %s)
+"""
+        ARGS = [5, "data2", "data3"]
+
+        self.assertEqual(
+            parse_insert(SQL, ARGS), {"sql_params_list": [(SQL, ARGS)]},
+        )


### PR DESCRIPTION
Spanner supports doing INSERT with values takes from a SELECT clause. However, DB API is processing such a cases incorrectly, so such a query, for example:
```sql
INSERT INTO manual_pk (id, data)
SELECT manual_pk.id + %s AS anon_1, manual_pk.data
FROM manual_pk
WHERE manual_pk.data IN (%s, %s)
```
Will fail with a syntax error:
```
400 Syntax error: Illegal input character \"%\" [at 3:23]\nSELECT manual_pk.id + %s AS anon_1, manual_pk.data\n
```
Fixing this bug.