### PR TITLE
feat: add support for low-cost instances

### DIFF
--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -49,7 +49,6 @@ from google.cloud.spanner_admin_instance_v1 import InstanceAdminClient
 from google.cloud.client import ClientWithProject
 from google.cloud.spanner_v1 import __version__
 from google.cloud.spanner_v1._helpers import _merge_query_options, _metadata_with_prefix
-from google.cloud.spanner_v1.instance import DEFAULT_NODE_COUNT
 from google.cloud.spanner_v1.instance import Instance
 from google.cloud.spanner_v1 import ExecuteSqlRequest
 from google.cloud.spanner_admin_instance_v1 import ListInstanceConfigsRequest
@@ -294,8 +293,9 @@ class Client(ClientWithProject):
         instance_id,
         configuration_name=None,
         display_name=None,
-        node_count=DEFAULT_NODE_COUNT,
+        node_count=None,
         labels=None,
+        processing_units=None,
     ):
         """Factory to create a instance associated with this client.
 
@@ -320,6 +320,10 @@ class Client(ClientWithProject):
         :param node_count: (Optional) The number of nodes in the instance's
                             cluster; used to set up the instance's cluster.
 
+        :type processing_units: int
+        :param processing_units: (Optional) The number of processing units
+                                allocated to this instance.
+
         :type labels: dict (str -> str) or None
         :param labels: (Optional) User-assigned labels for this instance.
 
@@ -334,6 +338,7 @@ class Client(ClientWithProject):
             display_name,
             self._emulator_host,
             labels,
+            processing_units,
         )
 
     def list_instances(self, filter_="", page_size=None):

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -225,7 +225,7 @@ class Instance(object):
     def processing_units(self, value):
         """Sets the processing units for requests. Affects node_count.
 
-        :param value: The numer of processing units allocated to this instance.
+        :param value: The number of processing units allocated to this instance.
         """
         self._processing_units = value
         self._node_count = value // PROCESSING_UNITS_PER_NODE

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -234,7 +234,7 @@ class Instance(object):
         """Node count used in requests.
 
         :rtype: int
-        :returns node_count:
+        :returns:
             The number of nodes in the instance's cluster;
             used to set up the instance's cluster.
         """

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -215,9 +215,8 @@ class Instance(object):
     def processing_units(self):
         """Processing units used in requests.
 
-        :rtype int
-        :returns processing_units: The number of processing units
-                                allocated to this instance.
+        :rtype: int
+        :returns: The number of processing units allocated to this instance.
         """
         return self._processing_units
 
@@ -234,9 +233,10 @@ class Instance(object):
     def node_count(self):
         """Node count used in requests.
 
-        :rtype int
-        :returns node count: The number of nodes in the instance's
-                            cluster; used to set up the instance's cluster.
+        :rtype: int
+        :returns node_count:
+            The number of nodes in the instance's cluster;
+            used to set up the instance's cluster.
         """
         return self._node_count
 
@@ -244,7 +244,7 @@ class Instance(object):
     def node_count(self, value):
         """Sets the node count for requests. Affects processing_units.
 
-        :param value: The number of nodes in the instance's cluster
+        :param value: The number of nodes in the instance's cluster.
         """
         self._node_count = value
         self._processing_units = value * PROCESSING_UNITS_PER_NODE

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -15,6 +15,7 @@
 """User friendly container for Cloud Spanner Instance."""
 
 import google.api_core.operation
+from google.api_core.exceptions import InvalidArgument
 import re
 
 from google.cloud.spanner_admin_instance_v1 import Instance as InstancePB
@@ -41,6 +42,7 @@ _INSTANCE_NAME_RE = re.compile(
 )
 
 DEFAULT_NODE_COUNT = 1
+PROCESSING_UNITS_PER_NODE = 1000
 
 _OPERATION_METADATA_MESSAGES = (
     backup.Backup,
@@ -95,6 +97,10 @@ class Instance(object):
     :type node_count: int
     :param node_count: (Optional) Number of nodes allocated to the instance.
 
+    :type processing_units: int
+    :param processing_units: (Optional) The number of processing units
+                            allocated to this instance.
+
     :type display_name: str
     :param display_name: (Optional) The display name for the instance in the
                          Cloud Console UI. (Must be between 4 and 30
@@ -110,15 +116,29 @@ class Instance(object):
         instance_id,
         client,
         configuration_name=None,
-        node_count=DEFAULT_NODE_COUNT,
+        node_count=None,
         display_name=None,
         emulator_host=None,
         labels=None,
+        processing_units=None,
     ):
         self.instance_id = instance_id
         self._client = client
         self.configuration_name = configuration_name
-        self.node_count = node_count
+        if node_count is not None and processing_units is not None:
+            if processing_units != node_count * PROCESSING_UNITS_PER_NODE:
+                raise InvalidArgument(
+                    "Only one of node count and processing units can be set."
+                )
+        if node_count is None and processing_units is None:
+            self._node_count = DEFAULT_NODE_COUNT
+            self._processing_units = DEFAULT_NODE_COUNT * PROCESSING_UNITS_PER_NODE
+        elif node_count is not None:
+            self._node_count = node_count
+            self._processing_units = node_count * PROCESSING_UNITS_PER_NODE
+        else:
+            self._processing_units = processing_units
+            self._node_count = processing_units // PROCESSING_UNITS_PER_NODE
         self.display_name = display_name or instance_id
         self.emulator_host = emulator_host
         if labels is None:
@@ -134,7 +154,8 @@ class Instance(object):
             raise ValueError("Instance protobuf does not contain display_name")
         self.display_name = instance_pb.display_name
         self.configuration_name = instance_pb.config
-        self.node_count = instance_pb.node_count
+        self._node_count = instance_pb.node_count
+        self._processing_units = instance_pb.processing_units
         self.labels = instance_pb.labels
 
     @classmethod
@@ -190,6 +211,44 @@ class Instance(object):
         """
         return self._client.project_name + "/instances/" + self.instance_id
 
+    @property
+    def processing_units(self):
+        """Processing units used in requests.
+
+        :rtype int
+        :returns processing_units: The number of processing units
+                                allocated to this instance.
+        """
+        return self._processing_units
+
+    @processing_units.setter
+    def processing_units(self, value):
+        """Sets the processing units for requests. Affects node_count.
+
+        :param value: The numer of processing units allocated to this instance.
+        """
+        self._processing_units = value
+        self._node_count = value // PROCESSING_UNITS_PER_NODE
+
+    @property
+    def node_count(self):
+        """Node count used in requests.
+
+        :rtype int
+        :returns node count: The number of nodes in the instance's
+                            cluster; used to set up the instance's cluster.
+        """
+        return self._node_count
+
+    @node_count.setter
+    def node_count(self, value):
+        """Sets the node count for requests. Affects processing_units.
+
+        :param value: The number of nodes in the instance's cluster
+        """
+        self._node_count = value
+        self._processing_units = value * PROCESSING_UNITS_PER_NODE
+
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return NotImplemented
@@ -218,7 +277,8 @@ class Instance(object):
             self.instance_id,
             new_client,
             self.configuration_name,
-            node_count=self.node_count,
+            node_count=self._node_count,
+            processing_units=self._processing_units,
             display_name=self.display_name,
         )
 
@@ -250,7 +310,7 @@ class Instance(object):
             name=self.name,
             config=self.configuration_name,
             display_name=self.display_name,
-            node_count=self.node_count,
+            processing_units=self._processing_units,
             labels=self.labels,
         )
         metadata = _metadata_with_prefix(self.name)
@@ -306,8 +366,8 @@ class Instance(object):
 
         .. note::
 
-            Updates the ``display_name``, ``node_count`` and ``labels``. To change those
-            values before updating, set them via
+            Updates the ``display_name``, ``node_count``, ``processing_units``
+            and ``labels``. To change those values before updating, set them via
 
             .. code:: python
 
@@ -325,10 +385,15 @@ class Instance(object):
             name=self.name,
             config=self.configuration_name,
             display_name=self.display_name,
-            node_count=self.node_count,
+            node_count=self._node_count,
+            processing_units=self._processing_units,
             labels=self.labels,
         )
-        field_mask = FieldMask(paths=["config", "display_name", "node_count", "labels"])
+
+        # Always update only processing_units, not nodes
+        field_mask = FieldMask(
+            paths=["config", "display_name", "processing_units", "labels"]
+        )
         metadata = _metadata_with_prefix(self.name)
 
         future = api.update_instance(

--- a/tests/system/test_system.py
+++ b/tests/system/test_system.py
@@ -227,6 +227,35 @@ class TestInstanceAdminAPI(unittest.TestCase):
         self.assertEqual(instance, instance_alt)
         self.assertEqual(instance.display_name, instance_alt.display_name)
 
+    @unittest.skipIf(USE_EMULATOR, "Skipping LCI tests")
+    @unittest.skipUnless(CREATE_INSTANCE, "Skipping instance creation")
+    def test_create_instance_with_processing_nodes(self):
+        ALT_INSTANCE_ID = "new" + unique_resource_id("-")
+        PROCESSING_UNITS = 5000
+        instance = Config.CLIENT.instance(
+            instance_id=ALT_INSTANCE_ID,
+            configuration_name=Config.INSTANCE_CONFIG.name,
+            processing_units=PROCESSING_UNITS,
+        )
+        operation = instance.create()
+        # Make sure this instance gets deleted after the test case.
+        self.instances_to_delete.append(instance)
+
+        # We want to make sure the operation completes.
+        operation.result(
+            SPANNER_OPERATION_TIMEOUT_IN_SECONDS
+        )  # raises on failure / timeout.
+
+        # Create a new instance instance and make sure it is the same.
+        instance_alt = Config.CLIENT.instance(
+            ALT_INSTANCE_ID, Config.INSTANCE_CONFIG.name
+        )
+        instance_alt.reload()
+
+        self.assertEqual(instance, instance_alt)
+        self.assertEqual(instance.display_name, instance_alt.display_name)
+        self.assertEqual(instance.processing_units, instance_alt.processing_units)
+
     @unittest.skipIf(USE_EMULATOR, "Skipping updating instance")
     def test_update_instance(self):
         OLD_DISPLAY_NAME = Config.INSTANCE.display_name

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -37,6 +37,7 @@ class TestClient(unittest.TestCase):
     INSTANCE_NAME = "%s/instances/%s" % (PATH, INSTANCE_ID)
     DISPLAY_NAME = "display-name"
     NODE_COUNT = 5
+    PROCESSING_UNITS = 5000
     LABELS = {"test": "true"}
     TIMEOUT_SECONDS = 80
 
@@ -580,6 +581,7 @@ class TestClient(unittest.TestCase):
                     config=self.CONFIGURATION_NAME,
                     display_name=self.DISPLAY_NAME,
                     node_count=self.NODE_COUNT,
+                    processing_units=self.PROCESSING_UNITS,
                 )
             ]
         )
@@ -597,6 +599,7 @@ class TestClient(unittest.TestCase):
         self.assertEqual(instance.config, self.CONFIGURATION_NAME)
         self.assertEqual(instance.display_name, self.DISPLAY_NAME)
         self.assertEqual(instance.node_count, self.NODE_COUNT)
+        self.assertEqual(instance.processing_units, self.PROCESSING_UNITS)
 
         expected_metadata = (
             ("google-cloud-resource-prefix", client.project_name),


### PR DESCRIPTION
Allow users to create an instance using `processing_units`.
1 node = 1000 processing units. There is currently a default node count used if node count is not specified.
`create` and `update` now only update processing units rather than node count, as only one can be specified.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)



