### PR TITLE
perf: use protobuf for metadata to reduce type conversions

### DIFF
--- a/google/cloud/spanner_v1/_helpers.py
+++ b/google/cloud/spanner_v1/_helpers.py
@@ -205,7 +205,7 @@ def _parse_value_pb(value_pb, field_type):
             _parse_value_pb(item_pb, field_type.struct_type.fields[i].type_)
             for (i, item_pb) in enumerate(value_pb.list_value.values)
         ]
-    elif field_type.code == TypeCode.NUMERIC:
+    elif type_code == TypeCode.NUMERIC:
         return decimal.Decimal(value_pb.string_value)
     else:
         raise ValueError("Unknown type: %s" % (field_type,))

--- a/google/cloud/spanner_v1/streamed.py
+++ b/google/cloud/spanner_v1/streamed.py
@@ -66,7 +66,9 @@ class StreamedResultSet(object):
         :rtype: :class:`~google.cloud.spanner_v1.types.ResultSetMetadata`
         :returns: structure describing the results
         """
-        return ResultSetMetadata.wrap(self._metadata)
+        if self._metadata:
+            return ResultSetMetadata.wrap(self._metadata)
+        return None
 
     @property
     def stats(self):

--- a/google/cloud/spanner_v1/streamed.py
+++ b/google/cloud/spanner_v1/streamed.py
@@ -18,6 +18,7 @@ from google.protobuf.struct_pb2 import ListValue
 from google.protobuf.struct_pb2 import Value
 from google.cloud import exceptions
 from google.cloud.spanner_v1 import PartialResultSet
+from google.cloud.spanner_v1 import ResultSetMetadata
 from google.cloud.spanner_v1 import TypeCode
 import six
 
@@ -65,7 +66,7 @@ class StreamedResultSet(object):
         :rtype: :class:`~google.cloud.spanner_v1.types.ResultSetMetadata`
         :returns: structure describing the results
         """
-        return self._metadata
+        return ResultSetMetadata.wrap(self._metadata)
 
     @property
     def stats(self):

--- a/google/cloud/spanner_v1/streamed.py
+++ b/google/cloud/spanner_v1/streamed.py
@@ -119,7 +119,7 @@ class StreamedResultSet(object):
         response_pb = PartialResultSet.pb(response)
 
         if self._metadata is None:  # first response
-            metadata = self._metadata = response.metadata
+            metadata = self._metadata = response_pb.metadata
 
             source = self._source
             if source is not None and source._transaction_id is None:

--- a/tests/unit/test_streamed.py
+++ b/tests/unit/test_streamed.py
@@ -147,7 +147,7 @@ class TestStreamedResultSet(unittest.TestCase):
         metadata = streamed._metadata = self._make_result_set_metadata(FIELDS)
         stats = streamed._stats = self._make_result_set_stats()
         self.assertEqual(list(streamed.fields), FIELDS)
-        self.assertIs(streamed.metadata, metadata)
+        self.assertIs(streamed.metadata._pb, metadata)
         self.assertIs(streamed.stats, stats)
 
     def test__merge_chunk_bool(self):


### PR DESCRIPTION
To fix performance issues in #207, the streaming logic switched to using the underlying protobuf objects instead of the `proto-plus` objects which have an type conversion overhead when accessing values. However, the metadata proto was kept in the `proto-plus` format. This metadata object contains the type information of the different fields which means it is frequently accessed when iterating over arrays. This causes major performance issues for large scale arrays due to the type conversion overhead. Using the underlying protobuf for the metadata removes this overhead and brings the performance in line with `v1.17.1`.


Fixes #310 