### PR TITLE
chore: Use the default python version for blacken

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -62,15 +62,11 @@ def lint(session):
     session.run("flake8", "google", "tests")
 
 
-@nox.session(python="3.6")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
     """Run black.
 
     Format code to uniform standard.
-
-    This currently uses Python 3.6 due to the automated Kokoro run of synthtool.
-    That run uses an image that doesn't have 3.6 installed. Before updating this
-    check the state of the `gcp_ubuntu_config` we use for that Kokoro run.
     """
     session.install(BLACK_VERSION)
     session.run(


### PR DESCRIPTION
This PR updates the `blacken` session in `noxfile.py` to use the default python version which is python 3.8. This change is needed for owl bot to run the `blacken` session on PRs in this repo.