### PR TITLE
fix: retry Aborted errors when creating PeekIterator

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -206,7 +206,12 @@ class Cursor(object):
                 (self._result_set, self._checksum,) = self.connection.run_statement(
                     statement
                 )
-                self._itr = PeekIterator(self._result_set)
+                while True:
+                    try:
+                        self._itr = PeekIterator(self._result_set)
+                        break
+                    except Aborted:
+                        self.connection.retry_transaction()
                 return
 
             if classification == parse_utils.STMT_NON_UPDATING:
@@ -352,7 +357,12 @@ class Cursor(object):
                 self._result_set = res
                 # Read the first element so that the StreamedResultSet can
                 # return the metadata after a DQL statement. See issue #155.
-                self._itr = PeekIterator(self._result_set)
+                while True:
+                    try:
+                        self._itr = PeekIterator(self._result_set)
+                        break
+                    except Aborted:
+                        self.connection.retry_transaction()
                 # Unfortunately, Spanner doesn't seem to send back
                 # information about the number of rows available.
                 self._row_count = _UNSET_COUNT


### PR DESCRIPTION
A `PeekIterator` object (used by `Cursor` as a wrapper around the results iterator) does a preliminary stream of the first resulting row (to get the metadata of the response itself). In such a case, if an `Aborted` exception happened, it'll not be retried - fixing this error.

Fixes #342 