### PR TITLE
chore: s.remove_staging_dirs() should only be called once

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -27,13 +27,9 @@ for library in s.get_staging_dirs(spanner_default_version):
     if library.parent.absolute() == "spanner":
         s.move(library, excludes=["google/cloud/spanner/**", "*.*", "docs/index.rst", "google/cloud/spanner_v1/__init__.py"])
 
-s.remove_staging_dirs()
-
 for library in s.get_staging_dirs(spanner_admin_instance_default_version):
     if library.parent.absolute() == "spanner_admin_instance":
         s.move(library, excludes=["google/cloud/spanner_admin_instance/**", "*.*", "docs/index.rst"])
-
-s.remove_staging_dirs()
 
 for library in s.get_staging_dirs(spanner_admin_database_default_version):
     if library.parent.absolute() == "spanner_admin_database":


### PR DESCRIPTION
There is [an issue](https://github.com/googleapis/python-spanner/blob/master/owlbot.py#L30) in the `owlbot.py` file added in #319 in that [s.remove_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L309) should only be called once after all the files are copied over.  [get_staging_dirs()](https://github.com/googleapis/synthtool/blob/master/synthtool/transforms.py#L280) will only return staging directories that exist.