### PR TITLE
fix: classify batched DDL statements

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -182,9 +182,7 @@ class Cursor(object):
                         if ddl[-1] == ";":
                             ddl = ddl[:-1]
                         if parse_utils.classify_stmt(ddl) != parse_utils.STMT_DDL:
-                            raise ValueError(
-                                "Only DDL statements may be batched."
-                            )
+                            raise ValueError("Only DDL statements may be batched.")
                         ddl_statements.append(ddl)
                 # Only queue DDL statements if they are all correctly classified.
                 self.connection._ddl_statements.extend(ddl_statements)

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -186,6 +186,7 @@ class Cursor(object):
                                 "Only DDL statements may be batched."
                             )
                         ddl_statements.append(ddl)
+                # Only queue DDL statements if they are all correctly classified.
                 self.connection._ddl_statements.extend(ddl_statements)
                 if self.connection.autocommit:
                     self.connection.run_prior_DDL_statements()

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -176,11 +176,17 @@ class Cursor(object):
         try:
             classification = parse_utils.classify_stmt(sql)
             if classification == parse_utils.STMT_DDL:
+                ddl_statements = []
                 for ddl in sqlparse.split(sql):
                     if ddl:
                         if ddl[-1] == ";":
                             ddl = ddl[:-1]
-                        self.connection._ddl_statements.append(ddl)
+                        if parse_utils.classify_stmt(ddl) != parse_utils.STMT_DDL:
+                            raise ValueError(
+                                "Only DDL statements may be batched."
+                            )
+                        ddl_statements.append(ddl)
+                self.connection._ddl_statements.extend(ddl_statements)
                 if self.connection.autocommit:
                     self.connection.run_prior_DDL_statements()
                 return

--- a/test.py
+++ b/test.py
@@ -1,0 +1,11 @@
+from google.cloud import spanner
+from gooogle.cloud.spanner_v1 import RequestOptions
+
+client = spanner.Client()
+instance = client.instance('test-instance')
+database = instance.database('test-db')
+
+with database.snapshot() as snapshot:
+    results = snapshot.execute_sql("SELECT * in all_types LIMIT %s", )
+
+database.drop()

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -173,11 +173,23 @@ class TestCursor(unittest.TestCase):
 
         with mock.patch(
             "google.cloud.spanner_dbapi.parse_utils.classify_stmt",
+            side_effect=[parse_utils.STMT_DDL, parse_utils.STMT_INSERT],
+        ) as mock_classify_stmt:
+            sql = "sql"
+            with self.assertRaises(ValueError):
+                cursor.execute(sql=sql)
+            mock_classify_stmt.assert_called_with(sql)
+            self.assertEqual(mock_classify_stmt.call_count, 2)
+            self.assertEqual(cursor.connection._ddl_statements, [])
+
+        with mock.patch(
+            "google.cloud.spanner_dbapi.parse_utils.classify_stmt",
             return_value=parse_utils.STMT_DDL,
         ) as mock_classify_stmt:
             sql = "sql"
             cursor.execute(sql=sql)
-            mock_classify_stmt.assert_called_once_with(sql)
+            mock_classify_stmt.assert_called_with(sql)
+            self.assertEqual(mock_classify_stmt.call_count, 2)
             self.assertEqual(cursor.connection._ddl_statements, [sql])
 
         with mock.patch(


### PR DESCRIPTION
Currently an SQL statement such as `"CREATE TABLE t (...); INSERT INTO T (...)"` would be classified as batched DDL despite not all the statements being DDL.

This PR adds a classification check for each of the statements and raises an error if any of the batched statements are non-DDL.
