### PR TITLE
fix(db_api): use sqlparse to split DDL statements

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -178,6 +178,8 @@ class Cursor(object):
             if classification == parse_utils.STMT_DDL:
                 for ddl in sqlparse.split(sql):
                     if ddl:
+                        if ddl[-1] == ";":
+                            ddl = ddl[:-1]
                         self.connection._ddl_statements.append(ddl)
                 if self.connection.autocommit:
                     self.connection.run_prior_DDL_statements()

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -14,6 +14,8 @@
 
 """Database cursor for Google Cloud Spanner DB-API."""
 
+import sqlparse
+
 from google.api_core.exceptions import Aborted
 from google.api_core.exceptions import AlreadyExists
 from google.api_core.exceptions import FailedPrecondition
@@ -174,8 +176,7 @@ class Cursor(object):
         try:
             classification = parse_utils.classify_stmt(sql)
             if classification == parse_utils.STMT_DDL:
-                for ddl in sql.split(";"):
-                    ddl = ddl.strip()
+                for ddl in sqlparse.split(sql):
                     if ddl:
                         self.connection._ddl_statements.append(ddl)
                 if self.connection.autocommit:

--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -199,7 +199,7 @@ def classify_stmt(query):
 
 def parse_insert(insert_sql, params):
     """
-    Parse an INSERT statement an generate a list of tuples of the form:
+    Parse an INSERT statement and generate a list of tuples of the form:
         [
             (SQL, params_per_row1),
             (SQL, params_per_row2),

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -939,16 +939,16 @@ class TestCursor(unittest.TestCase):
         from google.cloud.spanner_dbapi.connection import connect
 
         EXP_DDLS = [
-            "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ();",
-            "DROP INDEX index_name;",
+            "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ()",
+            "DROP INDEX index_name",
             (
                 "CREATE TABLE papers ("
                 "\n    id INT64,"
                 "\n    authors ARRAY<STRING(100)>,"
                 '\n    author_list STRING(MAX) AS (ARRAY_TO_STRING(authors, ";")) stored'
-                ") PRIMARY KEY (id);"
+                ") PRIMARY KEY (id)"
             ),
-            "DROP TABLE table_name;",
+            "DROP TABLE table_name",
         ]
 
         with mock.patch(

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -939,9 +939,16 @@ class TestCursor(unittest.TestCase):
         from google.cloud.spanner_dbapi.connection import connect
 
         EXP_DDLS = [
-            "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ()",
-            "DROP INDEX index_name",
-            "DROP TABLE table_name",
+            "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ();",
+            "DROP INDEX index_name;",
+            (
+                "CREATE TABLE papers ("
+                "\n    id INT64,"
+                "\n    authors ARRAY<STRING(100)>,"
+                '\n    author_list STRING(MAX) AS (ARRAY_TO_STRING(authors, ";")) stored'
+                ") PRIMARY KEY (id);"
+            ),
+            "DROP TABLE table_name;",
         ]
 
         with mock.patch(
@@ -956,7 +963,12 @@ class TestCursor(unittest.TestCase):
         cursor.execute(
             "CREATE TABLE table_name (row_id INT64) PRIMARY KEY ();"
             "DROP INDEX index_name;\n"
-            "DROP TABLE table_name;"
+            "CREATE TABLE papers ("
+            "\n    id INT64,"
+            "\n    authors ARRAY<STRING(100)>,"
+            '\n    author_list STRING(MAX) AS (ARRAY_TO_STRING(authors, ";")) stored'
+            ") PRIMARY KEY (id);"
+            "DROP TABLE table_name;",
         )
 
         self.assertEqual(connection._ddl_statements, EXP_DDLS)


### PR DESCRIPTION
Instead of simple `str.split(";")` method use more smart `sqlparse` package to split DDL statements executed in a form:
```python
cursor.execute("""
    ddl_statement1;
    ddl_statement2;
    ddl_statement3;
""")
```