### PR TITLE
chore: add sample name label to created instances

### DIFF
--- a/samples/samples/autocommit_test.py
+++ b/samples/samples/autocommit_test.py
@@ -42,6 +42,7 @@ def spanner_instance():
         instance_config,
         labels={
             "cloud_spanner_samples": "true",
+            "sample_name": "autocommit",
             "created": str(int(time.time()))
         }
     )

--- a/samples/samples/backup_sample_test.py
+++ b/samples/samples/backup_sample_test.py
@@ -59,8 +59,9 @@ def spanner_instance():
         INSTANCE_ID,
         instance_config,
         labels={
-           "cloud_spanner_samples": "true",
-           "created": str(int(time.time()))
+            "cloud_spanner_samples": "true",
+            "sample_name": "backup",
+            "created": str(int(time.time()))
         }
     )
     op = instance.create()

--- a/samples/samples/quickstart_test.py
+++ b/samples/samples/quickstart_test.py
@@ -40,7 +40,11 @@ def create_instance():
     instance = spanner_client.instance(
         INSTANCE_ID,
         instance_config,
-        labels={"cloud_spanner_samples": "true", "created": str(int(time.time()))},
+        labels={
+            "cloud_spanner_samples": "true",
+            "sample_name": "quickstart",
+            "created": str(int(time.time()))
+        },
     )
     op = instance.create()
     op.result(120)  # block until completion

--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -47,7 +47,7 @@ def create_instance(instance_id):
         node_count=1,
         labels={
             "cloud_spanner_samples": "true",
-            "sample_name": "snippets",
+            "sample_name": "snippets-create_instance",
             "created": str(int(time.time()))
         }
     )
@@ -77,6 +77,11 @@ def create_instance_with_processing_units(instance_id, processing_units):
         configuration_name=config_name,
         display_name="This is a display name.",
         processing_units=processing_units,
+        labels={
+            "cloud_spanner_samples": "true",
+            "sample_name": "snippets-create_instance_with_processing_units",
+            "created": str(int(time.time()))
+        }
     )
 
     operation = instance.create()

--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -47,6 +47,7 @@ def create_instance(instance_id):
         node_count=1,
         labels={
             "cloud_spanner_samples": "true",
+            "sample_name": "snippets",
             "created": str(int(time.time()))
         }
     )

--- a/samples/samples/snippets_test.py
+++ b/samples/samples/snippets_test.py
@@ -88,6 +88,9 @@ def test_create_instance_with_processing_units(capsys):
     out, _ = capsys.readouterr()
     assert LCI_INSTANCE_ID in out
     assert "{} processing units".format(processing_units) in out
+    spanner_client = spanner.Client()
+    instance = spanner_client.instance(LCI_INSTANCE_ID)
+    instance.delete()
 
 
 def test_create_database(database):


### PR DESCRIPTION
Make leaked instances more obviously debuggable