### PR TITLE
tests: refactor samples fixtures

### DIFF
--- a/samples/samples/autocommit_test.py
+++ b/samples/samples/autocommit_test.py
@@ -4,72 +4,29 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-import time
-import uuid
-
 from google.api_core.exceptions import Aborted
-from google.cloud import spanner
 import pytest
 from test_utils.retry import RetryErrors
 
 import autocommit
-from snippets_test import cleanup_old_instances
-
-
-def unique_instance_id():
-    """Creates a unique id for the database."""
-    return f"test-instance-{uuid.uuid4().hex[:10]}"
-
-
-def unique_database_id():
-    """Creates a unique id for the database."""
-    return f"test-db-{uuid.uuid4().hex[:10]}"
-
-
-INSTANCE_ID = unique_instance_id()
-DATABASE_ID = unique_database_id()
 
 
 @pytest.fixture(scope="module")
-def spanner_instance():
-    spanner_client = spanner.Client()
-    cleanup_old_instances(spanner_client)
-    instance_config = "{}/instanceConfigs/{}".format(
-        spanner_client.project_name, "regional-us-central1"
-    )
-    instance = spanner_client.instance(
-        INSTANCE_ID,
-        instance_config,
-        labels={
-            "cloud_spanner_samples": "true",
-            "sample_name": "autocommit",
-            "created": str(int(time.time()))
-        }
-    )
-    op = instance.create()
-    op.result(120)  # block until completion
-    yield instance
-    instance.delete()
-
-
-@pytest.fixture(scope="module")
-def database(spanner_instance):
-    """Creates a temporary database that is removed after testing."""
-    db = spanner_instance.database(DATABASE_ID)
-    db.create()
-    yield db
-    db.drop()
+def sample_name():
+    return "autocommit"
 
 
 @RetryErrors(exception=Aborted, max_tries=2)
-def test_enable_autocommit_mode(capsys, database):
+def test_enable_autocommit_mode(capsys, instance_id, sample_database):
     # Delete table if it exists for retry attempts.
-    table = database.table('Singers')
+    table = sample_database.table('Singers')
     if table.exists():
-        op = database.update_ddl(["DROP TABLE Singers"])
+        op = sample_database.update_ddl(["DROP TABLE Singers"])
         op.result()
 
-    autocommit.enable_autocommit_mode(INSTANCE_ID, DATABASE_ID)
+    autocommit.enable_autocommit_mode(
+        instance_id, sample_database.database_id,
+    )
     out, _ = capsys.readouterr()
     assert "Autocommit mode is enabled." in out
     assert "SingerId: 13, AlbumId: Russell, AlbumTitle: Morales" in out

--- a/samples/samples/backup_sample_test.py
+++ b/samples/samples/backup_sample_test.py
@@ -43,7 +43,7 @@ RETENTION_DATABASE_ID = unique_database_id()
 RETENTION_PERIOD = "7d"
 
 
-# @pytest.mark.dependency(name="create_backup")
+@pytest.mark.dependency(name="create_backup")
 def test_create_backup(capsys, instance_id, sample_database):
     version_time = None
     with sample_database.snapshot() as snapshot:
@@ -60,7 +60,7 @@ def test_create_backup(capsys, instance_id, sample_database):
     assert BACKUP_ID in out
 
 
-# @pytest.mark.dependency(name="create_backup_with_encryption_key")
+@pytest.mark.dependency(name="create_backup_with_encryption_key")
 def test_create_backup_with_encryption_key(
     capsys, instance_id, sample_database, kms_key_name,
 ):
@@ -75,7 +75,7 @@ def test_create_backup_with_encryption_key(
     assert kms_key_name in out
 
 
-# @pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup"])
 @RetryErrors(exception=DeadlineExceeded, max_tries=2)
 def test_restore_database(capsys, instance_id, sample_database):
     backup_sample.restore_database(instance_id, RESTORE_DB_ID, BACKUP_ID)
@@ -85,7 +85,7 @@ def test_restore_database(capsys, instance_id, sample_database):
     assert BACKUP_ID in out
 
 
-# @pytest.mark.dependency(depends=["create_backup_with_encryption_key"])
+@pytest.mark.dependency(depends=["create_backup_with_encryption_key"])
 @RetryErrors(exception=DeadlineExceeded, max_tries=2)
 def test_restore_database_with_encryption_key(
     capsys, instance_id, sample_database, kms_key_name,
@@ -99,7 +99,7 @@ def test_restore_database_with_encryption_key(
     assert kms_key_name in out
 
 
-# @pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup"])
 def test_list_backup_operations(capsys, instance_id, sample_database):
     backup_sample.list_backup_operations(
         instance_id, sample_database.database_id)
@@ -108,7 +108,7 @@ def test_list_backup_operations(capsys, instance_id, sample_database):
     assert sample_database.database_id in out
 
 
-# @pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup"])
 def test_list_backups(capsys, instance_id, sample_database):
     backup_sample.list_backups(
         instance_id, sample_database.database_id, BACKUP_ID,
@@ -118,21 +118,21 @@ def test_list_backups(capsys, instance_id, sample_database):
     assert id_count == 7
 
 
-# @pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup"])
 def test_update_backup(capsys, instance_id):
     backup_sample.update_backup(instance_id, BACKUP_ID)
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
 
 
-# @pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup"])
 def test_delete_backup(capsys, instance_id):
     backup_sample.delete_backup(instance_id, BACKUP_ID)
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
 
 
-# @pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup"])
 def test_cancel_backup(capsys, instance_id, sample_database):
     backup_sample.cancel_backup(
         instance_id, sample_database.database_id, BACKUP_ID,

--- a/samples/samples/backup_sample_test.py
+++ b/samples/samples/backup_sample_test.py
@@ -11,21 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import time
 import uuid
 
 from google.api_core.exceptions import DeadlineExceeded
-from google.cloud import spanner
 import pytest
 from test_utils.retry import RetryErrors
 
 import backup_sample
-from snippets_test import cleanup_old_instances
 
 
-def unique_instance_id():
-    """ Creates a unique id for the database. """
-    return f"test-instance-{uuid.uuid4().hex[:10]}"
+@pytest.fixture(scope="module")
+def sample_name():
+    return "backup"
 
 
 def unique_database_id():
@@ -38,8 +35,6 @@ def unique_backup_id():
     return f"test-backup-{uuid.uuid4().hex[:10]}"
 
 
-INSTANCE_ID = unique_instance_id()
-DATABASE_ID = unique_database_id()
 RESTORE_DB_ID = unique_database_id()
 BACKUP_ID = unique_backup_id()
 CMEK_RESTORE_DB_ID = unique_database_id()
@@ -48,121 +43,100 @@ RETENTION_DATABASE_ID = unique_database_id()
 RETENTION_PERIOD = "7d"
 
 
-@pytest.fixture(scope="module")
-def spanner_instance():
-    spanner_client = spanner.Client()
-    cleanup_old_instances(spanner_client)
-    instance_config = "{}/instanceConfigs/{}".format(
-        spanner_client.project_name, "regional-us-central1"
-    )
-    instance = spanner_client.instance(
-        INSTANCE_ID,
-        instance_config,
-        labels={
-            "cloud_spanner_samples": "true",
-            "sample_name": "backup",
-            "created": str(int(time.time()))
-        }
-    )
-    op = instance.create()
-    op.result(120)  # block until completion
-    yield instance
-    for database_pb in instance.list_databases():
-        database = instance.database(database_pb.name.split("/")[-1])
-        database.drop()
-    for backup_pb in instance.list_backups():
-        backup = instance.backup(backup_pb.name.split("/")[-1])
-        backup.delete()
-    instance.delete()
-
-
-@pytest.fixture(scope="module")
-def database(spanner_instance):
-    """ Creates a temporary database that is removed after testing. """
-    db = spanner_instance.database(DATABASE_ID)
-    db.create()
-    yield db
-    db.drop()
-
-
-def test_create_backup(capsys, database):
+# @pytest.mark.dependency(name="create_backup")
+def test_create_backup(capsys, instance_id, sample_database):
     version_time = None
-    with database.snapshot() as snapshot:
+    with sample_database.snapshot() as snapshot:
         results = snapshot.execute_sql("SELECT CURRENT_TIMESTAMP()")
         version_time = list(results)[0][0]
 
-    backup_sample.create_backup(INSTANCE_ID, DATABASE_ID, BACKUP_ID, version_time)
+    backup_sample.create_backup(
+        instance_id,
+        sample_database.database_id,
+        BACKUP_ID,
+        version_time,
+    )
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
 
 
-def test_create_backup_with_encryption_key(capsys, spanner_instance, database):
-    kms_key_name = "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}".format(
-        spanner_instance._client.project, "us-central1", "spanner-test-keyring", "spanner-test-cmek"
+# @pytest.mark.dependency(name="create_backup_with_encryption_key")
+def test_create_backup_with_encryption_key(
+    capsys, instance_id, sample_database, kms_key_name,
+):
+    backup_sample.create_backup_with_encryption_key(
+        instance_id,
+        sample_database.database_id,
+        CMEK_BACKUP_ID,
+        kms_key_name,
     )
-    backup_sample.create_backup_with_encryption_key(INSTANCE_ID, DATABASE_ID, CMEK_BACKUP_ID, kms_key_name)
     out, _ = capsys.readouterr()
     assert CMEK_BACKUP_ID in out
     assert kms_key_name in out
 
 
-# Depends on test_create_backup having run first
+# @pytest.mark.dependency(depends=["create_backup"])
 @RetryErrors(exception=DeadlineExceeded, max_tries=2)
-def test_restore_database(capsys):
-    backup_sample.restore_database(INSTANCE_ID, RESTORE_DB_ID, BACKUP_ID)
+def test_restore_database(capsys, instance_id, sample_database):
+    backup_sample.restore_database(instance_id, RESTORE_DB_ID, BACKUP_ID)
     out, _ = capsys.readouterr()
-    assert (DATABASE_ID + " restored to ") in out
+    assert (sample_database.database_id + " restored to ") in out
     assert (RESTORE_DB_ID + " from backup ") in out
     assert BACKUP_ID in out
 
 
-# Depends on test_create_backup having run first
+# @pytest.mark.dependency(depends=["create_backup_with_encryption_key"])
 @RetryErrors(exception=DeadlineExceeded, max_tries=2)
-def test_restore_database_with_encryption_key(capsys, spanner_instance):
-    kms_key_name = "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}".format(
-        spanner_instance._client.project, "us-central1", "spanner-test-keyring", "spanner-test-cmek"
-    )
-    backup_sample.restore_database_with_encryption_key(INSTANCE_ID, CMEK_RESTORE_DB_ID, CMEK_BACKUP_ID, kms_key_name)
+def test_restore_database_with_encryption_key(
+    capsys, instance_id, sample_database, kms_key_name,
+):
+    backup_sample.restore_database_with_encryption_key(
+        instance_id, CMEK_RESTORE_DB_ID, CMEK_BACKUP_ID, kms_key_name)
     out, _ = capsys.readouterr()
-    assert (DATABASE_ID + " restored to ") in out
+    assert (sample_database.database_id + " restored to ") in out
     assert (CMEK_RESTORE_DB_ID + " from backup ") in out
     assert CMEK_BACKUP_ID in out
     assert kms_key_name in out
 
 
-# Depends on test_create_backup having run first
-def test_list_backup_operations(capsys, spanner_instance):
-    backup_sample.list_backup_operations(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["create_backup"])
+def test_list_backup_operations(capsys, instance_id, sample_database):
+    backup_sample.list_backup_operations(
+        instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
-    assert DATABASE_ID in out
+    assert sample_database.database_id in out
 
 
-# Depends on test_create_backup having run first
-def test_list_backups(capsys, spanner_instance):
-    backup_sample.list_backups(INSTANCE_ID, DATABASE_ID, BACKUP_ID)
+# @pytest.mark.dependency(depends=["create_backup"])
+def test_list_backups(capsys, instance_id, sample_database):
+    backup_sample.list_backups(
+        instance_id, sample_database.database_id, BACKUP_ID,
+    )
     out, _ = capsys.readouterr()
     id_count = out.count(BACKUP_ID)
     assert id_count == 7
 
 
-# Depends on test_create_backup having run first
-def test_update_backup(capsys):
-    backup_sample.update_backup(INSTANCE_ID, BACKUP_ID)
+# @pytest.mark.dependency(depends=["create_backup"])
+def test_update_backup(capsys, instance_id):
+    backup_sample.update_backup(instance_id, BACKUP_ID)
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
 
 
-# Depends on test_create_backup having run first
-def test_delete_backup(capsys, spanner_instance):
-    backup_sample.delete_backup(INSTANCE_ID, BACKUP_ID)
+# @pytest.mark.dependency(depends=["create_backup"])
+def test_delete_backup(capsys, instance_id):
+    backup_sample.delete_backup(instance_id, BACKUP_ID)
     out, _ = capsys.readouterr()
     assert BACKUP_ID in out
 
 
-# Depends on test_create_backup having run first
-def test_cancel_backup(capsys):
-    backup_sample.cancel_backup(INSTANCE_ID, DATABASE_ID, BACKUP_ID)
+# @pytest.mark.dependency(depends=["create_backup"])
+def test_cancel_backup(capsys, instance_id, sample_database):
+    backup_sample.cancel_backup(
+        instance_id, sample_database.database_id, BACKUP_ID,
+    )
     out, _ = capsys.readouterr()
     cancel_success = "Backup creation was successfully cancelled." in out
     cancel_failure = ("Backup was created before the cancel completed." in out) and (
@@ -172,10 +146,12 @@ def test_cancel_backup(capsys):
 
 
 @RetryErrors(exception=DeadlineExceeded, max_tries=2)
-def test_create_database_with_retention_period(capsys, spanner_instance):
-    backup_sample.create_database_with_version_retention_period(INSTANCE_ID, RETENTION_DATABASE_ID, RETENTION_PERIOD)
+def test_create_database_with_retention_period(capsys, sample_instance):
+    backup_sample.create_database_with_version_retention_period(
+        sample_instance.instance_id, RETENTION_DATABASE_ID, RETENTION_PERIOD,
+    )
     out, _ = capsys.readouterr()
     assert (RETENTION_DATABASE_ID + " created with ") in out
     assert ("retention period " + RETENTION_PERIOD) in out
-    database = spanner_instance.database(RETENTION_DATABASE_ID)
+    database = sample_instance.database(RETENTION_DATABASE_ID)
     database.drop()

--- a/samples/samples/conftest.py
+++ b/samples/samples/conftest.py
@@ -1,0 +1,130 @@
+# Copyright 2021 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Shared pytest fixtures."""
+
+import time
+import uuid
+
+from google.cloud.spanner_v1 import backup
+from google.cloud.spanner_v1 import client
+from google.cloud.spanner_v1 import database
+from google.cloud.spanner_v1 import instance
+import pytest
+from test_utils import retry
+
+
+@pytest.fixture(scope="module")
+def sample_name():
+    """ Sample testcase modules must define this fixture.
+
+    The name is used to label the instance created by the sample, to
+    aid in debugging leaked instances.
+    """
+    raise NotImplementedError("Define 'sample_name' fixture in sample test driver")
+
+
+@pytest.fixture(scope="session")
+def spanner_client():
+    """Shared client used across all samples in a session."""
+    return client.Client()
+
+
+@pytest.fixture(scope="session")
+def cleanup_old_instances(spanner_client):
+    """Delete instances, created by samples, that are older than an hour."""
+    cutoff = int(time.time()) - 1 * 60 * 60
+    instance_filter = "labels.cloud_spanner_samples:true"
+
+    for instance_pb in spanner_client.list_instances(filter_=instance_filter):
+        inst = instance.Instance.from_pb(instance_pb, spanner_client)
+
+        if "created" in inst.labels:
+            create_time = int(inst.labels["created"])
+
+            if create_time <= cutoff:
+
+                for backup_pb in inst.list_backups():
+                    backup.Backup.from_pb(backup_pb, inst).delete()
+
+                inst.delete()
+
+
+@pytest.fixture(scope="module")
+def instance_id():
+    """Unique id for the instance used in samples."""
+    return f"test-instance-{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture(scope="module")
+def instance_config(spanner_client):
+    return "{}/instanceConfigs/{}".format(
+        spanner_client.project_name, "regional-us-central1"
+    )
+
+
+@pytest.fixture(scope="module")
+def sample_instance(
+    spanner_client,
+    cleanup_old_instances,
+    instance_id,
+    instance_config,
+    sample_name,
+):
+    sample_instance = spanner_client.instance(
+        instance_id,
+        instance_config,
+        labels={
+            "cloud_spanner_samples": "true",
+            "sample_name": sample_name,
+            "created": str(int(time.time()))
+        },
+    )
+    op = sample_instance.create()
+    op.result(120)  # block until completion
+
+    # Eventual consistency check
+    retry_found = retry.RetryResult(bool)
+    retry_found(sample_instance.exists)()
+
+    yield sample_instance
+
+    for database_pb in sample_instance.list_databases():
+        database.Database.from_pb(database_pb, sample_instance).drop()
+
+    for backup_pb in sample_instance.list_backups():
+        backup.Backup.from_pb(backup_pb, sample_instance).delete()
+
+    sample_instance.delete()
+
+
+@pytest.fixture(scope="module")
+def database_id():
+    """Id for the database used in samples.
+
+    Sample testcase modules can override as needed.
+    """
+    return "my-database-id"
+
+
+@pytest.fixture(scope="module")
+def sample_database(sample_instance, database_id):
+
+    sample_database = sample_instance.database(database_id)
+
+    if not sample_database.exists():
+        sample_database.create()
+
+    yield sample_database
+
+    sample_database.drop()

--- a/samples/samples/conftest.py
+++ b/samples/samples/conftest.py
@@ -125,6 +125,7 @@ def database_ddl():
     """
     return []
 
+
 @pytest.fixture(scope="module")
 def sample_database(sample_instance, database_id, database_ddl):
 

--- a/samples/samples/conftest.py
+++ b/samples/samples/conftest.py
@@ -128,3 +128,13 @@ def sample_database(sample_instance, database_id):
     yield sample_database
 
     sample_database.drop()
+
+
+@pytest.fixture(scope="module")
+def kms_key_name(spanner_client):
+    return "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}".format(
+        spanner_client.project,
+        "us-central1",
+        "spanner-test-keyring",
+        "spanner-test-cmek",
+    )

--- a/samples/samples/conftest.py
+++ b/samples/samples/conftest.py
@@ -118,9 +118,19 @@ def database_id():
 
 
 @pytest.fixture(scope="module")
-def sample_database(sample_instance, database_id):
+def database_ddl():
+    """Sequence of DDL statements used to set up the database.
 
-    sample_database = sample_instance.database(database_id)
+    Sample testcase modules can override as needed.
+    """
+    return []
+
+@pytest.fixture(scope="module")
+def sample_database(sample_instance, database_id, database_ddl):
+
+    sample_database = sample_instance.database(
+        database_id, ddl_statements=database_ddl,
+    )
 
     if not sample_database.exists():
         sample_database.create()

--- a/samples/samples/quickstart.py
+++ b/samples/samples/quickstart.py
@@ -15,22 +15,22 @@
 # limitations under the License.
 
 
-def run_quickstart():
+def run_quickstart(instance_id, database_id):
     # [START spanner_quickstart]
     # Imports the Google Cloud Client Library.
     from google.cloud import spanner
 
+    # Your Cloud Spanner instance ID.
+    # instance_id = "my-instance-id"
+    #
+    # Your Cloud Spanner database ID.
+    # database_id = "my-database-id"
+
     # Instantiate a client.
     spanner_client = spanner.Client()
 
-    # Your Cloud Spanner instance ID.
-    instance_id = "my-instance-id"
-
     # Get a Cloud Spanner instance by ID.
     instance = spanner_client.instance(instance_id)
-
-    # Your Cloud Spanner database ID.
-    database_id = "my-database-id"
 
     # Get a Cloud Spanner database by ID.
     database = instance.database(database_id)

--- a/samples/samples/quickstart_test.py
+++ b/samples/samples/quickstart_test.py
@@ -12,88 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-import uuid
-
-from google.cloud import spanner
-import mock
 import pytest
 
 import quickstart
-from snippets_test import cleanup_old_instances
 
 
-def unique_instance_id():
-    """Creates a unique id for the database."""
-    return f"test-instance-{uuid.uuid4().hex[:10]}"
+@pytest.fixture(scope="module")
+def sample_name():
+    return "quickstart"
 
 
-INSTANCE_ID = unique_instance_id()
-
-
-def create_instance():
-    spanner_client = spanner.Client()
-    cleanup_old_instances(spanner_client)
-    instance_config = "{}/instanceConfigs/{}".format(
-        spanner_client.project_name, "regional-us-central1"
-    )
-    instance = spanner_client.instance(
-        INSTANCE_ID,
-        instance_config,
-        labels={
-            "cloud_spanner_samples": "true",
-            "sample_name": "quickstart",
-            "created": str(int(time.time()))
-        },
-    )
-    op = instance.create()
-    op.result(120)  # block until completion
-
-
-@pytest.fixture
-def patch_instance():
-    original_instance = spanner.Client.instance
-
-    spanner_client = spanner.Client()
-    cleanup_old_instances(spanner_client)
-    create_instance()
-
-    def new_instance(self, unused_instance_name):
-        return original_instance(self, INSTANCE_ID)
-
-    instance_patch = mock.patch(
-        "google.cloud.spanner_v1.Client.instance",
-        side_effect=new_instance,
-        autospec=True,
-    )
-
-    with instance_patch:
-        yield
-
-
-@pytest.fixture
-def example_database():
-    spanner_client = spanner.Client()
-    instance = spanner_client.instance(INSTANCE_ID)
-    database = instance.database("my-database-id")
-
-    if not database.exists():
-        database.create()
-
-    yield
-
-
-def drop_instance():
-    spanner_client = spanner.Client()
-    instance = spanner_client.instance(INSTANCE_ID)
-    instance.delete()
-
-
-def test_quickstart(capsys, patch_instance, example_database):
-    quickstart.run_quickstart()
+def test_quickstart(capsys, instance_id, sample_database):
+    quickstart.run_quickstart(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
-
-    # Drop created instance before verifying output.
-    drop_instance()
 
     assert "[1]" in out

--- a/samples/samples/requirements-test.txt
+++ b/samples/samples/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==6.2.4
+pytest-dependency==0.5.1
 mock==4.0.3
 google-cloud-testutils==0.3.0

--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -47,7 +47,7 @@ def create_instance(instance_id):
         node_count=1,
         labels={
             "cloud_spanner_samples": "true",
-            "sample_name": "snippets-create_instance",
+            "sample_name": "snippets-create_instance-explicit",
             "created": str(int(time.time()))
         }
     )

--- a/samples/samples/snippets_test.py
+++ b/samples/samples/snippets_test.py
@@ -118,14 +118,14 @@ def test_create_database_with_encryption_config(capsys, instance_id, cmek_databa
     assert kms_key_name in out
 
 
-# @pytest.mark.dependency(name="insert_data")
+@pytest.mark.dependency(name="insert_data")
 def test_insert_data(capsys, instance_id, sample_database):
     snippets.insert_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted data" in out
 
 
-# @pytest.mark.dependency(depends=["insert_data"])
+@pytest.mark.dependency(depends=["insert_data"])
 def test_delete_data(capsys, instance_id, sample_database):
     snippets.delete_data(instance_id, sample_database.database_id)
     # put it back for other tests
@@ -134,28 +134,28 @@ def test_delete_data(capsys, instance_id, sample_database):
     assert "Deleted data" in out
 
 
-# @pytest.mark.dependency(depends=["insert_data"])
+@pytest.mark.dependency(depends=["insert_data"])
 def test_query_data(capsys, instance_id, sample_database):
     snippets.query_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk" in out
 
 
-# @pytest.mark.dependency(name="add_column", depends=["insert_data"])
+@pytest.mark.dependency(name="add_column", depends=["insert_data"])
 def test_add_column(capsys, instance_id, sample_database):
     snippets.add_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Added the MarketingBudget column." in out
 
 
-# @pytest.mark.dependency(depends=["insert_data"])
+@pytest.mark.dependency(depends=["insert_data"])
 def test_read_data(capsys, instance_id, sample_database):
     snippets.read_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk" in out
 
 
-# @pytest.mark.dependency(name="update_data", depends=["add_column"])
+@pytest.mark.dependency(name="update_data", depends=["add_column"])
 def test_update_data(capsys, instance_id, sample_database):
     # Sleep for 15 seconds to ensure previous inserts will be
     # 'stale' by the time test_read_stale_data is run.
@@ -166,7 +166,7 @@ def test_update_data(capsys, instance_id, sample_database):
     assert "Updated data." in out
 
 
-# @pytest.mark.dependency(depends=["update_data"])
+@pytest.mark.dependency(depends=["update_data"])
 def test_read_stale_data(capsys, instance_id, sample_database):
     # This snippet relies on test_update_data inserting data
     # at least 15 seconds after the previous insert
@@ -175,14 +175,14 @@ def test_read_stale_data(capsys, instance_id, sample_database):
     assert "SingerId: 1, AlbumId: 1, MarketingBudget: None" in out
 
 
-# @pytest.mark.dependency(depends=["add_column"])
+@pytest.mark.dependency(depends=["add_column"])
 def test_read_write_transaction(capsys, instance_id, sample_database):
     snippets.read_write_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Transaction complete" in out
 
 
-# @pytest.mark.dependency(depends=["add_column"])
+@pytest.mark.dependency(depends=["add_column"])
 def test_query_data_with_new_column(capsys, instance_id, sample_database):
     snippets.query_data_with_new_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -190,14 +190,14 @@ def test_query_data_with_new_column(capsys, instance_id, sample_database):
     assert "SingerId: 2, AlbumId: 2, MarketingBudget: 300000" in out
 
 
-# @pytest.mark.dependency(name="add_index", depends=["insert_data"])
+@pytest.mark.dependency(name="add_index", depends=["insert_data"])
 def test_add_index(capsys, instance_id, sample_database):
     snippets.add_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Added the AlbumsByAlbumTitle index" in out
 
 
-# @pytest.mark.dependency(depends=["add_index"])
+@pytest.mark.dependency(depends=["add_index"])
 def test_query_data_with_index(capsys, instance_id, sample_database):
     snippets.query_data_with_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -206,7 +206,7 @@ def test_query_data_with_index(capsys, instance_id, sample_database):
     assert "Green" not in out
 
 
-# @pytest.mark.dependency(depends=["add_index"])
+@pytest.mark.dependency(depends=["add_index"])
 def test_read_data_with_index(capsys, instance_id, sample_database):
     snippets.read_data_with_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -215,21 +215,21 @@ def test_read_data_with_index(capsys, instance_id, sample_database):
     assert "Green" in out
 
 
-# @pytest.mark.dependency(name="add_storing_index", depends=["insert_data"])
+@pytest.mark.dependency(name="add_storing_index", depends=["insert_data"])
 def test_add_storing_index(capsys, instance_id, sample_database):
     snippets.add_storing_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Added the AlbumsByAlbumTitle2 index." in out
 
 
-# @pytest.mark.dependency(depends=["add_storing_index"])
+@pytest.mark.dependency(depends=["add_storing_index"])
 def test_read_data_with_storing_index(capsys, instance_id, sample_database):
     snippets.read_data_with_storing_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "300000" in out
 
 
-# @pytest.mark.dependency(depends=["insert_data"])
+@pytest.mark.dependency(depends=["insert_data"])
 def test_read_only_transaction(capsys, instance_id, sample_database):
     snippets.read_only_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -237,21 +237,21 @@ def test_read_only_transaction(capsys, instance_id, sample_database):
     assert out.count("SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk") == 2
 
 
-# @pytest.mark.dependency(name="add_timestamp_column", depends=["insert_data"])
+@pytest.mark.dependency(name="add_timestamp_column", depends=["insert_data"])
 def test_add_timestamp_column(capsys, instance_id, sample_database):
     snippets.add_timestamp_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert 'Altered table "Albums" on database ' in out
 
 
-# @pytest.mark.dependency(depends=["add_timestamp_column"])
+@pytest.mark.dependency(depends=["add_timestamp_column"])
 def test_update_data_with_timestamp(capsys, instance_id, sample_database):
     snippets.update_data_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Updated data" in out
 
 
-# @pytest.mark.dependency(depends=["add_timestamp_column"])
+@pytest.mark.dependency(depends=["add_timestamp_column"])
 def test_query_data_with_timestamp(capsys, instance_id, sample_database):
     snippets.query_data_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -259,35 +259,35 @@ def test_query_data_with_timestamp(capsys, instance_id, sample_database):
     assert "SingerId: 2, AlbumId: 2, MarketingBudget: 750000" in out
 
 
-# @pytest.mark.dependency(name="create_table_with_timestamp"))
+@pytest.mark.dependency(name="create_table_with_timestamp")
 def test_create_table_with_timestamp(capsys, instance_id, sample_database):
     snippets.create_table_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Created Performances table on database" in out
 
 
-# @pytest.mark.dependency(depends=["test_create_table_with_datatypes"])
+@pytest.mark.dependency(depends=["create_table_with_datatypes"])
 def test_insert_data_with_timestamp(capsys, instance_id, sample_database):
     snippets.insert_data_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted data." in out
 
 
-# @pytest.mark.dependency(name="write_struct_data")
+@pytest.mark.dependency(name="write_struct_data")
 def test_write_struct_data(capsys, instance_id, sample_database):
     snippets.write_struct_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted sample data for STRUCT queries" in out
 
 
-# @pytest.mark.dependency(depends=["write_struct_data"])
+@pytest.mark.dependency(depends=["write_struct_data"])
 def test_query_with_struct(capsys, instance_id, sample_database):
     snippets.query_with_struct(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 6" in out
 
 
-# @pytest.mark.dependency(depends=["write_struct_data"])
+@pytest.mark.dependency(depends=["write_struct_data"])
 def test_query_with_array_of_struct(capsys, instance_id, sample_database):
     snippets.query_with_array_of_struct(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -296,14 +296,14 @@ def test_query_with_array_of_struct(capsys, instance_id, sample_database):
     assert "SingerId: 6" in out
 
 
-# @pytest.mark.dependency(depends=["write_struct_data"])
+@pytest.mark.dependency(depends=["write_struct_data"])
 def test_query_struct_field(capsys, instance_id, sample_database):
     snippets.query_struct_field(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 6" in out
 
 
-# @pytest.mark.dependency(depends=["write_struct_data"])
+@pytest.mark.dependency(depends=["write_struct_data"])
 def test_query_nested_struct_field(capsys, instance_id, sample_database):
     snippets.query_nested_struct_field(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -311,14 +311,14 @@ def test_query_nested_struct_field(capsys, instance_id, sample_database):
     assert "SingerId: 9 SongName: Imagination" in out
 
 
-# @pytest.mark.dependency(name="insert_data_with_dml")
+@pytest.mark.dependency(name="insert_data_with_dml")
 def test_insert_data_with_dml(capsys, instance_id, sample_database):
     snippets.insert_data_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) inserted." in out
 
 
-# @pytest.mark.dependency(name="log_commit_stats")
+@pytest.mark.dependency(name="log_commit_stats")
 def test_log_commit_stats(capsys, instance_id, sample_database):
     snippets.log_commit_stats(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -326,28 +326,28 @@ def test_log_commit_stats(capsys, instance_id, sample_database):
     assert "3 mutation(s) in transaction." in out
 
 
-# @pytest.mark.dependency(depends=["insert_data"])
+@pytest.mark.dependency(depends=["insert_data"])
 def test_update_data_with_dml(capsys, instance_id, sample_database):
     snippets.update_data_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) updated." in out
 
 
-# @pytest.mark.dependency(depends=["insert_data"])
+@pytest.mark.dependency(depends=["insert_data"])
 def test_delete_data_with_dml(capsys, instance_id, sample_database):
     snippets.delete_data_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) deleted." in out
 
 
-# @pytest.mark.dependency(depends=["add_timestamp_column"])
+@pytest.mark.dependency(depends=["add_timestamp_column"])
 def test_update_data_with_dml_timestamp(capsys, instance_id, sample_database):
     snippets.update_data_with_dml_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "2 record(s) updated." in out
 
 
-# @pytest.mark.dependency(name="dml_write_read_transaction")
+@pytest.mark.dependency(name="dml_write_read_transaction")
 def test_dml_write_read_transaction(capsys, instance_id, sample_database):
     snippets.dml_write_read_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -355,72 +355,72 @@ def test_dml_write_read_transaction(capsys, instance_id, sample_database):
     assert "FirstName: Timothy, LastName: Campbell" in out
 
 
-# @pytest.mark.dependency(depends=["dml_write_read_transaction"])
+@pytest.mark.dependency(depends=["dml_write_read_transaction"])
 def test_update_data_with_dml_struct(capsys, instance_id, sample_database):
     snippets.update_data_with_dml_struct(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) updated" in out
 
 
-# @pytest.mark.dependency(name="insert_with_dml")
+@pytest.mark.dependency(name="insert_with_dml")
 def test_insert_with_dml(capsys, instance_id, sample_database):
     snippets.insert_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "4 record(s) inserted" in out
 
 
-# @pytest.mark.dependency(depends=["insert_with_dml"])
+@pytest.mark.dependency(depends=["insert_with_dml"])
 def test_query_data_with_parameter(capsys, instance_id, sample_database):
     snippets.query_data_with_parameter(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 12, FirstName: Melissa, LastName: Garcia" in out
 
 
-# @pytest.mark.dependency(depends=["add_column"])
+@pytest.mark.dependency(depends=["add_column"])
 def test_write_with_dml_transaction(capsys, instance_id, sample_database):
     snippets.write_with_dml_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Transferred 200000 from Album2's budget to Album1's" in out
 
 
-# @pytest.mark.dependency(depends=["add_column"])
+@pytest.mark.dependency(depends=["add_column"])
 def update_data_with_partitioned_dml(capsys, instance_id, sample_database):
     snippets.update_data_with_partitioned_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "3 record(s) updated" in out
 
 
-# @pytest.mark.dependency(depends=["insert_with_dml"])
+@pytest.mark.dependency(depends=["insert_with_dml"])
 def test_delete_data_with_partitioned_dml(capsys, instance_id, sample_database):
     snippets.delete_data_with_partitioned_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "6 record(s) deleted" in out
 
 
-# @pytest.mark.dependency(depends=["add_column"])
+@pytest.mark.dependency(depends=["add_column"])
 def test_update_with_batch_dml(capsys, instance_id, sample_database):
     snippets.update_with_batch_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Executed 2 SQL statements using Batch DML" in out
 
 
-# @pytest.mark.dependency(name="create_table_with_datatypes")
+@pytest.mark.dependency(name="create_table_with_datatypes")
 def test_create_table_with_datatypes(capsys, instance_id, sample_database):
     snippets.create_table_with_datatypes(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Created Venues table on database" in out
 
 
-# @pytest.mark.dependency(
-#     name="insert_datatypes_data", depends=["create_table_with_datatypes"],
-# )
+@pytest.mark.dependency(
+    name="insert_datatypes_data", depends=["create_table_with_datatypes"],
+)
 def test_insert_datatypes_data(capsys, instance_id, sample_database):
     snippets.insert_datatypes_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted data." in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_array(capsys, instance_id, sample_database):
     snippets.query_data_with_array(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -428,21 +428,21 @@ def test_query_data_with_array(capsys, instance_id, sample_database):
     assert "VenueId: 42, VenueName: Venue 42, AvailableDate: 2020-10-01" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_bool(capsys, instance_id, sample_database):
     snippets.query_data_with_bool(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 19, VenueName: Venue 19, OutdoorVenue: True" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_bytes(capsys, instance_id, sample_database):
     snippets.query_data_with_bytes(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_date(capsys, instance_id, sample_database):
     snippets.query_data_with_date(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -450,7 +450,7 @@ def test_query_data_with_date(capsys, instance_id, sample_database):
     assert "VenueId: 42, VenueName: Venue 42, LastContactDate: 2018-10-01" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_float(capsys, instance_id, sample_database):
     snippets.query_data_with_float(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -458,7 +458,7 @@ def test_query_data_with_float(capsys, instance_id, sample_database):
     assert "VenueId: 19, VenueName: Venue 19, PopularityScore: 0.9" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_int(capsys, instance_id, sample_database):
     snippets.query_data_with_int(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -466,37 +466,37 @@ def test_query_data_with_int(capsys, instance_id, sample_database):
     assert "VenueId: 42, VenueName: Venue 42, Capacity: 3000" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_string(capsys, instance_id, sample_database):
     snippets.query_data_with_string(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 42, VenueName: Venue 42" in out
 
 
-# @pytest.mark.dependency(
-#     name="add_numeric_column", depends=["create_table_with_datatypes"],
-# )
+@pytest.mark.dependency(
+    name="add_numeric_column", depends=["create_table_with_datatypes"],
+)
 def test_add_numeric_column(capsys, instance_id, sample_database):
     snippets.add_numeric_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert 'Altered table "Venues" on database ' in out
 
 
-# @pytest.mark.dependency(depends=["add_numeric_column"])
+@pytest.mark.dependency(depends=["add_numeric_column", "insert_datatypes_data"])
 def test_update_data_with_numeric(capsys, instance_id, sample_database):
     snippets.update_data_with_numeric(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Updated data" in out
 
 
-# @pytest.mark.dependency(depends=["add_numeric_column"])
+@pytest.mark.dependency(depends=["add_numeric_column"])
 def test_query_data_with_numeric_parameter(capsys, instance_id, sample_database):
     snippets.query_data_with_numeric_parameter(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, Revenue: 35000" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_timestamp_parameter(capsys, instance_id, sample_database):
     snippets.query_data_with_timestamp_parameter(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -505,7 +505,7 @@ def test_query_data_with_timestamp_parameter(capsys, instance_id, sample_databas
     assert "VenueId: 42, VenueName: Venue 42, LastUpdateTime:" in out
 
 
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_query_data_with_query_options(capsys, instance_id, sample_database):
     snippets.query_data_with_query_options(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
@@ -518,7 +518,7 @@ def test_query_data_with_query_options(capsys, instance_id, sample_database):
     "Failure is due to the package being missing on the backend."
     "See: https://github.com/googleapis/python-spanner/issues/421"
 )
-# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+@pytest.mark.dependency(depends=["insert_datatypes_data"])
 def test_create_client_with_query_options(capsys, instance_id, sample_database):
     snippets.create_client_with_query_options(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()

--- a/samples/samples/snippets_test.py
+++ b/samples/samples/snippets_test.py
@@ -24,428 +24,490 @@ from test_utils.retry import RetryErrors
 
 import snippets
 
+CREATE_TABLE_SINGERS = """\
+CREATE TABLE Singers (
+    SingerId     INT64 NOT NULL,
+    FirstName    STRING(1024),
+    LastName     STRING(1024),
+    SingerInfo   BYTES(MAX)
+) PRIMARY KEY (SingerId)
+"""
+CREATE_TABLE_ALBUMS= """\
+CREATE TABLE Albums (
+    SingerId     INT64 NOT NULL,
+    AlbumId      INT64 NOT NULL,
+    AlbumTitle   STRING(MAX)
+) PRIMARY KEY (SingerId, AlbumId),
+INTERLEAVE IN PARENT Singers ON DELETE CASCADE
+"""
 
-def unique_instance_id():
-    """ Creates a unique id for the database. """
-    return f"test-instance-{uuid.uuid4().hex[:10]}"
-
-
-def unique_database_id():
-    """ Creates a unique id for the database. """
-    return f"test-db-{uuid.uuid4().hex[:10]}"
-
-
-def cleanup_old_instances(spanner_client):
-    # Delete test instances that are older than an hour.
-    cutoff = int(time.time()) - 1 * 60 * 60
-    instance_pbs = spanner_client.list_instances("labels.cloud_spanner_samples:true")
-    for instance_pb in instance_pbs:
-        instance = Instance.from_pb(instance_pb, spanner_client)
-        if "created" not in instance.labels:
-            continue
-        create_time = int(instance.labels["created"])
-        if create_time > cutoff:
-            continue
-
-        for backup_pb in instance.list_backups():
-            backup = Backup.from_pb(backup_pb, instance)
-            backup.delete()
-
-        instance.delete()
-
-
-INSTANCE_ID = unique_instance_id()
-LCI_INSTANCE_ID = unique_instance_id()
-DATABASE_ID = unique_database_id()
-CMEK_DATABASE_ID = unique_database_id()
+@pytest.fixture(scope="module")
+def sample_name():
+    return "snippets"
 
 
 @pytest.fixture(scope="module")
-def spanner_instance():
-    spanner_client = spanner.Client()
-    cleanup_old_instances(spanner_client)
-    snippets.create_instance(INSTANCE_ID)
-    instance = spanner_client.instance(INSTANCE_ID)
-    yield instance
+def create_instance_id():
+    """ Id for the low-cost instance. """
+    return f"create-instance-{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture(scope="module")
+def lci_instance_id():
+    """ Id for the low-cost instance. """
+    return f"lci-instance-{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture(scope="module")
+def database_id():
+    return f"test-db-{uuid.uuid4().hex[:10]}"
+
+@pytest.fixture(scope="module")
+def create_database_id():
+    return f"create-db-{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture(scope="module")
+def cmek_database_id():
+    return f"cmek-db-{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture(scope="module")
+def database_ddl():
+    """Sequence of DDL statements used to set up the database.
+
+    Sample testcase modules can override as needed.
+    """
+    return [CREATE_TABLE_SINGERS, CREATE_TABLE_ALBUMS]
+
+
+def test_create_instance_explicit(spanner_client, create_instance_id):
+    # Rather than re-use 'sample_isntance', we create a new instance, to
+    # ensure that the 'create_instance' snippet is tested.
+    snippets.create_instance(create_instance_id)
+    instance = spanner_client.instance(create_instance_id)
     instance.delete()
 
 
-@pytest.fixture(scope="module")
-def database(spanner_instance):
-    """ Creates a temporary database that is removed after testing. """
-    snippets.create_database(INSTANCE_ID, DATABASE_ID)
-    db = spanner_instance.database(DATABASE_ID)
-    yield db
-    db.drop()
+def test_create_database_explicit(sample_instance, create_database_id):
+    # Rather than re-use 'sample_database', we create a new database, to
+    # ensure that the 'create_database' snippet is tested.
+    snippets.create_database(sample_instance.instance_id, create_database_id)
+    database = sample_instance.database(create_database_id)
+    database.drop()
 
 
-def test_create_instance(spanner_instance):
-    # Reload will only succeed if the instance exists.
-    spanner_instance.reload()
-
-
-def test_create_instance_with_processing_units(capsys):
+def test_create_instance_with_processing_units(capsys, lci_instance_id):
     processing_units = 500
     retry_429 = RetryErrors(exceptions.ResourceExhausted, delay=15)
     retry_429(snippets.create_instance_with_processing_units)(
-        LCI_INSTANCE_ID, processing_units,
+        lci_instance_id, processing_units,
     )
     out, _ = capsys.readouterr()
-    assert LCI_INSTANCE_ID in out
+    assert lci_instance_id in out
     assert "{} processing units".format(processing_units) in out
     spanner_client = spanner.Client()
-    instance = spanner_client.instance(LCI_INSTANCE_ID)
+    instance = spanner_client.instance(lci_instance_id)
     instance.delete()
 
 
-def test_create_database(database):
-    # Reload will only succeed if the database exists.
-    database.reload()
-
-
-def test_create_database_with_encryption_config(capsys, spanner_instance):
-    kms_key_name = "projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}".format(
-        spanner_instance._client.project, "us-central1", "spanner-test-keyring", "spanner-test-cmek"
-    )
-    snippets.create_database_with_encryption_key(INSTANCE_ID, CMEK_DATABASE_ID, kms_key_name)
+def test_create_database_with_encryption_config(capsys, instance_id, cmek_database_id, kms_key_name):
+    snippets.create_database_with_encryption_key(instance_id, cmek_database_id, kms_key_name)
     out, _ = capsys.readouterr()
-    assert CMEK_DATABASE_ID in out
+    assert cmek_database_id in out
     assert kms_key_name in out
 
 
-def test_insert_data(capsys):
-    snippets.insert_data(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="insert_data")
+def test_insert_data(capsys, instance_id, sample_database):
+    snippets.insert_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted data" in out
 
 
-def test_delete_data(capsys):
-    snippets.delete_data(INSTANCE_ID, DATABASE_ID)
-    snippets.insert_data(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_data"])
+def test_delete_data(capsys, instance_id, sample_database):
+    snippets.delete_data(instance_id, sample_database.database_id)
+    # put it back for other tests
+    snippets.insert_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Deleted data" in out
 
 
-def test_query_data(capsys):
-    snippets.query_data(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_data"])
+def test_query_data(capsys, instance_id, sample_database):
+    snippets.query_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk" in out
 
 
-def test_add_column(capsys):
-    snippets.add_column(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="add_column", depends=["insert_data"])
+def test_add_column(capsys, instance_id, sample_database):
+    snippets.add_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Added the MarketingBudget column." in out
 
 
-def test_read_data(capsys):
-    snippets.read_data(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_data"])
+def test_read_data(capsys, instance_id, sample_database):
+    snippets.read_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk" in out
 
 
-def test_update_data(capsys):
+# @pytest.mark.dependency(name="update_data", depends=["add_column"])
+def test_update_data(capsys, instance_id, sample_database):
     # Sleep for 15 seconds to ensure previous inserts will be
     # 'stale' by the time test_read_stale_data is run.
     time.sleep(15)
 
-    snippets.update_data(INSTANCE_ID, DATABASE_ID)
+    snippets.update_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Updated data." in out
 
 
-def test_read_stale_data(capsys):
+# @pytest.mark.dependency(depends=["update_data"])
+def test_read_stale_data(capsys, instance_id, sample_database):
     # This snippet relies on test_update_data inserting data
     # at least 15 seconds after the previous insert
-    snippets.read_stale_data(INSTANCE_ID, DATABASE_ID)
+    snippets.read_stale_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, MarketingBudget: None" in out
 
 
-def test_read_write_transaction(capsys):
-    snippets.read_write_transaction(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_column"])
+def test_read_write_transaction(capsys, instance_id, sample_database):
+    snippets.read_write_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Transaction complete" in out
 
 
-def test_query_data_with_new_column(capsys):
-    snippets.query_data_with_new_column(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_column"])
+def test_query_data_with_new_column(capsys, instance_id, sample_database):
+    snippets.query_data_with_new_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, MarketingBudget: 300000" in out
     assert "SingerId: 2, AlbumId: 2, MarketingBudget: 300000" in out
 
 
-def test_add_index(capsys):
-    snippets.add_index(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="add_index", depends=["insert_data"])
+def test_add_index(capsys, instance_id, sample_database):
+    snippets.add_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Added the AlbumsByAlbumTitle index" in out
 
 
-def test_query_data_with_index(capsys):
-    snippets.query_data_with_index(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_index"])
+def test_query_data_with_index(capsys, instance_id, sample_database):
+    snippets.query_data_with_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Go, Go, Go" in out
     assert "Forever Hold Your Peace" in out
     assert "Green" not in out
 
 
-def test_read_data_with_index(capsys):
-    snippets.read_data_with_index(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_index"])
+def test_read_data_with_index(capsys, instance_id, sample_database):
+    snippets.read_data_with_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Go, Go, Go" in out
     assert "Forever Hold Your Peace" in out
     assert "Green" in out
 
 
-def test_add_storing_index(capsys):
-    snippets.add_storing_index(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="add_storing_index", depends=["insert_data"])
+def test_add_storing_index(capsys, instance_id, sample_database):
+    snippets.add_storing_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Added the AlbumsByAlbumTitle2 index." in out
 
 
-def test_read_data_with_storing_index(capsys):
-    snippets.read_data_with_storing_index(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_storing_index"])
+def test_read_data_with_storing_index(capsys, instance_id, sample_database):
+    snippets.read_data_with_storing_index(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "300000" in out
 
 
-def test_read_only_transaction(capsys):
-    snippets.read_only_transaction(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_data"])
+def test_read_only_transaction(capsys, instance_id, sample_database):
+    snippets.read_only_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     # Snippet does two reads, so entry should be listed twice
     assert out.count("SingerId: 1, AlbumId: 1, AlbumTitle: Total Junk") == 2
 
 
-def test_add_timestamp_column(capsys):
-    snippets.add_timestamp_column(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="add_timestamp_column", depends=["insert_data"])
+def test_add_timestamp_column(capsys, instance_id, sample_database):
+    snippets.add_timestamp_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert 'Altered table "Albums" on database ' in out
 
 
-def test_update_data_with_timestamp(capsys):
-    snippets.update_data_with_timestamp(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_timestamp_column"])
+def test_update_data_with_timestamp(capsys, instance_id, sample_database):
+    snippets.update_data_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Updated data" in out
 
 
-def test_query_data_with_timestamp(capsys):
-    snippets.query_data_with_timestamp(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_timestamp_column"])
+def test_query_data_with_timestamp(capsys, instance_id, sample_database):
+    snippets.query_data_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 1, AlbumId: 1, MarketingBudget: 1000000" in out
     assert "SingerId: 2, AlbumId: 2, MarketingBudget: 750000" in out
 
 
-def test_create_table_with_timestamp(capsys):
-    snippets.create_table_with_timestamp(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="create_table_with_timestamp"))
+def test_create_table_with_timestamp(capsys, instance_id, sample_database):
+    snippets.create_table_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Created Performances table on database" in out
 
 
-def test_insert_data_with_timestamp(capsys):
-    snippets.insert_data_with_timestamp(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["test_create_table_with_datatypes"])
+def test_insert_data_with_timestamp(capsys, instance_id, sample_database):
+    snippets.insert_data_with_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted data." in out
 
 
-def test_write_struct_data(capsys):
-    snippets.write_struct_data(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="write_struct_data")
+def test_write_struct_data(capsys, instance_id, sample_database):
+    snippets.write_struct_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted sample data for STRUCT queries" in out
 
 
-def test_query_with_struct(capsys):
-    snippets.query_with_struct(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["write_struct_data"])
+def test_query_with_struct(capsys, instance_id, sample_database):
+    snippets.query_with_struct(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 6" in out
 
 
-def test_query_with_array_of_struct(capsys):
-    snippets.query_with_array_of_struct(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["write_struct_data"])
+def test_query_with_array_of_struct(capsys, instance_id, sample_database):
+    snippets.query_with_array_of_struct(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 8" in out
     assert "SingerId: 7" in out
     assert "SingerId: 6" in out
 
 
-def test_query_struct_field(capsys):
-    snippets.query_struct_field(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["write_struct_data"])
+def test_query_struct_field(capsys, instance_id, sample_database):
+    snippets.query_struct_field(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 6" in out
 
 
-def test_query_nested_struct_field(capsys):
-    snippets.query_nested_struct_field(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["write_struct_data"])
+def test_query_nested_struct_field(capsys, instance_id, sample_database):
+    snippets.query_nested_struct_field(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 6 SongName: Imagination" in out
     assert "SingerId: 9 SongName: Imagination" in out
 
 
-def test_insert_data_with_dml(capsys):
-    snippets.insert_data_with_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="insert_data_with_dml")
+def test_insert_data_with_dml(capsys, instance_id, sample_database):
+    snippets.insert_data_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) inserted." in out
 
 
-def test_log_commit_stats(capsys):
-    snippets.log_commit_stats(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="log_commit_stats")
+def test_log_commit_stats(capsys, instance_id, sample_database):
+    snippets.log_commit_stats(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) inserted." in out
     assert "3 mutation(s) in transaction." in out
 
 
-def test_update_data_with_dml(capsys):
-    snippets.update_data_with_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_data"])
+def test_update_data_with_dml(capsys, instance_id, sample_database):
+    snippets.update_data_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) updated." in out
 
 
-def test_delete_data_with_dml(capsys):
-    snippets.delete_data_with_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_data"])
+def test_delete_data_with_dml(capsys, instance_id, sample_database):
+    snippets.delete_data_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) deleted." in out
 
 
-def test_update_data_with_dml_timestamp(capsys):
-    snippets.update_data_with_dml_timestamp(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_timestamp_column"])
+def test_update_data_with_dml_timestamp(capsys, instance_id, sample_database):
+    snippets.update_data_with_dml_timestamp(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "2 record(s) updated." in out
 
 
-def test_dml_write_read_transaction(capsys):
-    snippets.dml_write_read_transaction(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="dml_write_read_transaction")
+def test_dml_write_read_transaction(capsys, instance_id, sample_database):
+    snippets.dml_write_read_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) inserted." in out
     assert "FirstName: Timothy, LastName: Campbell" in out
 
 
-def test_update_data_with_dml_struct(capsys):
-    snippets.update_data_with_dml_struct(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["dml_write_read_transaction"])
+def test_update_data_with_dml_struct(capsys, instance_id, sample_database):
+    snippets.update_data_with_dml_struct(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) updated" in out
 
 
-def test_insert_with_dml(capsys):
-    snippets.insert_with_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="insert_with_dml")
+def test_insert_with_dml(capsys, instance_id, sample_database):
+    snippets.insert_with_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "4 record(s) inserted" in out
 
 
-def test_query_data_with_parameter(capsys):
-    snippets.query_data_with_parameter(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_with_dml"])
+def test_query_data_with_parameter(capsys, instance_id, sample_database):
+    snippets.query_data_with_parameter(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "SingerId: 12, FirstName: Melissa, LastName: Garcia" in out
 
 
-def test_write_with_dml_transaction(capsys):
-    snippets.write_with_dml_transaction(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_column"])
+def test_write_with_dml_transaction(capsys, instance_id, sample_database):
+    snippets.write_with_dml_transaction(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Transferred 200000 from Album2's budget to Album1's" in out
 
 
-def update_data_with_partitioned_dml(capsys):
-    snippets.update_data_with_partitioned_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_column"])
+def update_data_with_partitioned_dml(capsys, instance_id, sample_database):
+    snippets.update_data_with_partitioned_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "3 record(s) updated" in out
 
 
-def delete_data_with_partitioned_dml(capsys):
-    snippets.delete_data_with_partitioned_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_with_dml"])
+def test_delete_data_with_partitioned_dml(capsys, instance_id, sample_database):
+    snippets.delete_data_with_partitioned_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
-    assert "5 record(s) deleted" in out
+    assert "6 record(s) deleted" in out
 
 
-def update_with_batch_dml(capsys):
-    snippets.update_with_batch_dml(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_column"])
+def test_update_with_batch_dml(capsys, instance_id, sample_database):
+    snippets.update_with_batch_dml(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Executed 2 SQL statements using Batch DML" in out
 
 
-def test_create_table_with_datatypes(capsys):
-    snippets.create_table_with_datatypes(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(name="create_table_with_datatypes")
+def test_create_table_with_datatypes(capsys, instance_id, sample_database):
+    snippets.create_table_with_datatypes(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Created Venues table on database" in out
 
 
-def test_insert_datatypes_data(capsys):
-    snippets.insert_datatypes_data(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(
+#     name="insert_datatypes_data", depends=["create_table_with_datatypes"],
+# )
+def test_insert_datatypes_data(capsys, instance_id, sample_database):
+    snippets.insert_datatypes_data(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Inserted data." in out
 
 
-def test_query_data_with_array(capsys):
-    snippets.query_data_with_array(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_array(capsys, instance_id, sample_database):
+    snippets.query_data_with_array(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 19, VenueName: Venue 19, AvailableDate: 2020-11-01" in out
     assert "VenueId: 42, VenueName: Venue 42, AvailableDate: 2020-10-01" in out
 
 
-def test_query_data_with_bool(capsys):
-    snippets.query_data_with_bool(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_bool(capsys, instance_id, sample_database):
+    snippets.query_data_with_bool(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 19, VenueName: Venue 19, OutdoorVenue: True" in out
 
 
-def test_query_data_with_bytes(capsys):
-    snippets.query_data_with_bytes(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_bytes(capsys, instance_id, sample_database):
+    snippets.query_data_with_bytes(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4" in out
 
 
-def test_query_data_with_date(capsys):
-    snippets.query_data_with_date(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_date(capsys, instance_id, sample_database):
+    snippets.query_data_with_date(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4, LastContactDate: 2018-09-02" in out
     assert "VenueId: 42, VenueName: Venue 42, LastContactDate: 2018-10-01" in out
 
 
-def test_query_data_with_float(capsys):
-    snippets.query_data_with_float(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_float(capsys, instance_id, sample_database):
+    snippets.query_data_with_float(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4, PopularityScore: 0.8" in out
     assert "VenueId: 19, VenueName: Venue 19, PopularityScore: 0.9" in out
 
 
-def test_query_data_with_int(capsys):
-    snippets.query_data_with_int(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_int(capsys, instance_id, sample_database):
+    snippets.query_data_with_int(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 19, VenueName: Venue 19, Capacity: 6300" in out
     assert "VenueId: 42, VenueName: Venue 42, Capacity: 3000" in out
 
 
-def test_query_data_with_string(capsys):
-    snippets.query_data_with_string(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_string(capsys, instance_id, sample_database):
+    snippets.query_data_with_string(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 42, VenueName: Venue 42" in out
 
 
-def test_add_numeric_column(capsys):
-    snippets.add_numeric_column(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(
+#     name="add_numeric_column", depends=["create_table_with_datatypes"],
+# )
+def test_add_numeric_column(capsys, instance_id, sample_database):
+    snippets.add_numeric_column(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert 'Altered table "Venues" on database ' in out
 
 
-def test_update_data_with_numeric(capsys):
-    snippets.update_data_with_numeric(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_numeric_column"])
+def test_update_data_with_numeric(capsys, instance_id, sample_database):
+    snippets.update_data_with_numeric(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "Updated data" in out
 
 
-def test_query_data_with_numeric_parameter(capsys):
-    snippets.query_data_with_numeric_parameter(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["add_numeric_column"])
+def test_query_data_with_numeric_parameter(capsys, instance_id, sample_database):
+    snippets.query_data_with_numeric_parameter(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, Revenue: 35000" in out
 
 
-def test_query_data_with_timestamp_parameter(capsys):
-    snippets.query_data_with_timestamp_parameter(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_timestamp_parameter(capsys, instance_id, sample_database):
+    snippets.query_data_with_timestamp_parameter(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4, LastUpdateTime:" in out
     assert "VenueId: 19, VenueName: Venue 19, LastUpdateTime:" in out
     assert "VenueId: 42, VenueName: Venue 42, LastUpdateTime:" in out
 
 
-def test_query_data_with_query_options(capsys):
-    snippets.query_data_with_query_options(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_query_data_with_query_options(capsys, instance_id, sample_database):
+    snippets.query_data_with_query_options(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4, LastUpdateTime:" in out
     assert "VenueId: 19, VenueName: Venue 19, LastUpdateTime:" in out
@@ -456,8 +518,9 @@ def test_query_data_with_query_options(capsys):
     "Failure is due to the package being missing on the backend."
     "See: https://github.com/googleapis/python-spanner/issues/421"
 )
-def test_create_client_with_query_options(capsys):
-    snippets.create_client_with_query_options(INSTANCE_ID, DATABASE_ID)
+# @pytest.mark.dependency(depends=["insert_datatypes_data"])
+def test_create_client_with_query_options(capsys, instance_id, sample_database):
+    snippets.create_client_with_query_options(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "VenueId: 4, VenueName: Venue 4, LastUpdateTime:" in out
     assert "VenueId: 19, VenueName: Venue 19, LastUpdateTime:" in out

--- a/samples/samples/snippets_test.py
+++ b/samples/samples/snippets_test.py
@@ -17,8 +17,6 @@ import uuid
 
 from google.api_core import exceptions
 from google.cloud import spanner
-from google.cloud.spanner_v1.instance import Backup
-from google.cloud.spanner_v1.instance import Instance
 import pytest
 from test_utils.retry import RetryErrors
 
@@ -32,7 +30,8 @@ CREATE TABLE Singers (
     SingerInfo   BYTES(MAX)
 ) PRIMARY KEY (SingerId)
 """
-CREATE_TABLE_ALBUMS= """\
+
+CREATE_TABLE_ALBUMS = """\
 CREATE TABLE Albums (
     SingerId     INT64 NOT NULL,
     AlbumId      INT64 NOT NULL,
@@ -40,6 +39,7 @@ CREATE TABLE Albums (
 ) PRIMARY KEY (SingerId, AlbumId),
 INTERLEAVE IN PARENT Singers ON DELETE CASCADE
 """
+
 
 @pytest.fixture(scope="module")
 def sample_name():
@@ -61,6 +61,7 @@ def lci_instance_id():
 @pytest.fixture(scope="module")
 def database_id():
     return f"test-db-{uuid.uuid4().hex[:10]}"
+
 
 @pytest.fixture(scope="module")
 def create_database_id():


### PR DESCRIPTION
- [x] Move shared fixtures to `samples/samples/conftest.py`.
- [x] Parameterize to allow overriding e.g. the `sample_name` label.
- [x] Add explicit tests for the `create_instance` and `create_database` samples.
- [x] Drop use of `mock.patch` for instance:  just yield the already-created one for fixture use.
- [x] Add `pytest-dependency` plugin, which skips dependent samples if dependency has failed.

Per discussion with @larkee in PR #418.
