### PR TITLE
fix(samples): batch_update() results processing error

### DIFF
--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -1509,6 +1509,8 @@ def delete_data_with_partitioned_dml(instance_id, database_id):
 def update_with_batch_dml(instance_id, database_id):
     """Updates sample data in the database using Batch DML. """
     # [START spanner_dml_batch_update]
+    from google.rpc.code_pb2 import OK
+
     # instance_id = "your-spanner-instance"
     # database_id = "your-spanner-db-id"
 
@@ -1531,9 +1533,11 @@ def update_with_batch_dml(instance_id, database_id):
     def update_albums(transaction):
         status, row_cts = transaction.batch_update([insert_statement, update_statement])
 
-        # check response status and process error (if occurred)
-        # if status.code != rpc.code_pb2.OK:
-        # ...
+        if status.code != OK:
+            # Do handling here.
+            # Note: the error will still be raised when
+            # commit is called by `run_in_transaction`.
+            return
 
         print("Executed {} SQL statements using Batch DML.".format(len(row_cts)))
 

--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -1529,7 +1529,11 @@ def update_with_batch_dml(instance_id, database_id):
     )
 
     def update_albums(transaction):
-        row_cts = transaction.batch_update([insert_statement, update_statement])
+        status, row_cts = transaction.batch_update([insert_statement, update_statement])
+
+        # check response status and process error (if occurred)
+        # if status.code != rpc.code_pb2.OK:
+        # ...
 
         print("Executed {} SQL statements using Batch DML.".format(len(row_cts)))
 

--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -1535,8 +1535,8 @@ def update_with_batch_dml(instance_id, database_id):
 
         if status.code != OK:
             # Do handling here.
-            # Note: the error will still be raised when
-            # commit is called by `run_in_transaction`.
+            # Note: the exception will still be raised when
+            # `commit` is called by `run_in_transaction`.
             return
 
         print("Executed {} SQL statements using Batch DML.".format(len(row_cts)))


### PR DESCRIPTION
The original `batch_update()` method [returns two values](https://github.com/googleapis/python-spanner/blob/5629bacf780cf79c3af4cda3de50986c82e18c0d/google/cloud/spanner_v1/transaction.py#L315-L321): batch status and row counts, while the sample accepts only one value from the method call (and checks its length, which is always equal to 2).