### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ workloads.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-GA-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-spanner.svg
    :target: https://pypi.org/project/google-cloud-spanner/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-spanner.svg


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.