### PR TITLE
fix: handle google.api_core.exceptions.OutOfRange exception and throw IntegrityError

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -21,6 +21,7 @@ from google.api_core.exceptions import AlreadyExists
 from google.api_core.exceptions import FailedPrecondition
 from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import InvalidArgument
+from google.api_core.exceptions import OutOfRange
 
 from collections import namedtuple
 
@@ -241,7 +242,7 @@ class Cursor(object):
                 self.connection.database.run_in_transaction(
                     self._do_execute_update, sql, args or None
                 )
-        except (AlreadyExists, FailedPrecondition) as e:
+        except (AlreadyExists, FailedPrecondition, OutOfRange) as e:
             raise IntegrityError(e.details if hasattr(e, "details") else e)
         except InvalidArgument as e:
             raise ProgrammingError(e.details if hasattr(e, "details") else e)

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -251,6 +251,13 @@ class TestCursor(unittest.TestCase):
             with self.assertRaises(IntegrityError):
                 cursor.execute(sql="sql")
 
+        with mock.patch(
+            "google.cloud.spanner_dbapi.parse_utils.classify_stmt",
+            side_effect=exceptions.OutOfRange("message"),
+        ):
+            with self.assertRaises(IntegrityError):
+                cursor.execute("sql")
+
     def test_execute_invalid_argument(self):
         from google.api_core import exceptions
         from google.cloud.spanner_dbapi.exceptions import ProgrammingError


### PR DESCRIPTION
fix: handle google.api_core.exceptions.OutOfRange exception and throw IntegrityError as expected by dbapi standards


Fixes #570 🦕
