### PR TITLE
test: delete referencing databases before backups

### DIFF
--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -71,10 +71,21 @@ def _has_all_ddl(database):
 retry_has_all_dll = retry.RetryInstanceState(_has_all_ddl)
 
 
+def scrub_referencing_databases(to_scrub, db_list):
+    for db_name in db_list:
+        db = to_scrub.database(db_name.split("/")[-1])
+        try:
+            retry_429_503(db.delete)()
+        except exceptions.NotFound:  # lost the race
+            pass
+
+
 def scrub_instance_backups(to_scrub):
     try:
         for backup_pb in to_scrub.list_backups():
             bkp = instance_mod.Backup.from_pb(backup_pb, to_scrub)
+            # Backup cannot be deleted while referencing databases exist.
+            scrub_referencing_databases(to_scrub, bkp.referencing_databases)
             try:
                 # Instance cannot be deleted while backups exist.
                 retry_429_503(bkp.delete)()

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -83,9 +83,9 @@ def scrub_referencing_databases(to_scrub, db_list):
 def scrub_instance_backups(to_scrub):
     try:
         for backup_pb in to_scrub.list_backups():
-            bkp = instance_mod.Backup.from_pb(backup_pb, to_scrub)
             # Backup cannot be deleted while referencing databases exist.
-            scrub_referencing_databases(to_scrub, bkp.referencing_databases)
+            scrub_referencing_databases(to_scrub, backup_pb.referencing_databases)
+            bkp = instance_mod.Backup.from_pb(backup_pb, to_scrub)
             try:
                 # Instance cannot be deleted while backups exist.
                 retry_429_503(bkp.delete)()


### PR DESCRIPTION
Fixes #557
Fixes #573
Fixes #574
Fixes #575
Fixes #576
Fixes #577
Fixes #578 
Fixes #579
