### PR TITLE
samples: add samples for cross region backup

### DIFF
--- a/samples/samples/backup_sample.py
+++ b/samples/samples/backup_sample.py
@@ -330,7 +330,8 @@ def update_backup(instance_id, backup_id):
 
     # Expire time must be within 366 days of the create time of the backup.
     old_expire_time = backup.expire_time
-    new_expire_time = old_expire_time + timedelta(days=30)
+    # New expire time should be less than the max expire time
+    new_expire_time = min(backup.max_expire_time, old_expire_time + timedelta(days=30))
     backup.update_expire_time(new_expire_time)
     print(
         "Backup {} expire time was updated from {} to {}.".format(
@@ -380,6 +381,40 @@ def create_database_with_version_retention_period(instance_id, database_id, rete
 
 # [END spanner_create_database_with_version_retention_period]
 
+# [START spanner_copy_backup]
+def copy_backup(instance_id, backup_id, source_backup_id):
+    """Copied a backup for a database."""
+    spanner_client = spanner.Client()
+    instance = spanner_client.instance(instance_id)
+
+    # Create a source backup and wait for create backup operation to complete.
+    expire_time = datetime.utcnow() + timedelta(days=14)
+    source_backup = instance.backup(source_backup_id)
+    operation = source_backup.reload()
+    assert source_backup.is_ready() is True
+
+    # Create a copy backup and wait for backup operation to complete.
+    copy_backup = instance.copy_backup(backup_id, source_backup=source_backup.name, expire_time=expire_time)
+    operation = copy_backup.create()
+
+    # Wait for copy backup operation to complete.
+    operation.result(2100)
+
+    # Verify that the copy backup is ready.
+    copy_backup.reload()
+    assert copy_backup.is_ready() is True
+
+    # Get the name, create time and backup size.
+    copy_backup.reload()
+
+    print(
+        "Backup {} of size {} bytes was created at {}".format(
+            copy_backup.name, copy_backup.size_bytes, copy_backup.create_time
+        )
+    )
+
+
+# [END spanner_copy_backup]
 
 if __name__ == "__main__":  # noqa: C901
     parser = argparse.ArgumentParser(
@@ -404,6 +439,7 @@ if __name__ == "__main__":  # noqa: C901
         "list_database_operations", help=list_database_operations.__doc__
     )
     subparsers.add_parser("delete_backup", help=delete_backup.__doc__)
+    subparsers.add_parser("copy_backup", help=copy_backup.__doc__)
 
     args = parser.parse_args()
 
@@ -423,5 +459,7 @@ if __name__ == "__main__":  # noqa: C901
         list_database_operations(args.instance_id)
     elif args.command == "delete_backup":
         delete_backup(args.instance_id, args.backup_id)
+    elif args.command == "copy_backup":
+        copy_backup(args.instance_id, args.database_id, args.backup_id, args.source_backup_id)
     else:
         print("Command {} did not match expected commands.".format(args.command))

--- a/samples/samples/backup_sample_test.py
+++ b/samples/samples/backup_sample_test.py
@@ -37,8 +37,10 @@ def unique_backup_id():
 
 RESTORE_DB_ID = unique_database_id()
 BACKUP_ID = unique_backup_id()
+COPY_BACKUP_ID = unique_backup_id()
 CMEK_RESTORE_DB_ID = unique_database_id()
 CMEK_BACKUP_ID = unique_backup_id()
+CMEK_COPY_BACKUP_ID = unique_backup_id()
 RETENTION_DATABASE_ID = unique_database_id()
 RETENTION_PERIOD = "7d"
 
@@ -125,7 +127,7 @@ def test_update_backup(capsys, instance_id):
     assert BACKUP_ID in out
 
 
-@pytest.mark.dependency(depends=["create_backup"])
+@pytest.mark.dependency(depends=["create_backup","copy_backup"])
 def test_delete_backup(capsys, instance_id):
     backup_sample.delete_backup(instance_id, BACKUP_ID)
     out, _ = capsys.readouterr()
@@ -155,3 +157,16 @@ def test_create_database_with_retention_period(capsys, sample_instance):
     assert ("retention period " + RETENTION_PERIOD) in out
     database = sample_instance.database(RETENTION_DATABASE_ID)
     database.drop()
+
+@pytest.mark.dependency(name="copy_backup",depends=["create_backup"])
+def test_copy_backup(capsys, instance_id):
+    
+    backup_sample.copy_backup(
+        instance_id,
+        COPY_BACKUP_ID,
+        BACKUP_ID
+    )
+    out, _ = capsys.readouterr()
+    assert COPY_BACKUP_ID in out
+
+


### PR DESCRIPTION
Adding samples for the following operations:
1. copy_backup
2. copy_backup_with_encryption_key