### PR TITLE
chore: add yoshi-python as additional code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@
 
 # The api-spanner-python team is the default owner for anything not
 # explicitly taken by someone else.
-*                               @googleapis/api-spanner-python
+*                               @googleapis/api-spanner-python @googleapis/yoshi-python
 /samples/                       @googleapis/api-spanner-python @googleapis/python-samples-owners


### PR DESCRIPTION
I'd like to help out with [reviewing/approving/merging PRs opened by owlbot](https://github.com/search?q=is%3Apr+author%3Aapp%2Fgcf-owl-bot+is%3Aunmerged+language%3Apython+is%3Aopen+repo%3Agoogleapis%2Fpython-spanner&type=Issues). 