### PR TITLE
fix(db_api): emit warning instead of an exception for `rowcount` property

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -14,6 +14,9 @@
 
 """Database cursor for Google Cloud Spanner DB-API."""
 
+import warnings
+from collections import namedtuple
+
 import sqlparse
 
 from google.api_core.exceptions import Aborted
@@ -22,8 +25,6 @@ from google.api_core.exceptions import FailedPrecondition
 from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import InvalidArgument
 from google.api_core.exceptions import OutOfRange
-
-from collections import namedtuple
 
 from google.cloud import spanner_v1 as spanner
 from google.cloud.spanner_dbapi.checksum import ResultsChecksum
@@ -120,10 +121,12 @@ class Cursor(object):
 
         :raises: :class:`NotImplemented`.
         """
-        raise NotImplementedError(
+        warnings.warn(
             "The `rowcount` property is non-operational. Request "
             "resulting rows are streamed by the `fetch*()` methods "
-            "and can't be counted before they are all streamed."
+            "and can't be counted before they are all streamed.",
+            UserWarning,
+            stacklevel=2,
         )
 
     def _raise_if_closed(self):

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -61,11 +61,19 @@ class TestCursor(unittest.TestCase):
         self.assertIsNotNone(cursor.description)
         self.assertIsInstance(cursor.description[0], ColumnInfo)
 
-    def test_property_rowcount(self):
+    @mock.patch("warnings.warn")
+    def test_property_rowcount(self, warn_mock):
         connection = self._make_connection(self.INSTANCE, self.DATABASE)
         cursor = self._make_one(connection)
-        with self.assertRaises(NotImplementedError):
-            cursor.rowcount
+
+        cursor.rowcount
+        warn_mock.assert_called_once_with(
+            "The `rowcount` property is non-operational. Request "
+            "resulting rows are streamed by the `fetch*()` methods "
+            "and can't be counted before they are all streamed.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     def test_callproc(self):
         from google.cloud.spanner_dbapi.exceptions import InterfaceError


### PR DESCRIPTION
See for more context: https://github.com/googleapis/python-spanner-sqlalchemy/pull/134