### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "spanner",
     "name_pretty": "Cloud Spanner",
     "product_documentation": "https://cloud.google.com/spanner/docs/",
-    "client_documentation": "https://googleapis.dev/python/spanner/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/spanner/latest",
     "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ workloads.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-spanner.svg
    :target: https://pypi.org/project/google-cloud-spanner/
 .. _Cloud Spanner: https://cloud.google.com/spanner/
-.. _Client Library Documentation: https://googleapis.dev/python/spanner/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/spanner/latest
 .. _Product Documentation:  https://cloud.google.com/spanner/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.