### PR TITLE
fix: Django and SQLAlchemy APIs are failing to use rowcount

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -137,15 +137,11 @@ class Cursor(object):
     def rowcount(self):
         """The number of rows produced by the last `execute()` call.
 
-        :raises: :class:`NotImplemented`.
+        The property is non-operational and always returns -1. Request
+        resulting rows are streamed by the `fetch*()` methods and
+        can't be counted before they are all streamed.
         """
-        warnings.warn(
-            "The `rowcount` property is non-operational. Request "
-            "resulting rows are streamed by the `fetch*()` methods "
-            "and can't be counted before they are all streamed.",
-            UserWarning,
-            stacklevel=2,
-        )
+        return -1
 
     @check_not_closed
     def callproc(self, procname, args=None):

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -14,7 +14,6 @@
 
 """Database cursor for Google Cloud Spanner DB API."""
 
-import warnings
 from collections import namedtuple
 
 import sqlparse

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -61,19 +61,11 @@ class TestCursor(unittest.TestCase):
         self.assertIsNotNone(cursor.description)
         self.assertIsInstance(cursor.description[0], ColumnInfo)
 
-    @mock.patch("warnings.warn")
-    def test_property_rowcount(self, warn_mock):
+    def test_property_rowcount(self):
         connection = self._make_connection(self.INSTANCE, self.DATABASE)
         cursor = self._make_one(connection)
 
-        cursor.rowcount
-        warn_mock.assert_called_once_with(
-            "The `rowcount` property is non-operational. Request "
-            "resulting rows are streamed by the `fetch*()` methods "
-            "and can't be counted before they are all streamed.",
-            UserWarning,
-            stacklevel=2,
-        )
+        assert cursor.rowcount == -1
 
     def test_callproc(self):
         from google.cloud.spanner_dbapi.exceptions import InterfaceError


### PR DESCRIPTION
Towards:
https://github.com/googleapis/python-spanner-sqlalchemy/issues/179
https://github.com/googleapis/python-spanner-django/issues/740