### PR TITLE
chore: update supported python versions in README to >= 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ dependencies.
 
 Supported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Python >= 3.5
+Python >= 3.6
 
 Deprecated Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update supported python versions in README to >= 3.6, in line with setup.py which indicates python_requires=">=3.6".