### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v2 release

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,7 @@ def default(session):
     # Install all test dependencies, then install this package in-place.
     session.install("asyncmock", "pytest-asyncio")
 
-    session.install("mock", "pytest", "pytest-cov")
+    session.install("mock", "pytest", "pytest-cov", "pytz")
     session.install("-e", ".")
 
     # Run py.test against the unit tests.
@@ -143,7 +143,7 @@ def system(session):
     # Install all test dependencies, then install this package into the
     # virtualenv's dist-packages.
     session.install(
-        "mock", "pytest", "google-cloud-testutils",
+        "mock", "pytest", "google-cloud-testutils", "pytz",
     )
     session.install("-e", ".[tracing]")
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ version = "2.1.0"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core[grpc] >= 1.22.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "google-cloud-core >= 1.4.1, < 2.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "libcst >= 0.2.5",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ version = "2.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
-    "google-cloud-core >= 1.4.1, < 2.0dev",
+    "google-cloud-core >= 1.4.1, < 3.0dev",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     "libcst >= 0.2.5",
     "proto-plus == 1.11.0",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -87,7 +87,9 @@ class TestClient(unittest.TestCase):
 
         self.assertIs(client._credentials, expected_creds)
         if expected_scopes is not None:
-            creds.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
+            creds.with_scopes.assert_called_once_with(
+                expected_scopes, default_scopes=None
+            )
 
         self.assertEqual(client.project, self.PROJECT)
         self.assertIs(client._client_info, expected_client_info)
@@ -234,7 +236,9 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
+        credentials.with_scopes.assert_called_once_with(
+            expected_scopes, default_scopes=None
+        )
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_instance_admin_api_emulator_env(self, mock_em):
@@ -332,7 +336,9 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
+        credentials.with_scopes.assert_called_once_with(
+            expected_scopes, default_scopes=None
+        )
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_database_admin_api_emulator_env(self, mock_em):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -87,7 +87,7 @@ class TestClient(unittest.TestCase):
 
         self.assertIs(client._credentials, expected_creds)
         if expected_scopes is not None:
-            creds.with_scopes.assert_called_once_with(expected_scopes)
+            creds.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
 
         self.assertEqual(client.project, self.PROJECT)
         self.assertIs(client._client_info, expected_client_info)
@@ -234,7 +234,7 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes)
+        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_instance_admin_api_emulator_env(self, mock_em):
@@ -332,7 +332,7 @@ class TestClient(unittest.TestCase):
             credentials=mock.ANY, client_info=client_info, client_options=client_options
         )
 
-        credentials.with_scopes.assert_called_once_with(expected_scopes)
+        credentials.with_scopes.assert_called_once_with(expected_scopes, default_scopes=None)
 
     @mock.patch("google.cloud.spanner_v1.client._get_spanner_emulator_host")
     def test_database_admin_api_emulator_env(self, mock_em):


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v2**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566