### PR TITLE
fix: add session.exists() check in PingingPool.get() method.

### DIFF
--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -387,15 +387,14 @@ class PingingPool(AbstractSessionPool):
         if timeout is None:
             timeout = self.default_timeout
 
-        ping_after, session = self._sessions.get(block=True, timeout=timeout)
+        _, session = self._sessions.get(block=True, timeout=timeout)
 
-        if _NOW() > ping_after:
-            # Using session.exists() guarantees the returned session exists.
-            # session.ping() uses a cached result in the backend which could
-            # result in a recently deleted session being returned.
-            if not session.exists():
-                session = self._new_session()
-                session.create()
+        # Using session.exists() guarantees the returned session exists.
+        # session.ping() uses a cached result in the backend which could
+        # result in a recently deleted session being returned.
+        if not session.exists():
+            session = self._new_session()
+            session.create()
 
         return session
 

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -433,7 +433,7 @@ class TestPingingPool(unittest.TestCase):
         session = pool.get()
 
         self.assertIs(session, SESSIONS[0])
-        self.assertFalse(session._exists_checked)
+        self.assertTrue(session._exists_checked)
         self.assertFalse(pool._sessions.full())
 
     def test_get_hit_w_ping(self):


### PR DESCRIPTION
`PingingPool` currently checks if session exists in `.get()` method only when `_NOW() > ping_after`.  If the session is used in any query and then returned the pool then the ping_after is reset to `_NOW() _  + delta`. If the session is deleted in the backend and the checkout gives a not found error the session will still get returned to the pool with a reset for `ping_after = _NOW() _  + delta`.

As described in the comment in `get()` method.

> Using session.exists() guarantees the returned session exists.
> session.ping() uses a cached result in the backend which could
> result in a recently deleted session being returned.

Example:
An Application using `PingingPool` with 1 Session. The session has been killed on the server side, but the `ping` method has not cleared out the session from the pool yet because [ping_after > _NOW()](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/pool.py#L435) is not `True`.

Now `pool.get()` will return the session, and [SnapshotCheckout](https://github.com/googleapis/python-spanner/blob/828df62d1e14dd83003897c5b9ad58592fdff852/google/cloud/spanner_v1/database.py#L858) will use the session and fail and return the session back into the [pool](https://github.com/googleapis/python-spanner/blob/828df62d1e14dd83003897c5b9ad58592fdff852/google/cloud/spanner_v1/database.py#L865).

Put Method will put the session in the pool with a new [wait_time](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/pool.py#L402), and the process will continue. 

To avoid this inside the `__exit__` method of `SessionCheckout` we should check if `NOT_FOUND` error was raised or not. If that error was raised then create a new session and push it inside the pool.