### PR TITLE
fix: add NOT_FOUND  error check in __exit__ method of SessionCheckout.

### DIFF
--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -868,6 +868,12 @@ class SnapshotCheckout(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """End ``with`` block."""
+        if isinstance(exc_val, NotFound):
+            # If NotFound exception occurs inside the with block
+            # then we validate if the session still exists.
+            if not self._session.exists():
+                self._session = self._database._pool._new_session()
+                self._session.create()
         self._database._pool.put(self._session)
 
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -17,7 +17,6 @@ import unittest
 
 import mock
 from google.api_core import gapic_v1
-from google.cloud.exceptions import NotFound
 from google.cloud.spanner_v1.param_types import INT64
 from google.api_core.retry import Retry
 
@@ -1793,7 +1792,6 @@ class TestSnapshotCheckout(_BaseTest):
         self.assertIs(pool._session, session)
 
     def test_context_mgr_session_not_found_error(self):
-        from google.cloud.spanner_v1.database import SnapshotCheckout
         from google.cloud.exceptions import NotFound
 
         database = _Database(self.DATABASE_NAME)
@@ -1809,14 +1807,12 @@ class TestSnapshotCheckout(_BaseTest):
 
         self.assertEqual(pool._session, session)
         with self.assertRaises(NotFound):
-            with checkout as snapshot:
-                raise NotFound(f"Session not found")
+            with checkout as _:
+                raise NotFound("Session not found")
         # Assert that session-1 was removed from pool and new session was added.
         self.assertEqual(pool._session, new_session)
 
     def test_context_mgr_unknown_error(self):
-        from google.cloud.spanner_v1.database import SnapshotCheckout
-
         database = _Database(self.DATABASE_NAME)
         session = _Session(database)
         pool = database._pool = _Pool()
@@ -1829,8 +1825,8 @@ class TestSnapshotCheckout(_BaseTest):
 
         self.assertEqual(pool._session, session)
         with self.assertRaises(Testing):
-            with checkout as snapshot:
-                raise Testing(f"Session not found")
+            with checkout as _:
+                raise Testing("Unknown error.")
         # Assert that session-1 was not removed from pool.
         self.assertEqual(pool._session, session)
         pool._new_session.assert_not_called()


### PR DESCRIPTION
`PingingPool` currently checks if session exists in `.get()` method only when `_NOW() > ping_after`.  If the session is used in any query and then returned the pool then the ping_after is reset to `_NOW() _  + delta`. If the session is deleted in the backend and the checkout gives a not found error the session will still get returned to the pool with a reset for `ping_after = _NOW() _  + delta`.

As described in the comment in `get()` method.

> Using session.exists() guarantees the returned session exists.
> session.ping() uses a cached result in the backend which could
> result in a recently deleted session being returned.

Example:
An Application using `PingingPool` with 1 Session. The session has been killed on the server side, but the `ping` method has not cleared out the session from the pool yet because [ping_after > _NOW()](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/pool.py#L435) is not `True`.

Now `pool.get()` will return the session, and [SnapshotCheckout](https://github.com/googleapis/python-spanner/blob/828df62d1e14dd83003897c5b9ad58592fdff852/google/cloud/spanner_v1/database.py#L858) will use the session and fail and return the session back into the [pool](https://github.com/googleapis/python-spanner/blob/828df62d1e14dd83003897c5b9ad58592fdff852/google/cloud/spanner_v1/database.py#L865).

Put Method will put the session in the pool with a new [wait_time](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/pool.py#L402), and the process will continue. 

To avoid this inside the `__exit__` method of `SessionCheckout` we should check if `NOT_FOUND` error was raised or not. If that error was raised then create a new session and push it inside the pool.