### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,0 +1,18 @@
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
+google-api-core==1.31.5
+google-cloud-core==1.4.1
+grpc-google-iam-v1==0.12.4
+libcst==0.2.5
+proto-plus==1.15.0
+sqlparse==0.3.0
+opentelemetry-api==1.1.0
+opentelemetry-sdk==1.1.0
+opentelemetry-instrumentation==0.20b0
+packaging==14.3
+protobuf==3.19.0


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6