### PR TITLE
fix: don't use a list for empty arguments

### DIFF
--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -233,7 +233,7 @@ def sql_pyformat_args_to_spanner(sql, params):
               arguments.
     """
     if not params:
-        return sanitize_literals_for_upload(sql), params
+        return sanitize_literals_for_upload(sql), None
 
     found_pyformat_placeholders = RE_PYFORMAT.findall(sql)
     params_is_dict = isinstance(params, dict)


### PR DESCRIPTION
On SQLAlchemy dialect label I've noticed an error:

```python
File "/home/runner/work/python-spanner-sqlalchemy/python-spanner-sqlalchemy/.nox/compliance_test_13/lib/python3.8/site-packages/google/cloud/spanner_dbapi/connection.py", line 437, in run_statement
    _execute_insert_heterogenous(
  File "/home/runner/work/python-spanner-sqlalchemy/python-spanner-sqlalchemy/.nox/compliance_test_13/lib/python3.8/site-packages/google/cloud/spanner_dbapi/_helpers.py", line 53, in _execute_insert_heterogenous
    transaction.execute_update(sql, params, get_param_types(params))
  File "/home/runner/work/python-spanner-sqlalchemy/python-spanner-sqlalchemy/.nox/compliance_test_13/lib/python3.8/site-packages/google/cloud/spanner_dbapi/parse_utils.py", line 287, in get_param_types
    for key, value in params.items():
AttributeError: 'list' object has no attribute 'items'
```
This tiny change fixes the error.