### PR TITLE
fix: add pause for the staleness test

### DIFF
--- a/tests/system/test_dbapi.py
+++ b/tests/system/test_dbapi.py
@@ -17,6 +17,7 @@ import hashlib
 import pickle
 import pkg_resources
 import pytest
+import time
 
 from google.cloud import spanner_v1
 from google.cloud._helpers import UTC
@@ -447,6 +448,7 @@ def test_staleness(shared_instance, dbapi_database):
     cursor = conn.cursor()
 
     before_insert = datetime.datetime.utcnow().replace(tzinfo=UTC)
+    time.sleep(0.25)
 
     cursor.execute(
         """


### PR DESCRIPTION
The `test_staleness` test is checking if reading with steleness is possible. It takes the timestamp, then inserts a row, then is trying to read the database by the timestamp taken **before the insert**. However, from time to time the inserted row is read. Not 100% sure about precision Cloud Spanner is using for staleness (in the docs it's said than 10 seconds staleness is recommended as the minimal bound), but it feels like from time to time taking the timestamp and the row insertion are done too fast, so Spanner considers that the row is already inserted at the moment of the timestamp. If so, adding a small pause between taking the timestamp and row insertion should fix the problem.

Closes #752 