### PR TITLE
feat: Adding reason, domain, metadata & error_details fields in Custom Exceptions for additional info

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -281,11 +281,11 @@ class Cursor(object):
                     self._do_execute_update, sql, args or None
                 )
         except (AlreadyExists, FailedPrecondition, OutOfRange) as e:
-            raise IntegrityError(getattr(e, "details", e))
+            raise IntegrityError(getattr(e, "details", e)) from e
         except InvalidArgument as e:
-            raise ProgrammingError(getattr(e, "details", e))
+            raise ProgrammingError(getattr(e, "details", e)) from e
         except InternalServerError as e:
-            raise OperationalError(getattr(e, "details", e))
+            raise OperationalError(getattr(e, "details", e)) from e
 
     @check_not_closed
     def executemany(self, operation, seq_of_params):

--- a/google/cloud/spanner_dbapi/exceptions.py
+++ b/google/cloud/spanner_dbapi/exceptions.py
@@ -36,7 +36,7 @@ class Error(Exception):
     def reason(self):
         """The reason of the error.
         Reference:
-            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+            https://cloud.google.com/apis/design/errors#error_info
         Returns:
             Union[str, None]: An optional string containing reason of the error.
         """
@@ -50,7 +50,7 @@ class Error(Exception):
     def domain(self):
         """The logical grouping to which the "reason" belongs.
         Reference:
-            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+            https://cloud.google.com/apis/design/errors#error_info
         Returns:
             Union[str, None]: An optional string containing a logical grouping to which the "reason" belongs.
         """
@@ -64,7 +64,7 @@ class Error(Exception):
     def metadata(self):
         """Additional structured details about this error.
         Reference:
-            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+            https://cloud.google.com/apis/design/errors#error_info
         Returns:
             Union[Dict[str, str], None]: An optional object containing structured details about the error.
         """
@@ -78,8 +78,8 @@ class Error(Exception):
     def details(self):
         """Information contained in google.rpc.status.details.
         Reference:
-            https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
-            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+            https://cloud.google.com/apis/design/errors#error_model
+            https://cloud.google.com/apis/design/errors#error_details
         Returns:
             Sequence[Any]: A list of structured objects from error_details.proto
         """

--- a/google/cloud/spanner_dbapi/exceptions.py
+++ b/google/cloud/spanner_dbapi/exceptions.py
@@ -14,6 +14,8 @@
 
 """Spanner DB API exceptions."""
 
+from google.api_core.exceptions import GoogleAPICallError
+
 
 class Warning(Exception):
     """Important DB API warning."""
@@ -27,7 +29,49 @@ class Error(Exception):
     Does not include :class:`Warning`.
     """
 
-    pass
+    def _is_error_cause_instance_of_google_api_exception(self):
+        return isinstance(self.__cause__, GoogleAPICallError)
+
+    @property
+    def reason(self):
+        """The reason of the error.
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+        Returns:
+            Union[str, None]: An optional string containing reason of the error.
+        """
+        return self.__cause__.reason if self._is_error_cause_instance_of_google_api_exception() else None
+
+    @property
+    def domain(self):
+        """The logical grouping to which the "reason" belongs.
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+        Returns:
+            Union[str, None]: An optional string containing a logical grouping to which the "reason" belongs.
+        """
+        return self.__cause__.domain if self._is_error_cause_instance_of_google_api_exception() else None
+
+    @property
+    def metadata(self):
+        """Additional structured details about this error.
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto#L112
+        Returns:
+            Union[Dict[str, str], None]: An optional object containing structured details about the error.
+        """
+        return self.__cause__.metadata if self._is_error_cause_instance_of_google_api_exception() else None
+
+    @property
+    def details(self):
+        """Information contained in google.rpc.status.details.
+        Reference:
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
+            https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+        Returns:
+            Sequence[Any]: A list of structured objects from error_details.proto
+        """
+        return self.__cause__.details if self._is_error_cause_instance_of_google_api_exception() else None
 
 
 class InterfaceError(Error):

--- a/google/cloud/spanner_dbapi/exceptions.py
+++ b/google/cloud/spanner_dbapi/exceptions.py
@@ -40,7 +40,11 @@ class Error(Exception):
         Returns:
             Union[str, None]: An optional string containing reason of the error.
         """
-        return self.__cause__.reason if self._is_error_cause_instance_of_google_api_exception() else None
+        return (
+            self.__cause__.reason
+            if self._is_error_cause_instance_of_google_api_exception()
+            else None
+        )
 
     @property
     def domain(self):
@@ -50,7 +54,11 @@ class Error(Exception):
         Returns:
             Union[str, None]: An optional string containing a logical grouping to which the "reason" belongs.
         """
-        return self.__cause__.domain if self._is_error_cause_instance_of_google_api_exception() else None
+        return (
+            self.__cause__.domain
+            if self._is_error_cause_instance_of_google_api_exception()
+            else None
+        )
 
     @property
     def metadata(self):
@@ -60,7 +68,11 @@ class Error(Exception):
         Returns:
             Union[Dict[str, str], None]: An optional object containing structured details about the error.
         """
-        return self.__cause__.metadata if self._is_error_cause_instance_of_google_api_exception() else None
+        return (
+            self.__cause__.metadata
+            if self._is_error_cause_instance_of_google_api_exception()
+            else None
+        )
 
     @property
     def details(self):
@@ -71,7 +83,11 @@ class Error(Exception):
         Returns:
             Sequence[Any]: A list of structured objects from error_details.proto
         """
-        return self.__cause__.details if self._is_error_cause_instance_of_google_api_exception() else None
+        return (
+            self.__cause__.details
+            if self._is_error_cause_instance_of_google_api_exception()
+            else None
+        )
 
 
 class InterfaceError(Error):


### PR DESCRIPTION
Adding following properties under DBAPI exceptions to provide additional error info.
-reason
-domain
-metadata
-details