### PR TITLE
feat: Add snippets for Spanner DML with returning clause

### DIFF
--- a/samples/samples/pg_snippets_test.py
+++ b/samples/samples/pg_snippets_test.py
@@ -28,6 +28,8 @@ CREATE TABLE Singers (
     FirstName    CHARACTER VARYING(1024),
     LastName     CHARACTER VARYING(1024),
     SingerInfo   BYTEA,
+    FullName     CHARACTER VARYING(2048)
+        GENERATED ALWAYS AS (FirstName || ' ' || LastName) STORED,
     PRIMARY KEY (SingerId)
 )
 """
@@ -287,9 +289,23 @@ def test_update_data_with_dml(capsys, instance_id, sample_database):
     assert "1 record(s) updated." in out
 
 
+@pytest.mark.dependency(depends=["add_column"])
+def test_update_data_with_dml_returning(capsys, instance_id, sample_database):
+    snippets.update_data_with_dml_returning(instance_id, sample_database.database_id)
+    out, _ = capsys.readouterr()
+    assert "1 record(s) updated." in out
+
+
 @pytest.mark.dependency(depends=["insert_data"])
 def test_delete_data_with_dml(capsys, instance_id, sample_database):
     snippets.delete_data_with_dml(instance_id, sample_database.database_id)
+    out, _ = capsys.readouterr()
+    assert "1 record(s) deleted." in out
+
+
+@pytest.mark.dependency(depends=["insert_data"])
+def test_delete_data_with_dml_returning(capsys, instance_id, sample_database):
+    snippets.delete_data_with_dml_returning(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) deleted." in out
 
@@ -306,6 +322,13 @@ def test_dml_write_read_transaction(capsys, instance_id, sample_database):
 @pytest.mark.dependency(name="insert_with_dml")
 def test_insert_with_dml(capsys, instance_id, sample_database):
     snippets.insert_with_dml(instance_id, sample_database.database_id)
+    out, _ = capsys.readouterr()
+    assert "4 record(s) inserted" in out
+
+
+@pytest.mark.dependency(name="insert_with_dml_returning")
+def test_insert_with_dml_returning(capsys, instance_id, sample_database):
+    snippets.insert_with_dml_returning(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "4 record(s) inserted" in out
 
@@ -333,12 +356,12 @@ def update_data_with_partitioned_dml(capsys, instance_id, sample_database):
     assert "3 record(s) updated" in out
 
 
-@pytest.mark.dependency(depends=["insert_with_dml"])
+@pytest.mark.dependency(depends=["insert_with_dml", "insert_with_dml_returning"])
 def test_delete_data_with_partitioned_dml(capsys, instance_id, sample_database):
     snippets.delete_data_with_partitioned_dml(instance_id,
                                               sample_database.database_id)
     out, _ = capsys.readouterr()
-    assert "5 record(s) deleted" in out
+    assert "9 record(s) deleted" in out
 
 
 @pytest.mark.dependency(depends=["add_column"])


### PR DESCRIPTION
Samples are provided for INSERT, DELETE, and UPDATE in both GoogleSQL and PostgreSQL dialects. To provide a more compelling example for the INSERT case, a generated column has been added in the "create_database" example so that the generated value can be returned in the INSERT examples.