### PR TITLE
Revert "feat: Set LAR as False (#980)"

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -508,7 +508,7 @@ def connect(
     pool=None,
     user_agent=None,
     client=None,
-    route_to_leader_enabled=False,
+    route_to_leader_enabled=True,
 ):
     """Creates a connection to a Google Cloud Spanner database.
 
@@ -547,10 +547,9 @@ def connect(
 
     :type route_to_leader_enabled: boolean
     :param route_to_leader_enabled:
-        (Optional) Default False. Set route_to_leader_enabled as True to
-                   enable leader aware routing. Enabling leader aware routing
-                   would route all requests in RW/PDML transactions to the
-                   leader region.
+        (Optional) Default True. Set route_to_leader_enabled as False to
+        disable leader aware routing. Disabling leader aware routing would
+        route all requests in RW/PDML transactions to the closest region.
 
 
     :rtype: :class:`google.cloud.spanner_dbapi.connection.Connection`
@@ -568,14 +567,14 @@ def connect(
                 credentials,
                 project=project,
                 client_info=client_info,
-                route_to_leader_enabled=False,
+                route_to_leader_enabled=True,
             )
         else:
             client = spanner.Client(
                 project=project,
                 credentials=credentials,
                 client_info=client_info,
-                route_to_leader_enabled=False,
+                route_to_leader_enabled=True,
             )
     else:
         if project is not None and client.project != project:

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -116,10 +116,9 @@ class Client(ClientWithProject):
 
     :type route_to_leader_enabled: boolean
     :param route_to_leader_enabled:
-        (Optional) Default False. Set route_to_leader_enabled as True to
-                   enable leader aware routing. Enabling leader aware routing
-                   would route all requests in RW/PDML transactions to the
-                   leader region.
+        (Optional) Default True. Set route_to_leader_enabled as False to
+        disable leader aware routing. Disabling leader aware routing would
+        route all requests in RW/PDML transactions to the closest region.
 
     :raises: :class:`ValueError <exceptions.ValueError>` if both ``read_only``
              and ``admin`` are :data:`True`
@@ -139,7 +138,7 @@ class Client(ClientWithProject):
         client_info=_CLIENT_INFO,
         client_options=None,
         query_options=None,
-        route_to_leader_enabled=False,
+        route_to_leader_enabled=True,
     ):
         self._emulator_host = _get_spanner_emulator_host()
 

--- a/tests/unit/spanner_dbapi/test_connect.py
+++ b/tests/unit/spanner_dbapi/test_connect.py
@@ -86,7 +86,7 @@ class Test_connect(unittest.TestCase):
             project=PROJECT,
             credentials=credentials,
             client_info=mock.ANY,
-            route_to_leader_enabled=False,
+            route_to_leader_enabled=True,
         )
         client_info = mock_client.call_args_list[0][1]["client_info"]
         self.assertEqual(client_info.user_agent, USER_AGENT)
@@ -120,7 +120,7 @@ class Test_connect(unittest.TestCase):
             credentials_path,
             project=PROJECT,
             client_info=mock.ANY,
-            route_to_leader_enabled=False,
+            route_to_leader_enabled=True,
         )
         client_info = factory.call_args_list[0][1]["client_info"]
         self.assertEqual(client_info.user_agent, USER_AGENT)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -59,7 +59,7 @@ class TestClient(unittest.TestCase):
         client_options=None,
         query_options=None,
         expected_query_options=None,
-        route_to_leader_enabled=None,
+        route_to_leader_enabled=True,
     ):
         import google.api_core.client_options
         from google.cloud.spanner_v1 import client as MUT


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Enable leader aware routing by default. This update contains performance optimisations that will reduce the latency of read/write transactions that originate from a region other than the default leader region.
END_COMMIT_OVERRIDE
