### PR TITLE
feat: add support for PG.OID in parameterized queries

### DIFF
--- a/google/cloud/spanner_v1/param_types.py
+++ b/google/cloud/spanner_v1/param_types.py
@@ -33,6 +33,7 @@ NUMERIC = Type(code=TypeCode.NUMERIC)
 JSON = Type(code=TypeCode.JSON)
 PG_NUMERIC = Type(code=TypeCode.NUMERIC, type_annotation=TypeAnnotationCode.PG_NUMERIC)
 PG_JSONB = Type(code=TypeCode.JSON, type_annotation=TypeAnnotationCode.PG_JSONB)
+PG_OID = Type(code=TypeCode.INT64, type_annotation=TypeAnnotationCode.PG_OID)
 
 
 def Array(element_type):

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -2349,7 +2349,7 @@ def test_execute_sql_w_jsonb_bindings(
 
 
 def test_execute_sql_w_jsonb_bindings(
-        not_emulator, not_google_standard_sql, sessions_database, database_dialect
+    not_emulator, not_google_standard_sql, sessions_database, database_dialect
 ):
     _bind_test_helper(
         sessions_database,

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -2348,7 +2348,7 @@ def test_execute_sql_w_jsonb_bindings(
     )
 
 
-def test_execute_sql_w_jsonb_bindings(
+def test_execute_sql_w_oid_bindings(
     not_emulator, not_google_standard_sql, sessions_database, database_dialect
 ):
     _bind_test_helper(

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -2348,6 +2348,18 @@ def test_execute_sql_w_jsonb_bindings(
     )
 
 
+def test_execute_sql_w_jsonb_bindings(
+        not_emulator, not_google_standard_sql, sessions_database, database_dialect
+):
+    _bind_test_helper(
+        sessions_database,
+        database_dialect,
+        spanner_v1.param_types.PG_OID,
+        123,
+        [123, 456],
+    )
+
+
 def test_execute_sql_w_query_param_struct(sessions_database, not_postgres):
     name = "Phred"
     count = 123

--- a/tests/unit/test_param_types.py
+++ b/tests/unit/test_param_types.py
@@ -70,3 +70,20 @@ class Test_JsonbParamType(unittest.TestCase):
         found = param_types.PG_JSONB
 
         self.assertEqual(found, expected)
+
+
+class Test_OidParamType(unittest.TestCase):
+    def test_it(self):
+        from google.cloud.spanner_v1 import Type
+        from google.cloud.spanner_v1 import TypeCode
+        from google.cloud.spanner_v1 import TypeAnnotationCode
+        from google.cloud.spanner_v1 import param_types
+
+        expected = Type(
+            code=TypeCode.INT64,
+            type_annotation=TypeAnnotationCode.PG_OID,
+        )
+
+        found = param_types.PG_OID
+
+        self.assertEqual(found, expected)


### PR DESCRIPTION
This PR adds support for using PG.OID values in parameterized SELECT queries.

For example:
```
with database.snapshot() as snapshot:
  results = snapshot.execute_sql(
    "SELECT $1",
    params = {"p1": 123},
    param_types = {"p1": spanner.param_types.PG_OID})
    for row in results:
      print(row)
```