### PR TITLE
build: treat warnings as errors

### DIFF
--- a/docs/snapshot-usage.rst
+++ b/docs/snapshot-usage.rst
@@ -24,7 +24,7 @@ reads as of a given timestamp:
 .. code:: python
 
     import datetime
-    TIMESTAMP = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+    TIMESTAMP = datetime.datetime.now(datetime.timezone.utc)
 
     with database.snapshot(read_timestamp=TIMESTAMP) as snapshot:
         ...

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+filterwarnings =
+    # treat all warnings as errors
+    error
+    # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed
+    ignore:.*custom tp_new.*in Python 3.14:DeprecationWarning
+    # Remove once release PR https://github.com/googleapis/python-api-common-protos/pull/191 is merged
+    ignore:.*pkg_resources.declare_namespace:DeprecationWarning
+    ignore:.*pkg_resources is deprecated as an API:DeprecationWarning
+    # Remove once release PR https://github.com/googleapis/proto-plus-python/pull/391 is merged
+    ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated:DeprecationWarning:proto.datetime_helpers
+    # Remove once release PR https://github.com/googleapis/python-api-core/pull/555 is merged
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:google.api_core.datetime_helpers
+    # Remove once https://github.com/grpc/grpc/issues/35086 is fixed
+    ignore:There is no current event loop:DeprecationWarning:grpc.aio._channel

--- a/samples/samples/backup_sample.py
+++ b/samples/samples/backup_sample.py
@@ -33,7 +33,7 @@ def create_backup(instance_id, database_id, backup_id, version_time):
     database = instance.database(database_id)
 
     # Create a backup
-    expire_time = datetime.utcnow() + timedelta(days=14)
+    expire_time = datetime.now(datetime.utc) + timedelta(days=14)
     backup = instance.backup(
         backup_id, database=database, expire_time=expire_time, version_time=version_time
     )
@@ -69,7 +69,7 @@ def create_backup_with_encryption_key(
     database = instance.database(database_id)
 
     # Create a backup
-    expire_time = datetime.utcnow() + timedelta(days=14)
+    expire_time = datetime.now(datetime.utc) + timedelta(days=14)
     encryption_config = {
         "encryption_type": CreateBackupEncryptionConfig.EncryptionType.CUSTOMER_MANAGED_ENCRYPTION,
         "kms_key_name": kms_key_name,
@@ -178,7 +178,7 @@ def cancel_backup(instance_id, database_id, backup_id):
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
 
-    expire_time = datetime.utcnow() + timedelta(days=30)
+    expire_time = datetime.now(datetime.utc) + timedelta(days=30)
 
     # Create a backup.
     backup = instance.backup(backup_id, database=database, expire_time=expire_time)
@@ -426,7 +426,7 @@ def copy_backup(instance_id, backup_id, source_backup_path):
     instance = spanner_client.instance(instance_id)
 
     # Create a backup object and wait for copy backup operation to complete.
-    expire_time = datetime.utcnow() + timedelta(days=14)
+    expire_time = datetime.now(datetime.utc) + timedelta(days=14)
     copy_backup = instance.copy_backup(
         backup_id=backup_id, source_backup=source_backup_path, expire_time=expire_time
     )

--- a/samples/samples/pg_snippets.py
+++ b/samples/samples/pg_snippets.py
@@ -1297,12 +1297,12 @@ def query_data_with_timestamp_parameter(instance_id, database_id):
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
 
-    example_timestamp = datetime.datetime.utcnow().isoformat() + "Z"
+    example_timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z"
     # [END spanner_postgresql_query_with_timestamp_parameter]
     # Avoid time drift on the local machine.
     # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/4197.
     example_timestamp = (
-        datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
     ).isoformat() + "Z"
     # [START spanner_postgresql_query_with_timestamp_parameter]
     param = {"p1": example_timestamp}

--- a/samples/samples/snippets.py
+++ b/samples/samples/snippets.py
@@ -2156,12 +2156,12 @@ def query_data_with_timestamp_parameter(instance_id, database_id):
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
 
-    example_timestamp = datetime.datetime.utcnow().isoformat() + "Z"
+    example_timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z"
     # [END spanner_query_with_timestamp_parameter]
     # Avoid time drift on the local machine.
     # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/4197.
     example_timestamp = (
-        datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
     ).isoformat() + "Z"
     # [START spanner_query_with_timestamp_parameter]
     param = {"last_update_time": example_timestamp}

--- a/tests/system/_sample_data.py
+++ b/tests/system/_sample_data.py
@@ -16,7 +16,6 @@ import datetime
 import math
 
 from google.api_core import datetime_helpers
-from google.cloud._helpers import UTC
 from google.cloud import spanner_v1
 
 
@@ -45,7 +44,7 @@ COUNTERS_COLUMNS = ("name", "value")
 def _assert_timestamp(value, nano_value):
     assert isinstance(value, datetime.datetime)
     assert value.tzinfo is None
-    assert nano_value.tzinfo is UTC
+    assert nano_value.tzinfo is  datetime.timezone.utc
 
     assert value.year == nano_value.year
     assert value.month == nano_value.month

--- a/tests/system/test_dbapi.py
+++ b/tests/system/test_dbapi.py
@@ -19,7 +19,6 @@ import pytest
 import time
 
 from google.cloud import spanner_v1
-from google.cloud._helpers import UTC
 
 from google.cloud.spanner_dbapi.connection import Connection, connect
 from google.cloud.spanner_dbapi.exceptions import ProgrammingError, OperationalError
@@ -659,7 +658,7 @@ class TestDbApi:
     def test_staleness(self):
         """Check the DB API `staleness` option."""
 
-        before_insert = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        before_insert = datetime.datetime.now(datetime.timezone.utc)
         time.sleep(0.25)
 
         self._cursor.execute(

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -27,7 +27,6 @@ from google.api_core import datetime_helpers
 from google.api_core import exceptions
 from google.cloud import spanner_v1
 from google.cloud.spanner_admin_database_v1 import DatabaseDialect
-from google.cloud._helpers import UTC
 from google.cloud.spanner_v1.data_types import JsonObject
 from tests import _helpers as ot_helpers
 from . import _helpers
@@ -1372,7 +1371,7 @@ def test_snapshot_read_w_various_staleness(sessions_database):
     committed = _set_up_table(sessions_database, row_count)
     all_data_rows = list(_row_data(row_count))
 
-    before_reads = datetime.datetime.utcnow().replace(tzinfo=UTC)
+    before_reads = datetime.datetime.now(datetime.timezone.utc)
 
     # Test w/ read timestamp
     with sessions_database.snapshot(read_timestamp=committed) as read_tx:
@@ -1384,7 +1383,7 @@ def test_snapshot_read_w_various_staleness(sessions_database):
         rows = list(min_read_ts.read(sd.TABLE, sd.COLUMNS, sd.ALL))
         sd._check_row_data(rows, all_data_rows)
 
-    staleness = datetime.datetime.utcnow().replace(tzinfo=UTC) - before_reads
+    staleness = datetime.datetime.now(datetime.timezone.utc) - before_reads
 
     # Test w/ max staleness
     with sessions_database.snapshot(max_staleness=staleness) as max_staleness:
@@ -2192,7 +2191,7 @@ def test_execute_sql_w_timestamp_bindings(sessions_database, database_dialect):
     timestamps = [timestamp_1, timestamp_2]
 
     # In round-trip, timestamps acquire a timezone value.
-    expected_timestamps = [timestamp.replace(tzinfo=UTC) for timestamp in timestamps]
+    expected_timestamps = [timestamp.replace(tzinfo=datetime.timezone.utc) for timestamp in timestamps]
 
     _bind_test_helper(
         sessions_database,

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -216,7 +216,7 @@ class Test_make_value_pb(unittest.TestCase):
         from google.protobuf.struct_pb2 import Value
         from google.api_core import datetime_helpers
 
-        now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.timezone.utc)
         value_pb = self._callFUT(now)
         self.assertIsInstance(value_pb, Value)
         self.assertEqual(value_pb.string_value, datetime_helpers.to_rfc3339(now))
@@ -672,34 +672,36 @@ class Test_metadata_with_prefix(unittest.TestCase):
         self.assertEqual(metadata, [("google-cloud-resource-prefix", prefix)])
 
 
+class SomeClass:
+    def some_function(self):
+        pass
+
+
 class Test_retry(unittest.TestCase):
-    class test_class:
-        def test_fxn(self):
-            return True
 
     def test_retry_on_error(self):
         from google.api_core.exceptions import InternalServerError, NotFound
         from google.cloud.spanner_v1._helpers import _retry
         import functools
 
-        test_api = mock.create_autospec(self.test_class)
-        test_api.test_fxn.side_effect = [
+        test_api = mock.create_autospec(SomeClass)
+        test_api.some_function.side_effect = [
             InternalServerError("testing"),
             NotFound("testing"),
             True,
         ]
 
-        _retry(functools.partial(test_api.test_fxn))
+        _retry(functools.partial(test_api.some_function))
 
-        self.assertEqual(test_api.test_fxn.call_count, 3)
+        self.assertEqual(test_api.some_function.call_count, 3)
 
     def test_retry_allowed_exceptions(self):
         from google.api_core.exceptions import InternalServerError, NotFound
         from google.cloud.spanner_v1._helpers import _retry
         import functools
 
-        test_api = mock.create_autospec(self.test_class)
-        test_api.test_fxn.side_effect = [
+        test_api = mock.create_autospec(SomeClass)
+        test_api.some_function.side_effect = [
             NotFound("testing"),
             InternalServerError("testing"),
             True,
@@ -707,46 +709,46 @@ class Test_retry(unittest.TestCase):
 
         with self.assertRaises(InternalServerError):
             _retry(
-                functools.partial(test_api.test_fxn),
+                functools.partial(test_api.some_function),
                 allowed_exceptions={NotFound: None},
             )
 
-        self.assertEqual(test_api.test_fxn.call_count, 2)
+        self.assertEqual(test_api.some_function.call_count, 2)
 
     def test_retry_count(self):
         from google.api_core.exceptions import InternalServerError
         from google.cloud.spanner_v1._helpers import _retry
         import functools
 
-        test_api = mock.create_autospec(self.test_class)
-        test_api.test_fxn.side_effect = [
+        test_api = mock.create_autospec(SomeClass)
+        test_api.some_function.side_effect = [
             InternalServerError("testing"),
             InternalServerError("testing"),
         ]
 
         with self.assertRaises(InternalServerError):
-            _retry(functools.partial(test_api.test_fxn), retry_count=1)
+            _retry(functools.partial(test_api.some_function), retry_count=1)
 
-        self.assertEqual(test_api.test_fxn.call_count, 2)
+        self.assertEqual(test_api.some_function.call_count, 2)
 
     def test_check_rst_stream_error(self):
         from google.api_core.exceptions import InternalServerError
         from google.cloud.spanner_v1._helpers import _retry, _check_rst_stream_error
         import functools
 
-        test_api = mock.create_autospec(self.test_class)
-        test_api.test_fxn.side_effect = [
+        test_api = mock.create_autospec(SomeClass)
+        test_api.some_function.side_effect = [
             InternalServerError("Received unexpected EOS on DATA frame from server"),
             InternalServerError("RST_STREAM"),
             True,
         ]
 
         _retry(
-            functools.partial(test_api.test_fxn),
+            functools.partial(test_api.some_function),
             allowed_exceptions={InternalServerError: _check_rst_stream_error},
         )
 
-        self.assertEqual(test_api.test_fxn.call_count, 3)
+        self.assertEqual(test_api.some_function.call_count, 3)
 
 
 class Test_metadata_with_leader_aware_routing(unittest.TestCase):

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -34,9 +34,8 @@ class _BaseTest(unittest.TestCase):
     @staticmethod
     def _make_timestamp():
         import datetime
-        from google.cloud._helpers import UTC
 
-        return datetime.datetime.utcnow().replace(tzinfo=UTC)
+        return datetime.datetime.now(datetime.timezone.utc)
 
 
 class TestBackup(_BaseTest):
@@ -357,7 +356,7 @@ class TestBackup(_BaseTest):
         api.create_backup.return_value = op_future
 
         instance = _Instance(self.INSTANCE_NAME, client=client)
-        version_timestamp = datetime.utcnow() - timedelta(minutes=5)
+        version_timestamp = datetime.now(timezone.utc) - timedelta(minutes=5)
         version_timestamp = version_timestamp.replace(tzinfo=timezone.utc)
         expire_timestamp = self._make_timestamp()
         encryption_config = {"encryption_type": 3, "kms_key_name": "key_name"}

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -216,10 +216,10 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         import datetime
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import TransactionOptions
-        from google.cloud._helpers import UTC
+
         from google.cloud._helpers import _datetime_to_pb_timestamp
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now =datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         database = _Database()
@@ -255,10 +255,9 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         import datetime
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import TransactionOptions
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         database = _Database()
@@ -333,9 +332,8 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
 
     def test_context_mgr_already_committed(self):
         import datetime
-        from google.cloud._helpers import UTC
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         database = _Database()
         api = database.spanner_api = _FauxSpannerAPI()
         session = _Session(database)
@@ -352,10 +350,9 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         import datetime
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import TransactionOptions
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         database = _Database()
@@ -389,10 +386,9 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
     def test_context_mgr_failure(self):
         import datetime
         from google.cloud.spanner_v1 import CommitResponse
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         database = _Database()
@@ -471,11 +467,10 @@ class TestMutationGroups(_BaseTest, OpenTelemetryBase):
     def _test_batch_write_with_request_options(self, request_options=None):
         import datetime
         from google.cloud.spanner_v1 import BatchWriteResponse
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.rpc.status_pb2 import Status
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         status_pb = Status(code=200)
         response = BatchWriteResponse(

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -70,9 +70,8 @@ class _BaseTest(unittest.TestCase):
     @staticmethod
     def _make_timestamp():
         import datetime
-        from google.cloud._helpers import UTC
 
-        return datetime.datetime.utcnow().replace(tzinfo=UTC)
+        return datetime.datetime.now(datetime.timezone.utc)
 
     @staticmethod
     def _make_duration(seconds=1, microseconds=0):
@@ -1200,10 +1199,9 @@ class TestDatabase(_BaseTest):
 
     def test_snapshot_w_read_timestamp_and_multi_use(self):
         import datetime
-        from google.cloud._helpers import UTC
         from google.cloud.spanner_v1.database import SnapshotCheckout
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         client = _Client()
         instance = _Instance(self.INSTANCE_NAME, client=client)
         pool = _Pool()
@@ -1695,11 +1693,10 @@ class TestBatchCheckout(_BaseTest):
         from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import TransactionOptions
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.batch import Batch
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         database = _Database(self.DATABASE_NAME)
@@ -1742,11 +1739,10 @@ class TestBatchCheckout(_BaseTest):
         from google.cloud.spanner_v1 import CommitRequest
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import TransactionOptions
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.batch import Batch
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         commit_stats = CommitResponse.CommitStats(mutation_count=4)
         response = CommitResponse(commit_timestamp=now_pb, commit_stats=commit_stats)
@@ -1882,10 +1878,9 @@ class TestSnapshotCheckout(_BaseTest):
 
     def test_ctor_w_read_timestamp_and_multi_use(self):
         import datetime
-        from google.cloud._helpers import UTC
         from google.cloud.spanner_v1.snapshot import Snapshot
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         database = _Database(self.DATABASE_NAME)
         session = _Session(database)
         pool = database._pool = _Pool()
@@ -2728,12 +2723,11 @@ class TestMutationGroupsCheckout(_BaseTest):
         from google.cloud.spanner_v1 import BatchWriteRequest
         from google.cloud.spanner_v1 import BatchWriteResponse
         from google.cloud.spanner_v1 import Mutation
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.batch import MutationGroups
         from google.rpc.status_pb2 import Status
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         status_pb = Status(code=200)
         response = BatchWriteResponse(

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -666,7 +666,6 @@ class TestInstance(unittest.TestCase):
 
     def test_backup_factory_explicit(self):
         import datetime
-        from google.cloud._helpers import UTC
         from google.cloud.spanner_v1.backup import Backup
         from google.cloud.spanner_admin_database_v1 import CreateBackupEncryptionConfig
 
@@ -674,7 +673,7 @@ class TestInstance(unittest.TestCase):
         instance = self._make_one(self.INSTANCE_ID, client, self.CONFIG_NAME)
         BACKUP_ID = "backup-id"
         DATABASE_NAME = "database-name"
-        timestamp = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
         encryption_config = CreateBackupEncryptionConfig(
             encryption_type=CreateBackupEncryptionConfig.EncryptionType.CUSTOMER_MANAGED_ENCRYPTION,
             kms_key_name="kms_key_name",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -885,7 +885,6 @@ class TestSession(OpenTelemetryBase):
             Transaction as TransactionPB,
             TransactionOptions,
         )
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
 
@@ -897,7 +896,7 @@ class TestSession(OpenTelemetryBase):
         ]
         TRANSACTION_ID = b"FACEDACE"
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         gax_api = self._make_spanner_api()
@@ -1012,7 +1011,6 @@ class TestSession(OpenTelemetryBase):
             Transaction as TransactionPB,
             TransactionOptions,
         )
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
 
@@ -1024,7 +1022,7 @@ class TestSession(OpenTelemetryBase):
         ]
         TRANSACTION_ID = b"FACEDACE"
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         aborted = _make_rpc_error(Aborted, trailing_metadata=[])
         response = CommitResponse(commit_timestamp=now_pb)
@@ -1098,7 +1096,6 @@ class TestSession(OpenTelemetryBase):
             Transaction as TransactionPB,
             TransactionOptions,
         )
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
 
@@ -1119,7 +1116,7 @@ class TestSession(OpenTelemetryBase):
         ]
         aborted = _make_rpc_error(Aborted, trailing_metadata=trailing_metadata)
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         gax_api = self._make_spanner_api()
@@ -1197,7 +1194,6 @@ class TestSession(OpenTelemetryBase):
             Transaction as TransactionPB,
             TransactionOptions,
         )
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
 
@@ -1211,7 +1207,7 @@ class TestSession(OpenTelemetryBase):
         RETRY_SECONDS = 1
         RETRY_NANOS = 3456
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         retry_info = RetryInfo(
@@ -1287,7 +1283,6 @@ class TestSession(OpenTelemetryBase):
             TransactionOptions,
         )
         from google.cloud.spanner_v1.transaction import Transaction
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
 
         TABLE_NAME = "citizens"
@@ -1300,7 +1295,7 @@ class TestSession(OpenTelemetryBase):
         RETRY_SECONDS = 1
         RETRY_NANOS = 3456
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         response = CommitResponse(commit_timestamp=now_pb)
         retry_info = RetryInfo(
@@ -1476,7 +1471,6 @@ class TestSession(OpenTelemetryBase):
             Transaction as TransactionPB,
             TransactionOptions,
         )
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
 
@@ -1488,7 +1482,7 @@ class TestSession(OpenTelemetryBase):
         ]
         TRANSACTION_ID = b"FACEDACE"
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         commit_stats = CommitResponse.CommitStats(mutation_count=4)
         response = CommitResponse(commit_timestamp=now_pb, commit_stats=commit_stats)
@@ -1621,7 +1615,6 @@ class TestSession(OpenTelemetryBase):
             Transaction as TransactionPB,
             TransactionOptions,
         )
-        from google.cloud._helpers import UTC
         from google.cloud._helpers import _datetime_to_pb_timestamp
         from google.cloud.spanner_v1.transaction import Transaction
 
@@ -1633,7 +1626,7 @@ class TestSession(OpenTelemetryBase):
         ]
         TRANSACTION_ID = b"FACEDACE"
         transaction_pb = TransactionPB(id=TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         now_pb = _datetime_to_pb_timestamp(now)
         commit_stats = CommitResponse.CommitStats(mutation_count=4)
         response = CommitResponse(commit_timestamp=now_pb, commit_stats=commit_stats)

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -1378,9 +1378,8 @@ class TestSnapshot(OpenTelemetryBase):
 
     def _makeTimestamp(self):
         import datetime
-        from google.cloud._helpers import UTC
 
-        return datetime.datetime.utcnow().replace(tzinfo=UTC)
+        return datetime.datetime.now(datetime.timezone.utc)
 
     def _makeDuration(self, seconds=1, microseconds=0):
         import datetime

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -351,9 +351,8 @@ class TestTransaction(OpenTelemetryBase):
         import datetime
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1.keyset import KeySet
-        from google.cloud._helpers import UTC
 
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         keys = [[0], [1], [2]]
         keyset = KeySet(keys=keys)
         response = CommitResponse(commit_timestamp=now)
@@ -834,10 +833,9 @@ class TestTransaction(OpenTelemetryBase):
         import datetime
         from google.cloud.spanner_v1 import CommitResponse
         from google.cloud.spanner_v1 import Transaction as TransactionPB
-        from google.cloud._helpers import UTC
 
         transaction_pb = TransactionPB(id=self.TRANSACTION_ID)
-        now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+        now = datetime.datetime.now(datetime.timezone.utc)
         response = CommitResponse(commit_timestamp=now)
         database = _Database()
         api = database.spanner_api = _FauxSpannerAPI(


### PR DESCRIPTION
This PR adds a `pytest.ini` to treat warnings as errors.

I also included some simple fixes. Let me know if these should be pulled out into separate PRs with corresponding issues created.