### PR TITLE
fix: Few fixes in DBAPI

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -273,10 +273,11 @@ class Connection:
 
         The session will be returned into the sessions pool.
         """
+        if self._session is None:
+            return
         if self.database is None:
             raise ValueError("Database needs to be passed for this operation")
-        if self._session is not None:
-            self.database._pool.put(self._session)
+        self.database._pool.put(self._session)
         self._session = None
 
     def transaction_checkout(self):

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -125,7 +125,8 @@ class Cursor(object):
         :returns: The result columns' description.
         """
         if (
-            self._result_set.metadata is None
+            self._result_set is None
+            or self._result_set.metadata is None
             or self._result_set.metadata.row_type is None
             or self._result_set.metadata.row_type.fields is None
             or len(self._result_set.metadata.row_type.fields) == 0

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -123,7 +123,12 @@ class Cursor(object):
         :rtype: tuple
         :returns: The result columns' description.
         """
-        if not getattr(self._result_set, "metadata", None):
+        if (
+            self._result_set.metadata is None
+            or self._result_set.metadata.row_type is None
+            or self._result_set.metadata.row_type.fields is None
+            or len(self._result_set.metadata.row_type.fields) == 0
+        ):
             return
 
         columns = []

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -160,6 +160,7 @@ class TestConnection(unittest.TestCase):
 
     def test_release_session_database_error(self):
         connection = Connection(INSTANCE)
+        connection._session = "session"
         with pytest.raises(ValueError):
             connection._release_session()
 


### PR DESCRIPTION
The fixes done in this PR are

1) When database has not been initialized inside DBapi Connection then it should not throw exception when trying to release a session incase no session has been checked out

2) Adding different None checks while setting `description` property on `Cursor` to make sure its not set if metadata from the resultset doesn't have any row_type.fields present