### PR TITLE
fix: Small fix in `description` when metadata property is not present in cursor's _result_set

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -126,7 +126,7 @@ class Cursor(object):
         """
         if (
             self._result_set is None
-            or self._result_set.metadata is None
+            or not getattr(self._result_set, "metadata", None)
             or self._result_set.metadata.row_type is None
             or self._result_set.metadata.row_type.fields is None
             or len(self._result_set.metadata.row_type.fields) == 0


### PR DESCRIPTION
Cursor's `_result_set` attribute can be of type `StreamedResultSet` or `StreamedManyResultSet`. `metadata` property is not present in case of `StreamedManyResultSet`