### PR TITLE
feat!: Implementation of batch ddl in dbapi

### DIFF
--- a/google/cloud/spanner_dbapi/batch_executor.py
+++ b/google/cloud/spanner_dbapi/batch_executor.py
@@ -50,7 +50,7 @@ class BatchDdlExecutor:
         """Executes the statement when ddl batch is active by buffering the
         statement in-memory.
 
-        This method is internal and not for public use as it can change anytime.
+        This method is internal and not for public use
 
         :type parsed_statement: ParsedStatement
         :param parsed_statement: parsed statement containing sql query
@@ -67,14 +67,8 @@ class BatchDdlExecutor:
         """Executes all the buffered statements on the active ddl batch by
         making a call to Spanner.
 
-        This method is internal and not for public use as it can change anytime.
+        This method is internal and not for public use
         """
-        from google.cloud.spanner_dbapi import ProgrammingError
-
-        if self._connection._client_transaction_started:
-            raise ProgrammingError(
-                "Cannot execute DDL statement when transaction is already active."
-            )
         return self._connection.database.update_ddl(self._statements).result()
 
 
@@ -96,7 +90,7 @@ class BatchDmlExecutor:
         """Executes the statement when dml batch is active by buffering the
         statement in-memory.
 
-        This method is internal and not for public use as it can change anytime.
+        This method is internal and not for public use
 
         :type parsed_statement: ParsedStatement
         :param parsed_statement: parsed statement containing sql query and query
@@ -116,7 +110,7 @@ class BatchDmlExecutor:
         """Executes all the buffered statements on the active dml batch by
         making a call to Spanner.
 
-        This method is internal and not for public use as it can change anytime.
+        This method is internal and not for public use
         """
         return run_batch_dml(self._cursor, self._statements)
 
@@ -124,7 +118,7 @@ class BatchDmlExecutor:
 def run_batch_dml(cursor: "Cursor", statements: List[Statement]):
     """Executes all the dml statements by making a batch call to Spanner.
 
-    This method is internal and not for public use as it can change anytime.
+    This method is internal and not for public use
 
     :type cursor: Cursor
     :param cursor: Database Cursor object

--- a/google/cloud/spanner_dbapi/batch_executor.py
+++ b/google/cloud/spanner_dbapi/batch_executor.py
@@ -50,6 +50,8 @@ class BatchDdlExecutor:
         """Executes the statement when ddl batch is active by buffering the
         statement in-memory.
 
+        This method is internal and not for public use as it can change anytime.
+
         :type parsed_statement: ParsedStatement
         :param parsed_statement: parsed statement containing sql query
         """
@@ -64,6 +66,8 @@ class BatchDdlExecutor:
     def run_batch(self):
         """Executes all the buffered statements on the active ddl batch by
         making a call to Spanner.
+
+        This method is internal and not for public use as it can change anytime.
         """
         from google.cloud.spanner_dbapi import ProgrammingError
 
@@ -92,6 +96,8 @@ class BatchDmlExecutor:
         """Executes the statement when dml batch is active by buffering the
         statement in-memory.
 
+        This method is internal and not for public use as it can change anytime.
+
         :type parsed_statement: ParsedStatement
         :param parsed_statement: parsed statement containing sql query and query
          params
@@ -109,12 +115,16 @@ class BatchDmlExecutor:
     def run_batch(self):
         """Executes all the buffered statements on the active dml batch by
         making a call to Spanner.
+
+        This method is internal and not for public use as it can change anytime.
         """
         return run_batch_dml(self._cursor, self._statements)
 
 
 def run_batch_dml(cursor: "Cursor", statements: List[Statement]):
     """Executes all the dml statements by making a batch call to Spanner.
+
+    This method is internal and not for public use as it can change anytime.
 
     :type cursor: Cursor
     :param cursor: Database Cursor object

--- a/google/cloud/spanner_dbapi/client_side_statement_executor.py
+++ b/google/cloud/spanner_dbapi/client_side_statement_executor.py
@@ -85,6 +85,9 @@ def execute(cursor: "Cursor", parsed_statement: ParsedStatement):
             TypeCode.TIMESTAMP,
             column_values,
         )
+    if statement_type == ClientSideStatementType.START_BATCH_DDL:
+        connection.start_batch_ddl()
+        return None
     if statement_type == ClientSideStatementType.START_BATCH_DML:
         connection.start_batch_dml(cursor)
         return None

--- a/google/cloud/spanner_dbapi/client_side_statement_parser.py
+++ b/google/cloud/spanner_dbapi/client_side_statement_parser.py
@@ -30,6 +30,7 @@ RE_SHOW_COMMIT_TIMESTAMP = re.compile(
 RE_SHOW_READ_TIMESTAMP = re.compile(
     r"^\s*(SHOW)\s+(VARIABLE)\s+(READ_TIMESTAMP)", re.IGNORECASE
 )
+RE_START_BATCH_DDL = re.compile(r"^\s*(START)\s+(BATCH)\s+(DDL)", re.IGNORECASE)
 RE_START_BATCH_DML = re.compile(r"^\s*(START)\s+(BATCH)\s+(DML)", re.IGNORECASE)
 RE_RUN_BATCH = re.compile(r"^\s*(RUN)\s+(BATCH)", re.IGNORECASE)
 RE_ABORT_BATCH = re.compile(r"^\s*(ABORT)\s+(BATCH)", re.IGNORECASE)
@@ -62,6 +63,8 @@ def parse_stmt(query):
         client_side_statement_type = ClientSideStatementType.SHOW_COMMIT_TIMESTAMP
     elif RE_SHOW_READ_TIMESTAMP.match(query):
         client_side_statement_type = ClientSideStatementType.SHOW_READ_TIMESTAMP
+    elif RE_START_BATCH_DDL.match(query):
+        client_side_statement_type = ClientSideStatementType.START_BATCH_DDL
     elif RE_START_BATCH_DML.match(query):
         client_side_statement_type = ClientSideStatementType.START_BATCH_DML
     elif RE_BEGIN.match(query):

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -137,6 +137,16 @@ class Connection:
     @property
     def buffer_ddl_statements(self):
         """Whether to buffer ddl statements for this connection.
+        If the connection is in auto commit mode then this flag doesn't have any
+        significance as ddl statements would be executed as they come.
+
+        For connection not in auto commit mode:
+        If enabled ddl statements would be buffered at client and not executed
+        at cloud spanner. When a non ddl statement comes or a transaction is
+        committed then all the existing buffered ddl statements would be executed.
+
+        If disabled then its an error to execute ddl statement in autocommit mode.
+
 
         :rtype: bool
         :returns: _buffer_ddl_statements flag value.
@@ -483,6 +493,9 @@ class Connection:
 
     @check_not_closed
     def start_batch_ddl(self):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         if self._batch_mode is not BatchMode.NONE:
             raise ProgrammingError(
                 "Cannot start a DDL batch when a batch is already active"
@@ -500,6 +513,9 @@ class Connection:
 
     @check_not_closed
     def execute_batch_ddl_statement(self, parsed_statement: ParsedStatement):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         if self._batch_mode is not BatchMode.DDL:
             raise ProgrammingError(
                 "Cannot execute statement when the BatchMode is not DDL"
@@ -508,6 +524,9 @@ class Connection:
 
     @check_not_closed
     def start_batch_dml(self, cursor):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         if self._batch_mode is not BatchMode.NONE:
             raise ProgrammingError(
                 "Cannot start a DML batch when a batch is already active"
@@ -521,6 +540,9 @@ class Connection:
 
     @check_not_closed
     def execute_batch_dml_statement(self, parsed_statement: ParsedStatement):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         if self._batch_mode is not BatchMode.DML:
             raise ProgrammingError(
                 "Cannot execute statement when the BatchMode is not DML"
@@ -529,6 +551,9 @@ class Connection:
 
     @check_not_closed
     def run_batch(self):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         result_set = None
         if self._batch_mode is BatchMode.NONE:
             raise ProgrammingError("Cannot run a batch when the BatchMode is not set")
@@ -545,6 +570,9 @@ class Connection:
 
     @check_not_closed
     def abort_batch(self):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         if self._batch_mode is BatchMode.NONE:
             raise ProgrammingError("Cannot abort a batch when the BatchMode is not set")
         if self._batch_mode is BatchMode.DML:
@@ -559,6 +587,9 @@ class Connection:
         parsed_statement: ParsedStatement,
         query_options=None,
     ):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         statement = parsed_statement.statement
         partitioned_query = parsed_statement.client_side_statement_params[0]
         self._partitioned_query_validation(partitioned_query, statement)
@@ -583,6 +614,9 @@ class Connection:
 
     @check_not_closed
     def run_partition(self, encoded_partition_id):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         partition_id: PartitionId = partition_helper.decode_from_string(
             encoded_partition_id
         )
@@ -599,6 +633,9 @@ class Connection:
         self,
         parsed_statement: ParsedStatement,
     ):
+        """
+        This method is internal and not for public use as it can change anytime.
+        """
         statement = parsed_statement.statement
         partitioned_query = parsed_statement.client_side_statement_params[0]
         self._partitioned_query_validation(partitioned_query, statement)
@@ -639,7 +676,16 @@ def connect(
     """Creates a connection to a Google Cloud Spanner database.
 
     :type buffer_ddl_statements: bool
-    :param buffer_ddl_statements:
+    :param buffer_ddl_statements: Whether to buffer ddl statements at client
+        side. If the connection is in auto commit mode  then this flag doesn't
+        have any significance as ddl statements would be executed as they come.
+
+        For connection not in auto commit mode:
+        If enabled ddl statements would be buffered at client and not executed
+        at cloud spanner. When a non ddl statement comes or a transaction is
+        committed then all the existing buffered ddl statements would be executed.
+
+        If disabled then its an error to execute ddl statement in autocommit mode.
 
     :type instance_id: str
     :param instance_id: The ID of the instance to connect to.

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -265,7 +265,7 @@ class Cursor(object):
                         self.connection.run_prior_DDL_statements()
                     else:
                         raise ProgrammingError(
-                            "Cannot execute DDL statement when transaction is already active"
+                            "Cannot execute DDL statement when a transaction is already active"
                         )
                 else:
                     self._batch_DDLs(sql)

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -15,8 +15,6 @@
 """Database cursor for Google Cloud Spanner DB API."""
 from collections import namedtuple
 
-import sqlparse
-
 from google.api_core.exceptions import Aborted
 from google.api_core.exceptions import AlreadyExists
 from google.api_core.exceptions import FailedPrecondition
@@ -25,7 +23,7 @@ from google.api_core.exceptions import InvalidArgument
 from google.api_core.exceptions import OutOfRange
 
 from google.cloud import spanner_v1 as spanner
-from google.cloud.spanner_dbapi.batch_dml_executor import BatchMode
+from google.cloud.spanner_dbapi.batch_executor import BatchMode
 from google.cloud.spanner_dbapi.exceptions import IntegrityError
 from google.cloud.spanner_dbapi.exceptions import InterfaceError
 from google.cloud.spanner_dbapi.exceptions import OperationalError
@@ -34,7 +32,7 @@ from google.cloud.spanner_dbapi.exceptions import ProgrammingError
 from google.cloud.spanner_dbapi import (
     _helpers,
     client_side_statement_executor,
-    batch_dml_executor,
+    batch_executor,
 )
 from google.cloud.spanner_dbapi._helpers import ColumnInfo
 from google.cloud.spanner_dbapi._helpers import CODE_TO_DISPLAY_SIZE
@@ -210,18 +208,8 @@ class Cursor(object):
         :raises: :class:`ValueError` in case not a DDL statement
                  present in the operation.
         """
-        statements = []
-        for ddl in sqlparse.split(sql):
-            if ddl:
-                ddl = ddl.rstrip(";")
-                if (
-                    parse_utils.classify_statement(ddl).statement_type
-                    != StatementType.DDL
-                ):
-                    raise ValueError("Only DDL statements may be batched.")
 
-                statements.append(ddl)
-
+        statements = parse_utils.parse_and_get_ddl_statements(sql)
         # Only queue DDL statements if they are all correctly classified.
         self.connection._ddl_statements.extend(statements)
 
@@ -261,6 +249,8 @@ class Cursor(object):
                         self._itr = self._result_set
                     else:
                         self._itr = PeekIterator(self._result_set)
+            elif self.connection._batch_mode == BatchMode.DDL:
+                self.connection.execute_batch_ddl_statement(self._parsed_statement)
             elif self.connection._batch_mode == BatchMode.DML:
                 self.connection.execute_batch_dml_statement(self._parsed_statement)
             elif self.connection.read_only or (
@@ -269,9 +259,18 @@ class Cursor(object):
             ):
                 self._handle_DQL(sql, args or None)
             elif self._parsed_statement.statement_type == StatementType.DDL:
-                self._batch_DDLs(sql)
-                if not self.connection._client_transaction_started:
-                    self.connection.run_prior_DDL_statements()
+                if not self.connection.buffer_ddl_statements:
+                    if not self.connection._client_transaction_started:
+                        self._batch_DDLs(sql)
+                        self.connection.run_prior_DDL_statements()
+                    else:
+                        raise ProgrammingError(
+                            "Cannot execute DDL statement when transaction is already active"
+                        )
+                else:
+                    self._batch_DDLs(sql)
+                    if not self.connection._client_transaction_started:
+                        self.connection.run_prior_DDL_statements()
             else:
                 self._execute_in_rw_transaction()
 
@@ -296,9 +295,8 @@ class Cursor(object):
                 self.connection._spanner_transaction_started = False
 
     def _execute_in_rw_transaction(self):
-        # For every other operation, we've got to ensure that
-        # any prior DDL statements were run.
-        self.connection.run_prior_DDL_statements()
+        if self.connection.buffer_ddl_statements:
+            self.connection.run_prior_DDL_statements()
         statement = self._parsed_statement.statement
         if self.connection._client_transaction_started:
             while True:
@@ -347,9 +345,8 @@ class Cursor(object):
                     + ", with executemany() method is not allowed."
                 )
 
-            # For every operation, we've got to ensure that any prior DDL
-            # statements were run.
-            self.connection.run_prior_DDL_statements()
+            if self.connection.buffer_ddl_statements:
+                self.connection.run_prior_DDL_statements()
             if self._parsed_statement.statement_type in (
                 StatementType.INSERT,
                 StatementType.UPDATE,
@@ -360,7 +357,7 @@ class Cursor(object):
                         operation, params
                     )
                     statements.append(Statement(sql, params, get_param_types(params)))
-                many_result_set = batch_dml_executor.run_batch_dml(self, statements)
+                many_result_set = batch_executor.run_batch_dml(self, statements)
             else:
                 many_result_set = StreamedManyResultSets()
                 for params in seq_of_params:
@@ -523,7 +520,8 @@ class Cursor(object):
         # hence this method exists to circumvent that limit.
         if self.connection.database is None:
             raise ValueError("Database needs to be passed for this operation")
-        self.connection.run_prior_DDL_statements()
+        if self.connection.buffer_ddl_statements:
+            self.connection.run_prior_DDL_statements()
 
         with self.connection.database.snapshot() as snapshot:
             return list(snapshot.execute_sql(sql, params, param_types))

--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -205,6 +205,17 @@ def classify_stmt(query):
     return STMT_UPDATING
 
 
+def parse_and_get_ddl_statements(sql):
+    statements = []
+    for ddl in sqlparse.split(sql):
+        if ddl:
+            ddl = ddl.rstrip(";")
+            if classify_statement(ddl).statement_type != StatementType.DDL:
+                raise ValueError("Only DDL statements may be batched.")
+            statements.append(ddl)
+    return statements
+
+
 def classify_statement(query, args=None):
     """Determine SQL query type.
 

--- a/google/cloud/spanner_dbapi/parsed_statement.py
+++ b/google/cloud/spanner_dbapi/parsed_statement.py
@@ -36,6 +36,7 @@ class ClientSideStatementType(Enum):
     PARTITION_QUERY = 9
     RUN_PARTITION = 10
     RUN_PARTITIONED_QUERY = 11
+    START_BATCH_DDL = 12
 
 
 @dataclass

--- a/google/cloud/spanner_dbapi/transaction_helper.py
+++ b/google/cloud/spanner_dbapi/transaction_helper.py
@@ -18,7 +18,7 @@ from google.api_core.exceptions import Aborted
 
 import time
 
-from google.cloud.spanner_dbapi.batch_dml_executor import BatchMode
+from google.cloud.spanner_dbapi.batch_executor import BatchMode
 from google.cloud.spanner_dbapi.exceptions import RetryAborted
 from google.cloud.spanner_v1.session import _get_retry_delay
 

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -345,6 +345,7 @@ class TestConnection(unittest.TestCase):
             self._under_test.start_batch_ddl()
 
     def test_start_batch_ddl(self):
+        self._under_test.autocommit = True
         self._under_test.start_batch_ddl()
 
         self.assertEqual(self._under_test._batch_mode, BatchMode.DDL)

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -20,7 +20,7 @@ import unittest
 import warnings
 import pytest
 
-from google.cloud.spanner_dbapi.batch_dml_executor import BatchMode
+from google.cloud.spanner_dbapi.batch_executor import BatchMode
 from google.cloud.spanner_dbapi.exceptions import (
     InterfaceError,
     OperationalError,
@@ -326,6 +326,51 @@ class TestConnection(unittest.TestCase):
             CLIENT_TRANSACTION_NOT_STARTED_WARNING, UserWarning, stacklevel=2
         )
 
+    def test_start_batch_ddl_batch_mode_active(self):
+        self._under_test._batch_mode = BatchMode.DDL
+
+        with self.assertRaises(ProgrammingError):
+            self._under_test.start_batch_ddl()
+
+    def test_start_batch_ddl_connection_read_only(self):
+        self._under_test.read_only = True
+
+        with self.assertRaises(ProgrammingError):
+            self._under_test.start_batch_ddl()
+
+    def test_start_batch_ddl_buffer_ddl_active(self):
+        self._under_test._buffer_ddl_statements = True
+
+        with self.assertRaises(ProgrammingError):
+            self._under_test.start_batch_ddl()
+
+    def test_start_batch_ddl(self):
+        self._under_test.start_batch_ddl()
+
+        self.assertEqual(self._under_test._batch_mode, BatchMode.DDL)
+
+    def test_execute_batch_ddl_batch_mode_inactive(self):
+        self._under_test._batch_mode = BatchMode.NONE
+
+        with self.assertRaises(ProgrammingError):
+            self._under_test.execute_batch_ddl_statement(
+                ParsedStatement(StatementType.DDL, Statement("sql"))
+            )
+
+    @mock.patch(
+        "google.cloud.spanner_dbapi.batch_executor.BatchDdlExecutor", autospec=True
+    )
+    def test_execute_batch_ddl(self, mock_batch_ddl_executor):
+        self._under_test._batch_mode = BatchMode.DDL
+        self._under_test._batch_ddl_executor = mock_batch_ddl_executor
+
+        parsed_statement = ParsedStatement(StatementType.DDL, Statement("sql"))
+        self._under_test.execute_batch_ddl_statement(parsed_statement)
+
+        mock_batch_ddl_executor.execute_statement.assert_called_once_with(
+            parsed_statement
+        )
+
     def test_start_batch_dml_batch_mode_active(self):
         self._under_test._batch_mode = BatchMode.DML
         cursor = self._under_test.cursor()
@@ -356,7 +401,7 @@ class TestConnection(unittest.TestCase):
             )
 
     @mock.patch(
-        "google.cloud.spanner_dbapi.batch_dml_executor.BatchDmlExecutor", autospec=True
+        "google.cloud.spanner_dbapi.batch_executor.BatchDmlExecutor", autospec=True
     )
     def test_execute_batch_dml(self, mock_batch_dml_executor):
         self._under_test._batch_mode = BatchMode.DML
@@ -370,7 +415,7 @@ class TestConnection(unittest.TestCase):
         )
 
     @mock.patch(
-        "google.cloud.spanner_dbapi.batch_dml_executor.BatchDmlExecutor", autospec=True
+        "google.cloud.spanner_dbapi.batch_executor.BatchDmlExecutor", autospec=True
     )
     def test_run_batch_batch_mode_inactive(self, mock_batch_dml_executor):
         self._under_test._batch_mode = BatchMode.NONE
@@ -380,20 +425,33 @@ class TestConnection(unittest.TestCase):
             self._under_test.run_batch()
 
     @mock.patch(
-        "google.cloud.spanner_dbapi.batch_dml_executor.BatchDmlExecutor", autospec=True
+        "google.cloud.spanner_dbapi.batch_executor.BatchDmlExecutor", autospec=True
     )
-    def test_run_batch(self, mock_batch_dml_executor):
+    def test_run_dml_batch(self, mock_batch_dml_executor):
         self._under_test._batch_mode = BatchMode.DML
         self._under_test._batch_dml_executor = mock_batch_dml_executor
 
         self._under_test.run_batch()
 
-        mock_batch_dml_executor.run_batch_dml.assert_called_once_with()
+        mock_batch_dml_executor.run_batch.assert_called_once_with()
         self.assertEqual(self._under_test._batch_mode, BatchMode.NONE)
         self.assertEqual(self._under_test._batch_dml_executor, None)
 
     @mock.patch(
-        "google.cloud.spanner_dbapi.batch_dml_executor.BatchDmlExecutor", autospec=True
+        "google.cloud.spanner_dbapi.batch_executor.BatchDdlExecutor", autospec=True
+    )
+    def test_run_ddl_batch(self, mock_batch_ddl_executor):
+        self._under_test._batch_mode = BatchMode.DDL
+        self._under_test._batch_ddl_executor = mock_batch_ddl_executor
+
+        self._under_test.run_batch()
+
+        mock_batch_ddl_executor.run_batch.assert_called_once_with()
+        self.assertEqual(self._under_test._batch_mode, BatchMode.NONE)
+        self.assertEqual(self._under_test._batch_ddl_executor, None)
+
+    @mock.patch(
+        "google.cloud.spanner_dbapi.batch_executor.BatchDmlExecutor", autospec=True
     )
     def test_abort_batch_batch_mode_inactive(self, mock_batch_dml_executor):
         self._under_test._batch_mode = BatchMode.NONE
@@ -403,7 +461,7 @@ class TestConnection(unittest.TestCase):
             self._under_test.abort_batch()
 
     @mock.patch(
-        "google.cloud.spanner_dbapi.batch_dml_executor.BatchDmlExecutor", autospec=True
+        "google.cloud.spanner_dbapi.batch_executor.BatchDmlExecutor", autospec=True
     )
     def test_abort_dml_batch(self, mock_batch_dml_executor):
         self._under_test._batch_mode = BatchMode.DML

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -203,7 +203,9 @@ class TestCursor(unittest.TestCase):
                 self.assertIsInstance(cursor._result_set, mock.MagicMock)
 
     def test_execute_statement(self):
-        connection = self._make_connection(self.INSTANCE, mock.MagicMock())
+        connection = self._make_connection(
+            self.INSTANCE, mock.MagicMock(), buffer_ddl_statements=True
+        )
         cursor = self._make_one(connection)
 
         sql = "sql"
@@ -1163,7 +1165,9 @@ class TestCursor(unittest.TestCase):
             "DROP TABLE table_name",
         ]
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance", "test-database", buffer_ddl_statements=True
+        )
 
         cursor = connection.cursor()
         cursor.execute(


### PR DESCRIPTION
We are also adding a boolean property `buffer_ddl_statements` (disabled by default) which is changing the behavior of dbapi as currently it behave as per the property being enabled. We need to override the flag to enable it in SqlAlchemy and Django.  More details about this flag below:

If the connection is in auto commit mode then this flag doesn't have any significance as ddl statements would be executed as they come.
For connection not in auto commit mode:
-         If enabled ddl statements would be buffered at client and not executed at cloud spanner. When a non ddl statement comes or a transaction is committed then all the existing buffered ddl statements would be executed.
-         If disabled then its an error to execute ddl statement in autocommit mode.

More details here https://docs.google.com/document/d/1mSVC_AhPpdSA0xUoj4LUt2o2tVM_LDv6IdssiwWnbmw