### PR TITLE
fix: Correcting name of variable from `table_schema` to `schema_name`

### DIFF
--- a/google/cloud/spanner_dbapi/_helpers.py
+++ b/google/cloud/spanner_dbapi/_helpers.py
@@ -24,7 +24,7 @@ WHERE table_catalog = '' AND table_schema = @table_schema
 SQL_GET_TABLE_COLUMN_SCHEMA = """
 SELECT COLUMN_NAME, IS_NULLABLE, SPANNER_TYPE
 FROM INFORMATION_SCHEMA.COLUMNS
-WHERE TABLE_SCHEMA = @table_schema AND TABLE_NAME = @table_name
+WHERE TABLE_SCHEMA = @schema_name AND TABLE_NAME = @table_name
 """
 
 # This table maps spanner_types to Spanner's data type sizes as per


### PR DESCRIPTION
We are using `schema_name` as param name here https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_dbapi/cursor.py#L550 and this is the only place its used

This is leading to tests failing for our Spanner Django https://github.com/googleapis/python-spanner-django/pull/858