### PR TITLE
fix: use modernized and standardized OpenTelemetry when tracing

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -24,9 +24,17 @@ jobs:
           python-version: 3.8
       - name: Install nox
         run: python -m pip install nox
-      - name: Run system tests
+      - name: Run system tests (without extended tracing)
         run: nox -s system
         env:
           SPANNER_EMULATOR_HOST: localhost:9010
           GOOGLE_CLOUD_PROJECT: emulator-test-project
           GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE: true
+          EXTENDED_TRACING_ENABLED: false
+      - name: Run system tests (with extended tracing)
+        run: nox -s system
+        env:
+          SPANNER_EMULATOR_HOST: localhost:9010
+          GOOGLE_CLOUD_PROJECT: emulator-test-project
+          GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE: true
+          EXTENDED_TRACING_ENABLED: true

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -19,9 +19,9 @@ We also need to tell OpenTelemetry which exporter to use. To export Spanner trac
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
     from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
-    # BatchExportSpanProcessor exports spans to Cloud Trace 
+    # BatchSpanProcessor exports spans to Cloud Trace
     # in a seperate thread to not block on the main thread
-    from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     # Create and export one trace every 1000 requests
     sampler = TraceIdRatioBased(1/1000)
@@ -29,7 +29,7 @@ We also need to tell OpenTelemetry which exporter to use. To export Spanner trac
     trace.set_tracer_provider(TracerProvider(sampler=sampler))
     trace.get_tracer_provider().add_span_processor(
         # Initialize the cloud tracing exporter
-        BatchExportSpanProcessor(CloudTraceSpanExporter())
+        BatchSpanProcessor(CloudTraceSpanExporter())
     )
 
 
@@ -46,7 +46,7 @@ Alternatively you can pass in a tracer provider into the Cloud Spanner initializ
     tracerProvider = TracerProvider(sampler=sampler)
     tracerProvider.add_span_processor(
         # Initialize the cloud tracing exporter
-        BatchExportSpanProcessor(CloudTraceSpanExporter())
+        BatchSpanProcessor(CloudTraceSpanExporter())
     )
 
     o11y = dict(tracer_provider=tracerProvider)

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -9,6 +9,7 @@ To take advantage of these traces, we first need to install OpenTelemetry:
 .. code-block:: sh
 
     pip install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation
+    pip install opentelemetry-exporter-google-cloud
 
     # [Optional] Installs the cloud monitoring exporter, however you can use any exporter of your choice
     pip install opentelemetry-exporter-google-cloud
@@ -19,14 +20,14 @@ We also need to tell OpenTelemetry which exporter to use. To export Spanner trac
 
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.trace.sampling import ProbabilitySampler
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
     from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
     # BatchExportSpanProcessor exports spans to Cloud Trace 
     # in a seperate thread to not block on the main thread
     from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
 
     # Create and export one trace every 1000 requests
-    sampler = ProbabilitySampler(1/1000)
+    sampler = TraceIdRatioBased(1/1000)
     # Use the default tracer provider
     trace.set_tracer_provider(TracerProvider(sampler=sampler))
     trace.get_tracer_provider().add_span_processor(
@@ -38,3 +39,6 @@ Generated spanner traces should now be available on `Cloud Trace <https://consol
 
 Tracing is most effective when many libraries are instrumented to provide insight over the entire lifespan of a request.
 For a list of libraries that can be instrumented, see the `OpenTelemetry Integrations` section of the `OpenTelemetry Python docs <https://opentelemetry-python.readthedocs.io/en/stable/>`_
+
+To allow for SQL statements to be annotated in your spans, please set
+the environment variable `SPANNER_ENABLE_EXTENDED_TRACING=true`.

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -33,7 +33,8 @@ We also need to tell OpenTelemetry which exporter to use. To export Spanner trac
     )
 
 
-Alternatively you can pass in a tracer provider into the Cloud Spanner initialization
+Alternatively you can pass in a tracer provider into the Cloud Spanner
+initialization, otherwise the global tracer will be used:
 
 .. code:: python
 
@@ -49,17 +50,11 @@ Alternatively you can pass in a tracer provider into the Cloud Spanner initializ
         BatchSpanProcessor(CloudTraceSpanExporter())
     )
 
-    o11y = dict(tracer_provider=tracerProvider)
+    options = dict(tracer_provider=tracerProvider)
     # Pass the tracer provider while creating the Spanner client.
-    spanner_client = spanner.Client(observability_options=o11y)
+    spanner_client = spanner.Client(observability_options=options)
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
-
-please note that the tracer being used is retrieved by invoking:
-
-.. code:: python
-
-   tracer = tracerProvider.get_tracer('cloud.google.com/python/spanner', SPANNER_LIB_VERSION)
 
 
 To get more fine-grained traces from gRPC, you can enable the gRPC instrumentation by the following

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -9,10 +9,7 @@ To take advantage of these traces, we first need to install OpenTelemetry:
 .. code-block:: sh
 
     pip install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation
-    pip install opentelemetry-exporter-google-cloud
-
-    # [Optional] Installs the cloud monitoring exporter, however you can use any exporter of your choice
-    pip install opentelemetry-exporter-google-cloud
+    pip install opentelemetry-exporter-gcp-trace
 
 We also need to tell OpenTelemetry which exporter to use. To export Spanner traces to `Cloud Tracing <https://cloud.google.com/trace>`_, add the following lines to your application:
 
@@ -57,6 +54,12 @@ Alternatively you can pass in a tracer provider into the Cloud Spanner initializ
     spanner_client = spanner.Client(observability_options=o11y)
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
+
+please not that the tracer being used is retrieved by invoking:
+
+.. code:: python
+
+   tracer = tracerProvider.get_tracer('cloud.google.com/python/spanner', SPANNER_LIB_VERSION)
 
 Generated spanner traces should now be available on `Cloud Trace <https://console.cloud.google.com/traces>`_.
 

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -83,4 +83,10 @@ Tracing is most effective when many libraries are instrumented to provide insigh
 For a list of libraries that can be instrumented, see the `OpenTelemetry Integrations` section of the `OpenTelemetry Python docs <https://opentelemetry-python.readthedocs.io/en/stable/>`_
 
 To allow for SQL statements to be annotated in your spans, please set
-the environment variable `SPANNER_ENABLE_EXTENDED_TRACING=true` or please set the configuration field `enable_extended_tracing` to `True` when configuring the Cloud Spanner client.
+the environment variable `SPANNER_ENABLE_EXTENDED_TRACING=true` or please set the configuration field `enable_extended_tracing` to `True` when configuring the Cloud Spanner client, like this:
+
+.. code:: python
+
+   tracerProvider = TracerProvider(sampler=sampler)
+   opts = dict(tracer_provider=tracerProvider, enable_extended_tracing=true)
+   spanner_client = spanner.Client(project_id, observability_options=opts)

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -35,6 +35,29 @@ We also need to tell OpenTelemetry which exporter to use. To export Spanner trac
         BatchExportSpanProcessor(CloudTraceSpanExporter())
     )
 
+
+Alternatively you can pass in a tracer provider into the Cloud Spanner initialization
+
+.. code:: python
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+    from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+
+    # Create and export one trace every 1000 requests
+    sampler = TraceIdRatioBased(1/1000)
+    tracerProvider = TracerProvider(sampler=sampler)
+    tracerProvider.add_span_processor(
+        # Initialize the cloud tracing exporter
+        BatchExportSpanProcessor(CloudTraceSpanExporter())
+    )
+
+    o11y = dict(tracer_provider=tracerProvider)
+    # Pass the tracer provider while creating the Spanner client.
+    spanner_client = spanner.Client(observability_options=o11y)
+    instance = spanner_client.instance(instance_id)
+    database = instance.database(database_id)
+
 Generated spanner traces should now be available on `Cloud Trace <https://console.cloud.google.com/traces>`_.
 
 Tracing is most effective when many libraries are instrumented to provide insight over the entire lifespan of a request.

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -55,11 +55,27 @@ Alternatively you can pass in a tracer provider into the Cloud Spanner initializ
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
 
-please not that the tracer being used is retrieved by invoking:
+please note that the tracer being used is retrieved by invoking:
 
 .. code:: python
 
    tracer = tracerProvider.get_tracer('cloud.google.com/python/spanner', SPANNER_LIB_VERSION)
+
+
+To get more fine-grained traces from gRPC, you can enable the gRPC instrumentation by the following
+
+.. code-block:: sh
+
+    pip install opentelemetry-instrumentation-grpc
+
+and then in your Python code, please add the following lines:
+
+.. code:: python
+
+   from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+   grpc_client_instrumentor = GrpcInstrumentorClient()
+   grpc_client_instrumentor.instrument()
+
 
 Generated spanner traces should now be available on `Cloud Trace <https://console.cloud.google.com/traces>`_.
 

--- a/docs/opentelemetry-tracing.rst
+++ b/docs/opentelemetry-tracing.rst
@@ -67,4 +67,4 @@ Tracing is most effective when many libraries are instrumented to provide insigh
 For a list of libraries that can be instrumented, see the `OpenTelemetry Integrations` section of the `OpenTelemetry Python docs <https://opentelemetry-python.readthedocs.io/en/stable/>`_
 
 To allow for SQL statements to be annotated in your spans, please set
-the environment variable `SPANNER_ENABLE_EXTENDED_TRACING=true`.
+the environment variable `SPANNER_ENABLE_EXTENDED_TRACING=true` or please set the configuration field `enable_extended_tracing` to `True` when configuring the Cloud Spanner client.

--- a/examples/grpc_instrumentation_enabled.py
+++ b/examples/grpc_instrumentation_enabled.py
@@ -23,6 +23,11 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry import trace
 
+# Enable the gRPC instrumentation if you'd like more introspection.
+from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+grpc_client_instrumentor = GrpcInstrumentorClient()
+grpc_client_instrumentor.instrument()
+
 def main():
     # Setup common variables that'll be used between Spanner and traces.
     project_id = os.environ.get('SPANNER_PROJECT_ID')
@@ -38,11 +43,9 @@ def main():
     tracer = tracerProvider.get_tracer('cloud.google.com/python/spanner', spanner.__version__)
 
     # Setup the Cloud Spanner Client.
-    spanner_client = spanner.Client(project_id)
-    # Alternatively you can directly pass in the tracerProvider into the spanner client.
-    if False:
-        opts = dict(tracer_provider=tracerProvider)
-        spanner_client = spanner.Client(project_id, observability_options=opts)
+    # Here we directly pass in the tracerProvider into the spanner client.
+    opts = dict(tracer_provider=tracerProvider)
+    spanner_client = spanner.Client(project_id, observability_options=opts)
 
     instance = spanner_client.instance('test-instance')
     database = instance.database('test-db')
@@ -63,7 +66,6 @@ def main():
                 data = snapshot.execute_sql('SELECT CURRENT_TIMESTAMP()')
                 for row in data:
                     print(row)
-
 
 if __name__ == '__main__':
     main()

--- a/examples/trace.py
+++ b/examples/trace.py
@@ -35,11 +35,12 @@ def main():
         BatchSpanProcessor(traceExporter))
     trace.set_tracer_provider(tracerProvider)
     # Retrieve the set shared tracer.
-    tracer = tracerProvider.get_tracer('cloud.google.com/python/spanner', spanner.__version__)
+    tracer = tracerProvider.get_tracer('MyPackage')
 
     # Setup the Cloud Spanner Client.
     spanner_client = spanner.Client(project_id)
-    # Alternatively you can directly pass in the tracerProvider into the spanner client.
+    # Alternatively you can directly pass in the tracerProvider into
+    # the spanner client, otherwise the global tracer shall be used.
     if False:
         opts = dict(tracer_provider=tracerProvider)
         spanner_client = spanner.Client(project_id, observability_options=opts)

--- a/examples/trace.py
+++ b/examples/trace.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import os
+import time
+
+import google.cloud.spanner as spanner
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchExportSpanProcessor
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry import trace
+
+
+def main():
+    # Setup OpenTelemetry, trace and Cloud Trace exporter.
+    sampler = ALWAYS_ON
+    tracerProvider = TracerProvider(sampler=sampler)
+    tracerProvider.add_span_processor(
+        BatchExportSpanProcessor(CloudTraceSpanExporter()))
+    trace.set_tracer_provider(tracerProvider)
+    tracer = trace.get_tracer(__name__)
+
+    # Setup the Cloud Spanner Client.
+    project_id = os.environ.get('SPANNER_PROJECT_ID')
+    spanner_client = spanner.Client(project_id)
+    instance = spanner_client.instance('test-instance')
+    database = instance.database('test-db')
+
+    # Now run our queries
+    with tracer.start_as_current_span('QueryDatabase'):
+        with database.snapshot() as snapshot:
+            with tracer.start_as_current_span('InformationSchema'):
+                info_schema = snapshot.execute_sql(
+                    'SELECT * FROM INFORMATION_SCHEMA.TABLES')
+                for row in info_schema:
+                    print(row)
+
+        with tracer.start_as_current_span('ServerTimeQuery'):
+            with database.snapshot() as snapshot:
+                # Purposefully issue a bad SQL statement to examine exceptions
+                # that get recorded and a ERROR span status.
+                data = snapshot.execute_sql('SELECT CURRENT_TIMESTAMPx()')
+                for row in data:
+                    print(row)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/trace.py
+++ b/examples/trace.py
@@ -23,6 +23,10 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry import trace
 
+# Enable the gRPC instrumentation if you'd like more introspection.
+from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+grpc_client_instrumentor = GrpcInstrumentorClient()
+grpc_client_instrumentor.instrument()
 
 def main():
     # Setup common variables that'll be used between Spanner and traces.

--- a/google/cloud/spanner_v1/__init__.py
+++ b/google/cloud/spanner_v1/__init__.py
@@ -75,7 +75,7 @@ from google.cloud.spanner_v1.pool import BurstyPool
 from google.cloud.spanner_v1.pool import FixedSizePool
 from google.cloud.spanner_v1.pool import PingingPool
 from google.cloud.spanner_v1.pool import TransactionPingingPool
-from google.cloud.spanner_v1.tracing import get_tracer
+from google.cloud.spanner_v1._opentelemetry_tracing import get_tracer
 
 
 COMMIT_TIMESTAMP = "spanner.commit_timestamp()"

--- a/google/cloud/spanner_v1/__init__.py
+++ b/google/cloud/spanner_v1/__init__.py
@@ -75,6 +75,7 @@ from google.cloud.spanner_v1.pool import BurstyPool
 from google.cloud.spanner_v1.pool import FixedSizePool
 from google.cloud.spanner_v1.pool import PingingPool
 from google.cloud.spanner_v1.pool import TransactionPingingPool
+from google.cloud.spanner_v1.tracing import get_tracer
 
 
 COMMIT_TIMESTAMP = "spanner.commit_timestamp()"
@@ -88,6 +89,7 @@ __all__ = (
     # google.cloud.spanner_v1
     "__version__",
     "param_types",
+    "get_tracer",
     # google.cloud.spanner_v1.client
     "Client",
     # google.cloud.spanner_v1.keyset

--- a/google/cloud/spanner_v1/__init__.py
+++ b/google/cloud/spanner_v1/__init__.py
@@ -75,7 +75,6 @@ from google.cloud.spanner_v1.pool import BurstyPool
 from google.cloud.spanner_v1.pool import FixedSizePool
 from google.cloud.spanner_v1.pool import PingingPool
 from google.cloud.spanner_v1.pool import TransactionPingingPool
-from google.cloud.spanner_v1._opentelemetry_tracing import get_tracer
 
 
 COMMIT_TIMESTAMP = "spanner.commit_timestamp()"
@@ -89,7 +88,6 @@ __all__ = (
     # google.cloud.spanner_v1
     "__version__",
     "param_types",
-    "get_tracer",
     # google.cloud.spanner_v1.client
     "Client",
     # google.cloud.spanner_v1.keyset

--- a/google/cloud/spanner_v1/_helpers.py
+++ b/google/cloud/spanner_v1/_helpers.py
@@ -358,8 +358,9 @@ class _SessionWrapper(object):
     :param session: the session used to perform the commit
     """
 
-    def __init__(self, session):
+    def __init__(self, session, observability_options=None):
         self._session = session
+        self._observability_options = observability_options
 
 
 def _metadata_with_prefix(prefix, **kw):

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -36,7 +36,7 @@ try:
     DB_CONNECTION_STRING = SpanAttributes.DB_CONNECTION_STRING
     NET_HOST_NAME = SpanAttributes.NET_HOST_NAME
     DB_STATEMENT = SpanAttributes.DB_STATEMENT
-except ImportError:
+except ImportError as e:
     HAS_OPENTELEMETRY_INSTALLED = False
     DB_STATEMENT = 'db.statement'
 
@@ -54,10 +54,12 @@ def get_tracer(tracer_provider=None):
     When the tracer_provider is set, it'll retrieve the tracer from it, otherwise
     it'll fall back to the global tracer provider and use this library's specific semantics.
     """
-    if tracer_provider:
-        return tracer_provider.get_tracer(TRACER_NAME, TRACER_VERSION)
-    else:
-        return trace.get_tracer(TRACER_NAME, TRACER_VERSION)
+    if not tracer_provider:
+        # Acquire the global tracer provider.
+        tracer_provider = trace.get_tracer_provider()
+
+    return tracer_provider.get_tracer(TRACER_NAME, TRACER_VERSION)
+
 
 @contextmanager
 def trace_call(name, session, extra_attributes=None, observability_options=None):

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -38,16 +38,6 @@ except ImportError:
 EXTENDED_TRACING_ENABLED = os.environ.get('SPANNER_ENABLE_EXTENDED_TRACING', '') == 'true'
 
 
-def annotate_with_sql_statement(span, sql):
-    """
-    annotate_sql_statement will set the attribute DB_STATEMENT
-    to the sql statement, only if SPANNER_ENABLE_EXTENDED_TRACING=true
-    is set in the environment.
-    """
-    if EXTENDED_TRACING_ENABLED:
-        span.set_attribute(DB_STATEMENT, sql)
-
-
 @contextmanager
 def trace_call(name, session, extra_attributes=None):
     if not HAS_OPENTELEMETRY_INSTALLED or not session:
@@ -59,7 +49,7 @@ def trace_call(name, session, extra_attributes=None):
 
     # Set base attributes that we know for every trace created
     attributes = {
-        DB_SYSTEM: "google.cloud.spanner",
+        DB_SYSTEM: "spanner",
         DB_CONNECTION_STRING: SpannerClient.DEFAULT_ENDPOINT,
         DB_NAME: session._database.name,
         NET_HOST_NAME: SpannerClient.DEFAULT_ENDPOINT,

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -55,7 +55,7 @@ def get_tracer(tracer_provider=None):
     it'll fall back to the global tracer provider and use this library's specific semantics.
     """
     if tracer_provider:
-        return tracerProvider.get_tracer(TRACER_NAME, TRACER_VERSION)
+        return tracer_provider.get_tracer(TRACER_NAME, TRACER_VERSION)
     else:
         return trace.get_tracer(TRACER_NAME, TRACER_VERSION)
 

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -80,7 +80,11 @@ def trace_call(name, session, extra_attributes=None, observability_options=None)
     if extra_attributes:
         attributes.update(extra_attributes)
 
-    if not EXTENDED_TRACING_ENABLED:
+    extended_tracing = EXTENDED_TRACING_ENABLED or (
+                        observability_options and
+                        observability_options.get('enable_extended_tracing', False))
+
+    if not extended_tracing:
         attributes.pop(DB_STATEMENT, None)
 
     with tracer.start_as_current_span(

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -87,8 +87,9 @@ def trace_call(name, session, extra_attributes=None, observability_options=None)
     if not extended_tracing:
         attributes.pop(DB_STATEMENT, None)
 
+    span_name = TRACER_NAME + '/' + name
     with tracer.start_as_current_span(
-        name, kind=trace.SpanKind.CLIENT, attributes=attributes
+        span_name, kind=trace.SpanKind.CLIENT, attributes=attributes
     ) as span:
         try:
             span.set_status(Status(StatusCode.OK))

--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -205,7 +205,8 @@ class Batch(_BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("CloudSpanner.Commit", self._session, trace_attributes):
+        with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
+                        observability_options=self._observability_options):
             method = functools.partial(
                 api.commit,
                 request=request,
@@ -318,7 +319,8 @@ class MutationGroups(_SessionWrapper):
             request_options=request_options,
             exclude_txn_from_change_streams=exclude_txn_from_change_streams,
         )
-        with trace_call("CloudSpanner.BatchWrite", self._session, trace_attributes):
+        with trace_call("CloudSpanner.BatchWrite", self._session, trace_attributes,
+                        observability_options=self._observability_options):
             method = functools.partial(
                 api.batch_write,
                 request=request,

--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -205,7 +205,7 @@ class Batch(_BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
+        with trace_call("Batch.commit", self._session, trace_attributes,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.commit,
@@ -319,7 +319,7 @@ class MutationGroups(_SessionWrapper):
             request_options=request_options,
             exclude_txn_from_change_streams=exclude_txn_from_change_streams,
         )
-        with trace_call("CloudSpanner.BatchWrite", self._session, trace_attributes,
+        with trace_call("MutationgGroups.batchWrite", self._session, trace_attributes,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.batch_write,

--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -205,7 +205,7 @@ class Batch(_BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("Batch.commit", self._session, trace_attributes,
+        with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.commit,
@@ -319,7 +319,7 @@ class MutationGroups(_SessionWrapper):
             request_options=request_options,
             exclude_txn_from_change_streams=exclude_txn_from_change_streams,
         )
-        with trace_call("MutationgGroups.batchWrite", self._session, trace_attributes,
+        with trace_call("CloudSpanner.BatchWrite", self._session, trace_attributes,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.batch_write,

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -146,6 +146,7 @@ class Client(ClientWithProject):
         query_options=None,
         route_to_leader_enabled=True,
         directed_read_options=None,
+        observability_options=None,
     ):
         self._emulator_host = _get_spanner_emulator_host()
 
@@ -187,6 +188,7 @@ class Client(ClientWithProject):
 
         self._route_to_leader_enabled = route_to_leader_enabled
         self._directed_read_options = directed_read_options
+        self._observability_options = observability_options
 
     @property
     def credentials(self):
@@ -371,6 +373,7 @@ class Client(ClientWithProject):
             self._emulator_host,
             labels,
             processing_units,
+            self._observability_options,
         )
 
     def list_instances(self, filter_="", page_size=None):

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -156,6 +156,7 @@ class Database(object):
         database_role=None,
         enable_drop_protection=False,
         proto_descriptors=None,
+        observability_options=None,
     ):
         self.database_id = database_id
         self._instance = instance
@@ -178,6 +179,7 @@ class Database(object):
         self._reconciling = False
         self._directed_read_options = self._instance._client.directed_read_options
         self._proto_descriptors = proto_descriptors
+        self._observability_options = observability_options
 
         if pool is None:
             pool = BurstyPool(database_role=database_role)

--- a/google/cloud/spanner_v1/instance.py
+++ b/google/cloud/spanner_v1/instance.py
@@ -122,6 +122,7 @@ class Instance(object):
         emulator_host=None,
         labels=None,
         processing_units=None,
+        observability_options=None,
     ):
         self.instance_id = instance_id
         self._client = client
@@ -145,6 +146,7 @@ class Instance(object):
         if labels is None:
             labels = {}
         self.labels = labels
+        self._observability_options = observability_options
 
     def _update_from_pb(self, instance_pb):
         """Refresh self from the server-provided protobuf.
@@ -436,6 +438,7 @@ class Instance(object):
         # should be only set for tests if tests want to use interceptors
         enable_interceptors_in_tests=False,
         proto_descriptors=None,
+        observability_options=None,
     ):
         """Factory to create a database within this instance.
 
@@ -499,6 +502,7 @@ class Instance(object):
                 database_role=database_role,
                 enable_drop_protection=enable_drop_protection,
                 proto_descriptors=proto_descriptors,
+                observability_options=observability_options or self._observability_options,
             )
         else:
             return TestDatabase(
@@ -511,6 +515,7 @@ class Instance(object):
                 database_dialect=database_dialect,
                 database_role=database_role,
                 enable_drop_protection=enable_drop_protection,
+                observability_options=observability_options or self._observability_options,
             )
 
     def list_databases(self, page_size=None):

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -143,7 +143,7 @@ class Session(object):
         if self._labels:
             request.session.labels = self._labels
 
-        with trace_call("Session.create", self, self._labels,
+        with trace_call("CloudSpanner.CreateSession", self, self._labels,
                         observability_options=self._observability_options):
             session_pb = api.create_session(
                 request=request,
@@ -172,7 +172,7 @@ class Session(object):
             )
 
         opts = self._observability_options
-        with trace_call("Session.exists", self, observability_options=opts) as span:
+        with trace_call("CloudSpanner.GetSession", self, observability_options=opts) as span:
             try:
                 api.get_session(name=self.name, metadata=metadata)
                 if span:
@@ -198,7 +198,7 @@ class Session(object):
         api = self._database.spanner_api
         metadata = _metadata_with_prefix(self._database.name)
         opts = self._observability_options
-        with trace_call("Session.delete", self, observability_options=opts):
+        with trace_call("CloudSpanner.DeleteSession", self, observability_options=opts):
             api.delete_session(name=self.name, metadata=metadata)
 
     def ping(self):

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -143,7 +143,7 @@ class Session(object):
         if self._labels:
             request.session.labels = self._labels
 
-        with trace_call("CloudSpanner.CreateSession", self, self._labels,
+        with trace_call("Session.create", self, self._labels,
                         observability_options=self._observability_options):
             session_pb = api.create_session(
                 request=request,
@@ -172,7 +172,7 @@ class Session(object):
             )
 
         opts = self._observability_options
-        with trace_call("CloudSpanner.GetSession", self, observability_options=opts) as span:
+        with trace_call("Session.exists", self, observability_options=opts) as span:
             try:
                 api.get_session(name=self.name, metadata=metadata)
                 if span:
@@ -198,7 +198,7 @@ class Session(object):
         api = self._database.spanner_api
         metadata = _metadata_with_prefix(self._database.name)
         opts = self._observability_options
-        with trace_call("CloudSpanner.DeleteSession", self, observability_options=opts):
+        with trace_call("Session.delete", self, observability_options=opts):
             api.delete_session(name=self.name, metadata=metadata)
 
     def ping(self):

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -310,7 +310,7 @@ class _SnapshotBase(_SessionWrapper):
                 iterator = _restart_on_unavailable(
                     restart,
                     request,
-                    "CloudSpanner.ReadOnlyTransaction",
+                    "Snapshot.read",
                     self._session,
                     trace_attributes,
                     transaction=self,
@@ -326,7 +326,7 @@ class _SnapshotBase(_SessionWrapper):
             iterator = _restart_on_unavailable(
                 restart,
                 request,
-                "CloudSpanner.ReadOnlyTransaction",
+                "Snapshot.read",
                 self._session,
                 trace_attributes,
                 transaction=self,

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -498,18 +498,18 @@ class _SnapshotBase(_SessionWrapper):
             # lock is added to handle the inline begin for first rpc
             with self._lock:
                 return self._get_streamed_result_set(
-                    restart, request, trace_attributes, column_info, "Snapshot.execute_sql",
+                    restart, request, trace_attributes, column_info
                 )
         else:
             return self._get_streamed_result_set(
-                restart, request, trace_attributes, column_info, "Snapshot.execute_sql",
+                restart, request, trace_attributes, column_info
             )
 
-    def _get_streamed_result_set(self, restart, request, trace_attributes, column_info, span_name=None):
+    def _get_streamed_result_set(self, restart, request, trace_attributes, column_info):
         iterator = _restart_on_unavailable(
             restart,
             request,
-            span_name or "CloudSpanner.ReadWriteTransaction",
+            "CloudSpanner.ReadWriteTransaction",
             self._session,
             trace_attributes,
             transaction=self,
@@ -602,7 +602,7 @@ class _SnapshotBase(_SessionWrapper):
 
         trace_attributes = {"table_id": table, "columns": columns}
         with trace_call(
-            "Snapshot.partitionRead", self._session, trace_attributes,
+            "CloudSpanner.PartitionReadOnlyTransaction", self._session, trace_attributes,
             observability_options=self._observability_options,
         ):
             method = functools.partial(
@@ -703,7 +703,7 @@ class _SnapshotBase(_SessionWrapper):
 
         trace_attributes = {DB_STATEMENT: sql}
         with trace_call(
-            "Snapshot.partitionQuery",
+            "CloudSpanner.PartitionReadWriteTransaction",
             self._session,
             trace_attributes,
             observability_options=self._observability_options,
@@ -852,7 +852,7 @@ class Snapshot(_SnapshotBase):
             )
         txn_selector = self._make_txn_selector()
         opts = self._observability_options
-        with trace_call("Snapshot.begin", self._session, observability_options=opts):
+        with trace_call("CloudSpanner.BeginTransaction", self._session, observability_options=opts):
             method = functools.partial(
                 api.begin_transaction,
                 session=self._session.name,

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -38,7 +38,10 @@ from google.cloud.spanner_v1._helpers import (
     _check_rst_stream_error,
     _SessionWrapper,
 )
-from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
+from google.cloud.spanner_v1._opentelemetry_tracing import (
+    trace_call,
+    DB_STATEMENT,
+)
 from google.cloud.spanner_v1.streamed import StreamedResultSet
 from google.cloud.spanner_v1 import RequestOptions
 
@@ -488,7 +491,7 @@ class _SnapshotBase(_SessionWrapper):
             timeout=timeout,
         )
 
-        trace_attributes = {"db.statement": sql}
+        trace_attributes = {DB_STATEMENT: sql}
 
         if self._transaction_id is None:
             # lock is added to handle the inline begin for first rpc
@@ -696,7 +699,7 @@ class _SnapshotBase(_SessionWrapper):
             partition_options=partition_options,
         )
 
-        trace_attributes = {"db.statement": sql}
+        trace_attributes = {DB_STATEMENT: sql}
         with trace_call(
             "CloudSpanner.PartitionReadWriteTransaction",
             self._session,

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -498,18 +498,18 @@ class _SnapshotBase(_SessionWrapper):
             # lock is added to handle the inline begin for first rpc
             with self._lock:
                 return self._get_streamed_result_set(
-                    restart, request, trace_attributes, column_info
+                    restart, request, trace_attributes, column_info, "Snapshot.execute_sql",
                 )
         else:
             return self._get_streamed_result_set(
-                restart, request, trace_attributes, column_info
+                restart, request, trace_attributes, column_info, "Snapshot.execute_sql",
             )
 
-    def _get_streamed_result_set(self, restart, request, trace_attributes, column_info):
+    def _get_streamed_result_set(self, restart, request, trace_attributes, column_info, span_name=None):
         iterator = _restart_on_unavailable(
             restart,
             request,
-            "CloudSpanner.ReadWriteTransaction",
+            span_name or "CloudSpanner.ReadWriteTransaction",
             self._session,
             trace_attributes,
             transaction=self,
@@ -602,7 +602,7 @@ class _SnapshotBase(_SessionWrapper):
 
         trace_attributes = {"table_id": table, "columns": columns}
         with trace_call(
-            "CloudSpanner.PartitionReadOnlyTransaction", self._session, trace_attributes,
+            "Snapshot.partitionRead", self._session, trace_attributes,
             observability_options=self._observability_options,
         ):
             method = functools.partial(
@@ -703,7 +703,7 @@ class _SnapshotBase(_SessionWrapper):
 
         trace_attributes = {DB_STATEMENT: sql}
         with trace_call(
-            "CloudSpanner.PartitionReadWriteTransaction",
+            "Snapshot.partitionQuery",
             self._session,
             trace_attributes,
             observability_options=self._observability_options,
@@ -852,7 +852,7 @@ class Snapshot(_SnapshotBase):
             )
         txn_selector = self._make_txn_selector()
         opts = self._observability_options
-        with trace_call("CloudSpanner.BeginTransaction", self._session, observability_options=opts):
+        with trace_call("Snapshot.begin", self._session, observability_options=opts):
             method = functools.partial(
                 api.begin_transaction,
                 session=self._session.name,

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -113,7 +113,8 @@ class Transaction(_SnapshotBase, _BatchBase):
         """
         transaction = self._make_txn_selector()
         request.transaction = transaction
-        with trace_call(trace_name, session, attributes):
+        with trace_call(trace_name, session, attributes,
+                        observability_options=self._observability_options):
             method = functools.partial(method, request=request)
             response = _retry(
                 method,
@@ -150,7 +151,8 @@ class Transaction(_SnapshotBase, _BatchBase):
             read_write=TransactionOptions.ReadWrite(),
             exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
         )
-        with trace_call("CloudSpanner.BeginTransaction", self._session):
+        with trace_call("CloudSpanner.BeginTransaction", self._session,
+                        observability_options=.self._observability_options):
             method = functools.partial(
                 api.begin_transaction,
                 session=self._session.name,
@@ -178,7 +180,8 @@ class Transaction(_SnapshotBase, _BatchBase):
                         database._route_to_leader_enabled
                     )
                 )
-            with trace_call("CloudSpanner.Rollback", self._session):
+            with trace_call("CloudSpanner.Rollback", self._session,
+                        observability_options=.self._observability_options):
                 method = functools.partial(
                     api.rollback,
                     session=self._session.name,
@@ -251,7 +254,8 @@ class Transaction(_SnapshotBase, _BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("CloudSpanner.Commit", self._session, trace_attributes):
+        with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
+                        observability_options=.self._observability_options):
             method = functools.partial(
                 api.commit,
                 request=request,

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Spanner read-write transaction support."""
 import functools
 import threading
@@ -90,20 +91,18 @@ class Transaction(_SnapshotBase, _BatchBase):
         self._check_state()
 
         if self._transaction_id is None:
-            return TransactionSelector(begin=TransactionOptions(
-                read_write=TransactionOptions.ReadWrite(),
-                exclude_txn_from_change_streams=self.
-                exclude_txn_from_change_streams,
-            ))
+            return TransactionSelector(
+                begin=TransactionOptions(
+                    read_write=TransactionOptions.ReadWrite(),
+                    exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
+                )
+            )
         else:
             return TransactionSelector(id=self._transaction_id)
 
-    def _execute_request(self,
-                         method,
-                         request,
-                         trace_name=None,
-                         session=None,
-                         attributes=None):
+    def _execute_request(
+        self, method, request, trace_name=None, session=None, attributes=None
+    ):
         """Helper method to execute request after fetching transaction selector.
 
         :type method: callable
@@ -118,9 +117,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             method = functools.partial(method, request=request)
             response = _retry(
                 method,
-                allowed_exceptions={
-                    InternalServerError: _check_rst_stream_error
-                },
+                allowed_exceptions={InternalServerError: _check_rst_stream_error},
             )
 
         return response
@@ -147,12 +144,11 @@ class Transaction(_SnapshotBase, _BatchBase):
         metadata = _metadata_with_prefix(database.name)
         if database._route_to_leader_enabled:
             metadata.append(
-                _metadata_with_leader_aware_routing(
-                    database._route_to_leader_enabled))
+                _metadata_with_leader_aware_routing(database._route_to_leader_enabled)
+            )
         txn_options = TransactionOptions(
             read_write=TransactionOptions.ReadWrite(),
-            exclude_txn_from_change_streams=self.
-            exclude_txn_from_change_streams,
+            exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
         )
         with trace_call("CloudSpanner.BeginTransaction", self._session):
             method = functools.partial(
@@ -163,9 +159,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             )
             response = _retry(
                 method,
-                allowed_exceptions={
-                    InternalServerError: _check_rst_stream_error
-                },
+                allowed_exceptions={InternalServerError: _check_rst_stream_error},
             )
         self._transaction_id = response.id
         return self._transaction_id
@@ -181,7 +175,9 @@ class Transaction(_SnapshotBase, _BatchBase):
             if database._route_to_leader_enabled:
                 metadata.append(
                     _metadata_with_leader_aware_routing(
-                        database._route_to_leader_enabled))
+                        database._route_to_leader_enabled
+                    )
+                )
             with trace_call("CloudSpanner.Rollback", self._session):
                 method = functools.partial(
                     api.rollback,
@@ -191,17 +187,14 @@ class Transaction(_SnapshotBase, _BatchBase):
                 )
                 _retry(
                     method,
-                    allowed_exceptions={
-                        InternalServerError: _check_rst_stream_error
-                    },
+                    allowed_exceptions={InternalServerError: _check_rst_stream_error},
                 )
         self.rolled_back = True
         del self._session._transaction
 
-    def commit(self,
-               return_commit_stats=False,
-               request_options=None,
-               max_commit_delay=None):
+    def commit(
+        self, return_commit_stats=False, request_options=None, max_commit_delay=None
+    ):
         """Commit mutations to the database.
 
         :type return_commit_stats: bool
@@ -236,8 +229,8 @@ class Transaction(_SnapshotBase, _BatchBase):
         metadata = _metadata_with_prefix(database.name)
         if database._route_to_leader_enabled:
             metadata.append(
-                _metadata_with_leader_aware_routing(
-                    database._route_to_leader_enabled))
+                _metadata_with_leader_aware_routing(database._route_to_leader_enabled)
+            )
         trace_attributes = {"num_mutations": len(self._mutations)}
 
         if request_options is None:
@@ -258,8 +251,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("CloudSpanner.Commit", self._session,
-                        trace_attributes):
+        with trace_call("CloudSpanner.Commit", self._session, trace_attributes):
             method = functools.partial(
                 api.commit,
                 request=request,
@@ -267,9 +259,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             )
             response = _retry(
                 method,
-                allowed_exceptions={
-                    InternalServerError: _check_rst_stream_error
-                },
+                allowed_exceptions={InternalServerError: _check_rst_stream_error},
             )
         self.committed = response.commit_timestamp
         if return_commit_stats:
@@ -298,10 +288,9 @@ class Transaction(_SnapshotBase, _BatchBase):
             If ``params`` is None but ``param_types`` is not None.
         """
         if params is not None:
-            return Struct(fields={
-                key: _make_value_pb(value)
-                for key, value in params.items()
-            })
+            return Struct(
+                fields={key: _make_value_pb(value) for key, value in params.items()}
+            )
 
         return {}
 
@@ -363,8 +352,8 @@ class Transaction(_SnapshotBase, _BatchBase):
         metadata = _metadata_with_prefix(database.name)
         if database._route_to_leader_enabled:
             metadata.append(
-                _metadata_with_leader_aware_routing(
-                    database._route_to_leader_enabled))
+                _metadata_with_leader_aware_routing(database._route_to_leader_enabled)
+            )
         api = database.spanner_api
 
         seqno, self._execute_sql_count = (
@@ -375,8 +364,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         # Query-level options have higher precedence than client-level and
         # environment-level options
         default_query_options = database._instance._client._query_options
-        query_options = _merge_query_options(default_query_options,
-                                             query_options)
+        query_options = _merge_query_options(default_query_options, query_options)
 
         if request_options is None:
             request_options = RequestOptions()
@@ -416,9 +404,12 @@ class Transaction(_SnapshotBase, _BatchBase):
                     trace_attributes,
                 )
                 # Setting the transaction id because the transaction begin was inlined for first rpc.
-                if (self._transaction_id is None and response is not None
-                        and response.metadata is not None
-                        and response.metadata.transaction is not None):
+                if (
+                    self._transaction_id is None
+                    and response is not None
+                    and response.metadata is not None
+                    and response.metadata.transaction is not None
+                ):
                     self._transaction_id = response.metadata.transaction.id
         else:
             response = self._execute_request(
@@ -481,16 +472,17 @@ class Transaction(_SnapshotBase, _BatchBase):
                 dml, params, param_types = statement
                 params_pb = self._make_params_pb(params, param_types)
                 parsed.append(
-                    ExecuteBatchDmlRequest.Statement(sql=dml,
-                                                     params=params_pb,
-                                                     param_types=param_types))
+                    ExecuteBatchDmlRequest.Statement(
+                        sql=dml, params=params_pb, param_types=param_types
+                    )
+                )
 
         database = self._session._database
         metadata = _metadata_with_prefix(database.name)
         if database._route_to_leader_enabled:
             metadata.append(
-                _metadata_with_leader_aware_routing(
-                    database._route_to_leader_enabled))
+                _metadata_with_leader_aware_routing(database._route_to_leader_enabled)
+            )
         api = database.spanner_api
 
         seqno, self._execute_sql_count = (
@@ -535,9 +527,11 @@ class Transaction(_SnapshotBase, _BatchBase):
                 )
                 # Setting the transaction id because the transaction begin was inlined for first rpc.
                 for result_set in response.result_sets:
-                    if (self._transaction_id is None
-                            and result_set.metadata is not None
-                            and result_set.metadata.transaction is not None):
+                    if (
+                        self._transaction_id is None
+                        and result_set.metadata is not None
+                        and result_set.metadata.transaction is not None
+                    ):
                         self._transaction_id = result_set.metadata.transaction.id
                         break
         else:
@@ -550,8 +544,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             )
 
         row_counts = [
-            result_set.stats.row_count_exact
-            for result_set in response.result_sets
+            result_set.stats.row_count_exact for result_set in response.result_sets
         ]
 
         return response.status, row_counts

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -151,7 +151,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             read_write=TransactionOptions.ReadWrite(),
             exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
         )
-        with trace_call("Transaction.begin", self._session,
+        with trace_call("CloudSpanner.BeginTransaction", self._session,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.begin_transaction,
@@ -180,7 +180,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                         database._route_to_leader_enabled
                     )
                 )
-            with trace_call("Transaction.Rollback", self._session,
+            with trace_call("CloudSpanner.Rollback", self._session,
                         observability_options=self._observability_options):
                 method = functools.partial(
                     api.rollback,
@@ -254,7 +254,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("Transaction.Commit", self._session, trace_attributes,
+        with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.commit,
@@ -403,7 +403,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 response = self._execute_request(
                     method,
                     request,
-                    "Transaction.executeSqlRequest",
+                    "CloudSpanner.ReadWriteTransaction",
                     self._session,
                     trace_attributes,
                 )
@@ -419,7 +419,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             response = self._execute_request(
                 method,
                 request,
-                "Transaction.executeSqlRequest",
+                "CloudSpanner.ReadWriteTransaction",
                 self._session,
                 trace_attributes,
             )
@@ -525,7 +525,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 response = self._execute_request(
                     method,
                     request,
-                    "Transaction.executeBatchDML",
+                    "CloudSpanner.DMLTransaction",
                     self._session,
                     trace_attributes,
                 )
@@ -542,7 +542,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             response = self._execute_request(
                 method,
                 request,
-                "Transaction.executeBatchDML",
+                "CloudSpanner.DMLTransaction",
                 self._session,
                 trace_attributes,
             )

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -152,7 +152,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
         )
         with trace_call("CloudSpanner.BeginTransaction", self._session,
-                        observability_options=.self._observability_options):
+                        observability_options=self._observability_options):
             method = functools.partial(
                 api.begin_transaction,
                 session=self._session.name,
@@ -181,7 +181,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                     )
                 )
             with trace_call("CloudSpanner.Rollback", self._session,
-                        observability_options=.self._observability_options):
+                        observability_options=self._observability_options):
                 method = functools.partial(
                     api.rollback,
                     session=self._session.name,
@@ -255,7 +255,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             request_options=request_options,
         )
         with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
-                        observability_options=.self._observability_options):
+                        observability_options=self._observability_options):
             method = functools.partial(
                 api.commit,
                 request=request,

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -151,7 +151,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             read_write=TransactionOptions.ReadWrite(),
             exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
         )
-        with trace_call("CloudSpanner.BeginTransaction", self._session,
+        with trace_call("Transaction.begin", self._session,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.begin_transaction,
@@ -180,7 +180,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                         database._route_to_leader_enabled
                     )
                 )
-            with trace_call("CloudSpanner.Rollback", self._session,
+            with trace_call("Transaction.Rollback", self._session,
                         observability_options=self._observability_options):
                 method = functools.partial(
                     api.rollback,
@@ -254,7 +254,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             max_commit_delay=max_commit_delay,
             request_options=request_options,
         )
-        with trace_call("CloudSpanner.Commit", self._session, trace_attributes,
+        with trace_call("Transaction.Commit", self._session, trace_attributes,
                         observability_options=self._observability_options):
             method = functools.partial(
                 api.commit,
@@ -403,7 +403,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 response = self._execute_request(
                     method,
                     request,
-                    "CloudSpanner.ReadWriteTransaction",
+                    "Transaction.executeSqlRequest",
                     self._session,
                     trace_attributes,
                 )
@@ -419,7 +419,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             response = self._execute_request(
                 method,
                 request,
-                "CloudSpanner.ReadWriteTransaction",
+                "Transaction.executeSqlRequest",
                 self._session,
                 trace_attributes,
             )
@@ -525,7 +525,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 response = self._execute_request(
                     method,
                     request,
-                    "CloudSpanner.DMLTransaction",
+                    "Transaction.executeBatchDML",
                     self._session,
                     trace_attributes,
                 )
@@ -542,7 +542,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             response = self._execute_request(
                 method,
                 request,
-                "CloudSpanner.DMLTransaction",
+                "Transaction.executeBatchDML",
                 self._session,
                 trace_attributes,
             )

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,10 @@ dependencies = [
 ]
 extras = {
     "tracing": [
-        "opentelemetry-api >= 1.1.0",
-        "opentelemetry-sdk >= 1.1.0",
-        "opentelemetry-instrumentation >= 0.20b0, < 0.23dev",
+        "opentelemetry-api >= 1.25.0",
+        "opentelemetry-sdk >= 1.25.0",
+        "opentelemetry-instrumentation >= 0.46b0",
+        "opentelemetry-semantic-conventions >= 0.46b0",
     ],
     "libcst": "libcst >= 0.2.5",
 }

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ dependencies = [
 ]
 extras = {
     "tracing": [
-        "opentelemetry-api >= 1.25.0",
-        "opentelemetry-sdk >= 1.25.0",
+        "opentelemetry-api >= 1.24.0",
+        "opentelemetry-sdk >= 1.24.0",
         "opentelemetry-instrumentation >= 0.46b0",
         "opentelemetry-semantic-conventions >= 0.46b0",
     ],

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -10,8 +10,8 @@ grpc-google-iam-v1==0.12.4
 libcst==0.2.5
 proto-plus==1.22.0
 sqlparse==0.4.4
-opentelemetry-api==1.25.0
-opentelemetry-sdk==1.25.0
+opentelemetry-api>=1.24.0
+opentelemetry-sdk>=1.24.0
 opentelemetry-instrumentation==0.46b0
 opentelemetry-semantic-conventions==0.46b0
 protobuf==3.20.2

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -10,9 +10,10 @@ grpc-google-iam-v1==0.12.4
 libcst==0.2.5
 proto-plus==1.22.0
 sqlparse==0.4.4
-opentelemetry-api==1.1.0
-opentelemetry-sdk==1.1.0
-opentelemetry-instrumentation==0.20b0
+opentelemetry-api==1.25.0
+opentelemetry-sdk==1.25.0
+opentelemetry-instrumentation==0.46b0
+opentelemetry-semantic-conventions==0.46b0
 protobuf==3.20.2
 deprecated==1.2.14
 grpc-interceptor==0.15.4

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import mock
 
@@ -32,6 +33,7 @@ except ImportError:
 
 _TEST_OT_EXPORTER = None
 _TEST_OT_PROVIDER_INITIALIZED = False
+EXTENDED_TRACING_ENABLED = os.environ.get('SPANNER_ENABLE_EXTENDED_TRACING', '') == 'true'
 
 
 def get_test_ot_exporter():

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -21,6 +21,7 @@ try:
     DB_NAME = SpanAttributes.DB_NAME
     DB_CONNECTION_STRING = SpanAttributes.DB_CONNECTION_STRING
     NET_HOST_NAME = SpanAttributes.NET_HOST_NAME
+    DB_STATEMENT = SpanAttributes.DB_STATEMENT
 
 except ImportError:
     HAS_OPENTELEMETRY_INSTALLED = False
@@ -30,6 +31,7 @@ except ImportError:
     DB_NAME = "db.name"
     DB_CONNECTION_STRING = "db.connection_string"
     NET_HOST_NAME = "net.host.name"
+    DB_STATEMENT = "db.statement"
 
 _TEST_OT_EXPORTER = None
 _TEST_OT_PROVIDER_INITIALIZED = False

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -10,13 +10,25 @@ try:
     )
     from opentelemetry.trace.status import StatusCode
 
+    from opentelemetry.semconv.trace import SpanAttributes
+
     trace.set_tracer_provider(TracerProvider())
 
     HAS_OPENTELEMETRY_INSTALLED = True
+    
+    DB_SYSTEM = SpanAttributes.DB_SYSTEM
+    DB_NAME = SpanAttributes.DB_NAME
+    DB_CONNECTION_STRING = SpanAttributes.DB_CONNECTION_STRING
+    NET_HOST_NAME = SpanAttributes.NET_HOST_NAME
+
 except ImportError:
     HAS_OPENTELEMETRY_INSTALLED = False
 
     StatusCode = mock.Mock()
+    DB_SYSTEM = "db.system"
+    DB_NAME = "db.name"
+    DB_CONNECTION_STRING = "db.connection_string"
+    NET_HOST_NAME = "net.host.name"
 
 _TEST_OT_EXPORTER = None
 _TEST_OT_PROVIDER_INITIALIZED = False

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -12,6 +12,10 @@ try:
     from opentelemetry.trace.status import StatusCode
 
     from opentelemetry.semconv.trace import SpanAttributes
+    from opentelemetry.semconv.attributes import (
+       OTEL_SCOPE_NAME,
+       OTEL_SCOPE_VERSION,
+    )
 
     trace.set_tracer_provider(TracerProvider())
 
@@ -32,6 +36,8 @@ except ImportError:
     DB_CONNECTION_STRING = "db.connection_string"
     NET_HOST_NAME = "net.host.name"
     DB_STATEMENT = "db.statement"
+    OTEL_SCOPE_NAME = "otel.scope.name"
+    OTEL_SCOPE_VERSION = "otel.scope.version"
 
 _TEST_OT_EXPORTER = None
 _TEST_OT_PROVIDER_INITIALIZED = False

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -341,10 +341,10 @@ def assert_span_attributes(
 
 def _make_attributes(db_instance, **kwargs):
     attributes = {
-        "db.type": "spanner",
-        "db.url": "spanner.googleapis.com",
-        "net.host.name": "spanner.googleapis.com",
-        "db.instance": db_instance,
+        ot_helpers.DB_SYSTEM: "google.cloud.spanner",
+        ot_helpers.DB_CONNECTION_STRING: "spanner.googleapis.com",
+        ot_helpers.DB_NAME: db_instance,
+        ot_helpers.NET_HOST_NAME: "spanner.googleapis.com",
     }
     attributes.update(kwargs)
 

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -341,7 +341,7 @@ def assert_span_attributes(
 
 def _make_attributes(db_instance, **kwargs):
     attributes = {
-        ot_helpers.DB_SYSTEM: "google.cloud.spanner",
+        ot_helpers.DB_SYSTEM: "spanner",
         ot_helpers.DB_CONNECTION_STRING: "spanner.googleapis.com",
         ot_helpers.DB_NAME: db_instance,
         ot_helpers.NET_HOST_NAME: "spanner.googleapis.com",

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -63,7 +63,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
             }
 
             expected_attributes = {
-                DB_SYSTEM: "google.cloud.spanner",
+                DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
             }
@@ -88,7 +88,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
             extra_attributes = {DB_NAME: "database_name"}
 
             expected_attributes = {
-                DB_SYSTEM: "google.cloud.spanner",
+                DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
             }
@@ -115,7 +115,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
             extra_attributes = {DB_NAME: "database_name"}
 
             expected_attributes = {
-                DB_SYSTEM: "google.cloud.spanner",
+                DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
             }
@@ -139,7 +139,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
             extra_attributes = {DB_NAME: "database_name"}
 
             expected_attributes = {
-                DB_SYSTEM: "google.cloud.spanner",
+                DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
             }

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -12,8 +12,15 @@ except ImportError:
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.spanner_v1 import _opentelemetry_tracing
 
-from tests._helpers import OpenTelemetryBase, HAS_OPENTELEMETRY_INSTALLED
-
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCode,
+    DB_SYSTEM,
+    DB_NAME,
+    DB_CONNECTION_STRING,
+    HAS_OPENTELEMETRY_INSTALLED,
+    NET_HOST_NAME,
+)
 
 def _make_rpc_error(error_cls, trailing_metadata=None):
     import grpc
@@ -51,14 +58,14 @@ if HAS_OPENTELEMETRY_INSTALLED:
         def test_trace_call(self):
             extra_attributes = {
                 "attribute1": "value1",
-                # Since our database is mocked, we have to override the db.instance parameter so it is a string
-                "db.instance": "database_name",
+                # Since our database is mocked, we have to override the DB_NAME parameter so it is a string
+                DB_NAME: "database_name",
             }
 
             expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com",
-                "net.host.name": "spanner.googleapis.com",
+                DB_SYSTEM: "google.cloud.spanner",
+                DB_CONNECTION_STRING: "spanner.googleapis.com",
+                NET_HOST_NAME: "spanner.googleapis.com",
             }
             expected_attributes.update(extra_attributes)
 
@@ -78,13 +85,14 @@ if HAS_OPENTELEMETRY_INSTALLED:
             self.assertEqual(span.status.status_code, StatusCode.OK)
 
         def test_trace_error(self):
-            extra_attributes = {"db.instance": "database_name"}
+            extra_attributes = {DB_NAME: "database_name"}
 
             expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com",
-                "net.host.name": "spanner.googleapis.com",
+                DB_SYSTEM: "google.cloud.spanner",
+                DB_CONNECTION_STRING: "spanner.googleapis.com",
+                NET_HOST_NAME: "spanner.googleapis.com",
             }
+            
             expected_attributes.update(extra_attributes)
 
             with self.assertRaises(GoogleAPICallError):
@@ -104,13 +112,14 @@ if HAS_OPENTELEMETRY_INSTALLED:
             self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
         def test_trace_grpc_error(self):
-            extra_attributes = {"db.instance": "database_name"}
+            extra_attributes = {DB_NAME: "database_name"}
 
             expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com:443",
-                "net.host.name": "spanner.googleapis.com:443",
+                DB_SYSTEM: "google.cloud.spanner",
+                DB_CONNECTION_STRING: "spanner.googleapis.com",
+                NET_HOST_NAME: "spanner.googleapis.com",
             }
+
             expected_attributes.update(extra_attributes)
 
             with self.assertRaises(GoogleAPICallError):
@@ -127,13 +136,14 @@ if HAS_OPENTELEMETRY_INSTALLED:
             self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
         def test_trace_codeless_error(self):
-            extra_attributes = {"db.instance": "database_name"}
+            extra_attributes = {DB_NAME: "database_name"}
 
             expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com:443",
-                "net.host.name": "spanner.googleapis.com:443",
+                DB_SYSTEM: "google.cloud.spanner",
+                DB_CONNECTION_STRING: "spanner.googleapis.com",
+                NET_HOST_NAME: "spanner.googleapis.com",
             }
+
             expected_attributes.update(extra_attributes)
 
             with self.assertRaises(GoogleAPICallError):

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -20,6 +20,7 @@ from tests._helpers import (
     DB_CONNECTION_STRING,
     HAS_OPENTELEMETRY_INSTALLED,
     NET_HOST_NAME,
+    OTEL_SCOPE_NAME,
 )
 
 def _make_rpc_error(error_cls, trailing_metadata=None):
@@ -66,6 +67,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
                 DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
+                OTEL_SCOPE_NAME: "cloud.google.com/python/spanner",
             }
             expected_attributes.update(extra_attributes)
 
@@ -91,6 +93,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
                 DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
+                OTEL_SCOPE_NAME: "cloud.google.com/python/spanner",
             }
             
             expected_attributes.update(extra_attributes)
@@ -118,6 +121,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
                 DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
+                OTEL_SCOPE_NAME: "cloud.google.com/python/spanner",
             }
 
             expected_attributes.update(extra_attributes)
@@ -142,6 +146,7 @@ if HAS_OPENTELEMETRY_INSTALLED:
                 DB_SYSTEM: "spanner",
                 DB_CONNECTION_STRING: "spanner.googleapis.com",
                 NET_HOST_NAME: "spanner.googleapis.com",
+                OTEL_SCOPE_NAME: "cloud.google.com/python/spanner",
             }
 
             expected_attributes.update(extra_attributes)

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -14,7 +14,14 @@
 
 
 import unittest
-from tests._helpers import OpenTelemetryBase, StatusCode
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCode,
+    DB_SYSTEM,
+    DB_NAME,
+    DB_CONNECTION_STRING,
+    NET_HOST_NAME,
+)
 from google.cloud.spanner_v1 import RequestOptions
 
 TABLE_NAME = "citizens"
@@ -24,10 +31,10 @@ VALUES = [
     ["bharney@example.com", "Bharney", "Rhubble", 31],
 ]
 BASE_ATTRIBUTES = {
-    "db.type": "spanner",
-    "db.url": "spanner.googleapis.com",
-    "db.instance": "testing",
-    "net.host.name": "spanner.googleapis.com",
+    DB_SYSTEM: "google.cloud.spanner",
+    DB_CONNECTION_STRING: "spanner.googleapis.com",
+    DB_NAME: "testing",
+    NET_HOST_NAME: "spanner.googleapis.com",
 }
 
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -31,7 +31,7 @@ VALUES = [
     ["bharney@example.com", "Bharney", "Rhubble", 31],
 ]
 BASE_ATTRIBUTES = {
-    DB_SYSTEM: "google.cloud.spanner",
+    DB_SYSTEM: "spanner",
     DB_CONNECTION_STRING: "spanner.googleapis.com",
     DB_NAME: "testing",
     NET_HOST_NAME: "spanner.googleapis.com",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -50,7 +50,7 @@ class TestSession(OpenTelemetryBase):
     SESSION_NAME = DATABASE_NAME + "/sessions/" + SESSION_ID
     DATABASE_ROLE = "dummy-role"
     BASE_ATTRIBUTES = {
-        DB_SYSTEM: "google.cloud.spanner",
+        DB_SYSTEM: "spanner",
         DB_CONNECTION_STRING: "spanner.googleapis.com",
         DB_NAME: DATABASE_NAME,
         NET_HOST_NAME: "spanner.googleapis.com",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -20,6 +20,10 @@ from tests._helpers import (
     OpenTelemetryBase,
     StatusCode,
     HAS_OPENTELEMETRY_INSTALLED,
+    DB_SYSTEM,
+    DB_NAME,
+    DB_CONNECTION_STRING,
+    NET_HOST_NAME,
 )
 
 
@@ -46,12 +50,11 @@ class TestSession(OpenTelemetryBase):
     SESSION_NAME = DATABASE_NAME + "/sessions/" + SESSION_ID
     DATABASE_ROLE = "dummy-role"
     BASE_ATTRIBUTES = {
-        "db.type": "spanner",
-        "db.url": "spanner.googleapis.com",
-        "db.instance": DATABASE_NAME,
-        "net.host.name": "spanner.googleapis.com",
+        DB_SYSTEM: "google.cloud.spanner",
+        DB_CONNECTION_STRING: "spanner.googleapis.com",
+        DB_NAME: DATABASE_NAME,
+        NET_HOST_NAME: "spanner.googleapis.com",
     }
-
     def _getTargetClass(self):
         from google.cloud.spanner_v1.session import Session
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -55,6 +55,7 @@ class TestSession(OpenTelemetryBase):
         DB_NAME: DATABASE_NAME,
         NET_HOST_NAME: "spanner.googleapis.com",
     }
+
     def _getTargetClass(self):
         from google.cloud.spanner_v1.session import Session
 

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -20,12 +20,12 @@ from google.cloud.spanner_v1 import RequestOptions, DirectedReadOptions
 from tests._helpers import (
     OpenTelemetryBase,
     StatusCode,
+    EXTENDED_TRACING_ENABLED,
     HAS_OPENTELEMETRY_INSTALLED,
     DB_STATEMENT,
     DB_SYSTEM,
     DB_NAME,
     DB_CONNECTION_STRING,
-    EXTENDED_TRACING_EANBLED,
     NET_HOST_NAME,
 )
 from google.cloud.spanner_v1.param_types import INT64
@@ -868,11 +868,17 @@ class Test_SnapshotBase(OpenTelemetryBase):
 
         self.assertEqual(derived._execute_sql_count, 1)
 
-        if EXTENDED_TRACING_EANBLED:
+        if EXTENDED_TRACING_ENABLED:
             self.assertSpanAttributes(
                 "CloudSpanner.ReadWriteTransaction",
                 status=StatusCode.ERROR,
                 attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY}),
+            )
+        else:
+            self.assertSpanAttributes(
+                "CloudSpanner.ReadWriteTransaction",
+                status=StatusCode.ERROR,
+                attributes=BASE_ATTRIBUTES,
             )
 
     def _execute_sql_helper(
@@ -1025,11 +1031,18 @@ class Test_SnapshotBase(OpenTelemetryBase):
 
         self.assertEqual(derived._execute_sql_count, sql_count + 1)
 
-        self.assertSpanAttributes(
-            "CloudSpanner.ReadWriteTransaction",
-            status=StatusCode.OK,
-            attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY_WITH_PARAM}),
-        )
+        if EXTENDED_TRACING_ENABLED:
+            self.assertSpanAttributes(
+                "CloudSpanner.ReadWriteTransaction",
+                status=StatusCode.OK,
+                attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY_WITH_PARAM}),
+            )
+        else:
+            self.assertSpanAttributes(
+                "CloudSpanner.ReadWriteTransaction",
+                status=StatusCode.OK,
+                attributes=BASE_ATTRIBUTES,
+            )
 
     def test_execute_sql_wo_multi_use(self):
         self._execute_sql_helper(multi_use=False)
@@ -1370,11 +1383,18 @@ class Test_SnapshotBase(OpenTelemetryBase):
             timeout=timeout,
         )
 
-        self.assertSpanAttributes(
-            "CloudSpanner.PartitionReadWriteTransaction",
-            status=StatusCode.OK,
-            attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY_WITH_PARAM}),
-        )
+        if EXTENDED_TRACING_ENABLED:
+            self.assertSpanAttributes(
+                "CloudSpanner.PartitionReadWriteTransaction",
+                status=StatusCode.OK,
+                attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY_WITH_PARAM}),
+            )
+        else:
+            self.assertSpanAttributes(
+                "CloudSpanner.PartitionReadWriteTransaction",
+                status=StatusCode.OK,
+                attributes=BASE_ATTRIBUTES,
+            )
 
     def test_partition_query_other_error(self):
         database = _Database()
@@ -1388,11 +1408,18 @@ class Test_SnapshotBase(OpenTelemetryBase):
         with self.assertRaises(RuntimeError):
             list(derived.partition_query(SQL_QUERY))
 
-        self.assertSpanAttributes(
-            "CloudSpanner.PartitionReadWriteTransaction",
-            status=StatusCode.ERROR,
-            attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY}),
-        )
+        if EXTENDED_TRACING_ENABLED:
+            self.assertSpanAttributes(
+                "CloudSpanner.PartitionReadWriteTransaction",
+                status=StatusCode.ERROR,
+                attributes=dict(BASE_ATTRIBUTES, **{DB_STATEMENT: SQL_QUERY}),
+            )
+        else:
+            self.assertSpanAttributes(
+                "CloudSpanner.PartitionReadWriteTransaction",
+                status=StatusCode.ERROR,
+                attributes=BASE_ATTRIBUTES,
+            )
 
     def test_partition_query_single_use_raises(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -47,7 +47,7 @@ TXN_ID = b"DEAFBEAD"
 SECONDS = 3
 MICROS = 123456
 BASE_ATTRIBUTES = {
-    DB_SYSTEM: "google.cloud.spanner",
+    DB_SYSTEM: "spanner",
     DB_CONNECTION_STRING: "spanner.googleapis.com",
     DB_NAME: "testing",
     NET_HOST_NAME: "spanner.googleapis.com",
@@ -537,7 +537,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
                 self.assertEqual(
                     dict(span.attributes),
                     {
-                        DB_SYSTEM: "google.cloud.spanner",
+                        DB_SYSTEM: "spanner",
                         DB_CONNECTION_STRING: "spanner.googleapis.com",
                         DB_NAME: "testing",
                         NET_HOST_NAME: "spanner.googleapis.com",

--- a/tests/unit/test_spanner.py
+++ b/tests/unit/test_spanner.py
@@ -45,7 +45,13 @@ import mock
 
 from google.api_core import gapic_v1
 
-from tests._helpers import OpenTelemetryBase
+from tests._helpers import (
+    OpenTelemetryBase,
+    DB_SYSTEM,
+    DB_NAME,
+    DB_CONNECTION_STRING,
+    NET_HOST_NAME,
+)
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -110,10 +116,10 @@ class TestTransaction(OpenTelemetryBase):
     TRANSACTION_TAG = "transaction-tag"
 
     BASE_ATTRIBUTES = {
-        "db.type": "spanner",
-        "db.url": "spanner.googleapis.com",
-        "db.instance": "testing",
-        "net.host.name": "spanner.googleapis.com",
+        DB_SYSTEM: "google.cloud.spanner",
+        DB_CONNECTION_STRING: "spanner.googleapis.com",
+        DB_NAME: "testing",
+        NET_HOST_NAME: "spanner.googleapis.com",
     }
 
     def _getTargetClass(self):

--- a/tests/unit/test_spanner.py
+++ b/tests/unit/test_spanner.py
@@ -116,7 +116,7 @@ class TestTransaction(OpenTelemetryBase):
     TRANSACTION_TAG = "transaction-tag"
 
     BASE_ATTRIBUTES = {
-        DB_SYSTEM: "google.cloud.spanner",
+        DB_SYSTEM: "spanner",
         DB_CONNECTION_STRING: "spanner.googleapis.com",
         DB_NAME: "testing",
         NET_HOST_NAME: "spanner.googleapis.com",

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -60,7 +60,7 @@ class TestTransaction(OpenTelemetryBase):
     TRANSACTION_TAG = "transaction-tag"
 
     BASE_ATTRIBUTES = {
-        DB_SYSTEM: "google.cloud.spanner",
+        DB_SYSTEM: "spanner",
         DB_CONNECTION_STRING: "spanner.googleapis.com",
         DB_NAME: "testing",
         NET_HOST_NAME: "spanner.googleapis.com",

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -21,7 +21,14 @@ from google.cloud.spanner_v1 import TypeCode
 from google.api_core.retry import Retry
 from google.api_core import gapic_v1
 
-from tests._helpers import OpenTelemetryBase, StatusCode
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCode,
+    DB_SYSTEM,
+    DB_NAME,
+    DB_CONNECTION_STRING,
+    NET_HOST_NAME,
+)
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -53,10 +60,10 @@ class TestTransaction(OpenTelemetryBase):
     TRANSACTION_TAG = "transaction-tag"
 
     BASE_ATTRIBUTES = {
-        "db.type": "spanner",
-        "db.url": "spanner.googleapis.com",
-        "db.instance": "testing",
-        "net.host.name": "spanner.googleapis.com",
+        DB_SYSTEM: "google.cloud.spanner",
+        DB_CONNECTION_STRING: "spanner.googleapis.com",
+        DB_NAME: "testing",
+        NET_HOST_NAME: "spanner.googleapis.com",
     }
 
     def _getTargetClass(self):


### PR DESCRIPTION
This change modernizes trace span attributes by using OpenTelemetry's
semantic conventions that are standardized and allow for much
better common ground adoption by broader systems, even more as
Google Cloud Tracing & Monitoring pushes towards OpenTelemetry more.

With this change we've made the replacement of these fields, directly
with imports from `opentelemetry.semconv.trace.SpanAttributes`, as:

* "db.type"       => DB_SYSTEM aka "db.system"
* "db.url"        => DB_CONNECTION_STRING aka "db.connection_string"
* "db.instance"   => DB_NAME aka "db.name"
* "net.host.name" => NET_HOST_NAME aka "net.host.name"

While here, also updated opentelemetry-(api, sdk) dependencies to use
versions "1.25.0", then opentelemetry-(instrumentation) to "0.46b0"

Also added in an option toggled by environment variable

    ENABLE_EXTENDED_TRACING=true

which allows spans to be annotated with the SQL statement keyed by

    "db.statement"

Fixes #1170
Fixes #1171
Fixes #1173

## Exhibit
With the change made, we now have this trace with attributes visualized from Google Cloud Tracing per
<img width="1434" alt="Screenshot 2024-07-26 at 7 12 42 PM" src="https://github.com/user-attachments/assets/f71df423-9a99-46dd-994f-dfb763416b6c">
<img width="699" alt="Screenshot 2024-07-26 at 7 11 10 PM" src="https://github.com/user-attachments/assets/ae99a24c-8f1f-4487-83e5-04075e42f83c">