### PR TITLE
tracing: update OpenTelemetry dependencies from 2021 to 2024

### DIFF
--- a/examples/grpc_instrumentation_enabled.py
+++ b/examples/grpc_instrumentation_enabled.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import os
+import time
+
+import google.cloud.spanner as spanner
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry import trace
+
+# Enable the gRPC instrumentation if you'd like more introspection.
+from opentelemetry.instrumentation.grpc import GrpcInstrumentorClient
+
+grpc_client_instrumentor = GrpcInstrumentorClient()
+grpc_client_instrumentor.instrument()
+
+
+def main():
+    # Setup common variables that'll be used between Spanner and traces.
+    project_id = os.environ.get('SPANNER_PROJECT_ID', 'test-project')
+
+    # Setup OpenTelemetry, trace and Cloud Trace exporter.
+    tracer_provider = TracerProvider(sampler=ALWAYS_ON)
+    trace_exporter = CloudTraceSpanExporter(project_id=project_id)
+    tracer_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
+    trace.set_tracer_provider(tracer_provider)
+    # Retrieve a tracer from the global tracer provider.
+    tracer = tracer_provider.get_tracer('MyApp')
+
+    # Setup the Cloud Spanner Client.
+    spanner_client = spanner.Client(project_id)
+
+    instance = spanner_client.instance('test-instance')
+    database = instance.database('test-db')
+
+    # Now run our queries
+    with tracer.start_as_current_span('QueryInformationSchema'):
+        with database.snapshot() as snapshot:
+            with tracer.start_as_current_span('InformationSchema'):
+                info_schema = snapshot.execute_sql(
+                    'SELECT * FROM INFORMATION_SCHEMA.TABLES')
+                for row in info_schema:
+                    print(row)
+
+        with tracer.start_as_current_span('ServerTimeQuery'):
+            with database.snapshot() as snapshot:
+                # Purposefully issue a bad SQL statement to examine exceptions
+                # that get recorded and a ERROR span status.
+                try:
+                    data = snapshot.execute_sql('SELECT CURRENT_TIMESTAMPx()')
+                    for row in data:
+                        print(row)
+                except Exception as e:
+                    pass
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/trace.py
+++ b/examples/trace.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import os
+import time
+
+import google.cloud.spanner as spanner
+from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry import trace
+
+
+def main():
+    # Setup common variables that'll be used between Spanner and traces.
+    project_id = os.environ.get('SPANNER_PROJECT_ID', 'test-project')
+
+    # Setup OpenTelemetry, trace and Cloud Trace exporter.
+    tracer_provider = TracerProvider(sampler=ALWAYS_ON)
+    trace_exporter = CloudTraceSpanExporter(project_id=project_id)
+    tracer_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
+    trace.set_tracer_provider(tracer_provider)
+    # Retrieve a tracer from the global tracer provider.
+    tracer = tracer_provider.get_tracer('MyApp')
+
+    # Setup the Cloud Spanner Client.
+    spanner_client = spanner.Client(project_id)
+    instance = spanner_client.instance('test-instance')
+    database = instance.database('test-db')
+
+    # Now run our queries
+    with tracer.start_as_current_span('QueryInformationSchema'):
+        with database.snapshot() as snapshot:
+            with tracer.start_as_current_span('InformationSchema'):
+                info_schema = snapshot.execute_sql(
+                    'SELECT * FROM INFORMATION_SCHEMA.TABLES')
+                for row in info_schema:
+                    print(row)
+
+        with tracer.start_as_current_span('ServerTimeQuery'):
+            with database.snapshot() as snapshot:
+                # Purposefully issue a bad SQL statement to examine exceptions
+                # that get recorded and a ERROR span status.
+                try:
+                    data = snapshot.execute_sql('SELECT CURRENT_TIMESTAMPx()')
+                    for row in data:
+                        print(row)
+                except Exception as e:
+                    print(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ dependencies = [
 ]
 extras = {
     "tracing": [
-        "opentelemetry-api >= 1.1.0",
-        "opentelemetry-sdk >= 1.1.0",
-        "opentelemetry-instrumentation >= 0.20b0, < 0.23dev",
+        "opentelemetry-api >= 1.22.0",
+        "opentelemetry-sdk >= 1.22.0",
+        "opentelemetry-semantic-conventions >= 0.43b0",
     ],
     "libcst": "libcst >= 0.2.5",
 }

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -10,9 +10,9 @@ grpc-google-iam-v1==0.12.4
 libcst==0.2.5
 proto-plus==1.22.0
 sqlparse==0.4.4
-opentelemetry-api==1.1.0
-opentelemetry-sdk==1.1.0
-opentelemetry-instrumentation==0.20b0
+opentelemetry-api==1.22.0
+opentelemetry-sdk==1.22.0
+opentelemetry-semantic-conventions==0.43b0
 protobuf==3.20.2
 deprecated==1.2.14
 grpc-interceptor==0.15.4

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,6 +1,10 @@
 import unittest
 import mock
 
+from google.cloud.spanner_v1 import gapic_version
+
+LIB_VERSION = gapic_version.__version__
+
 try:
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
@@ -8,6 +12,11 @@ try:
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
         InMemorySpanExporter,
     )
+    from opentelemetry.semconv.attributes.otel_attributes import (
+        OTEL_SCOPE_NAME,
+        OTEL_SCOPE_VERSION,
+    )
+
     from opentelemetry.trace.status import StatusCode
 
     trace.set_tracer_provider(TracerProvider())
@@ -28,6 +37,18 @@ def get_test_ot_exporter():
     if _TEST_OT_EXPORTER is None:
         _TEST_OT_EXPORTER = InMemorySpanExporter()
     return _TEST_OT_EXPORTER
+
+
+def enrich_with_otel_scope(attrs):
+    """
+    This helper enriches attrs with OTEL_SCOPE_NAME and OTEL_SCOPE_VERSION
+    for the purpose of avoiding cumbersome duplicated imports.
+    """
+    if HAS_OPENTELEMETRY_INSTALLED:
+        attrs[OTEL_SCOPE_NAME] = "cloud.google.com/python/spanner"
+        attrs[OTEL_SCOPE_VERSION] = LIB_VERSION
+
+    return attrs
 
 
 def use_test_ot_exporter():

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -346,6 +346,8 @@ def _make_attributes(db_instance, **kwargs):
         "net.host.name": "spanner.googleapis.com",
         "db.instance": db_instance,
     }
+    ot_helpers.enrich_with_otel_scope(attributes)
+
     attributes.update(kwargs)
 
     return attributes

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -12,7 +12,11 @@ except ImportError:
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.spanner_v1 import _opentelemetry_tracing
 
-from tests._helpers import OpenTelemetryBase, HAS_OPENTELEMETRY_INSTALLED
+from tests._helpers import (
+    OpenTelemetryBase,
+    HAS_OPENTELEMETRY_INSTALLED,
+    enrich_with_otel_scope,
+)
 
 
 def _make_rpc_error(error_cls, trailing_metadata=None):
@@ -55,11 +59,13 @@ if HAS_OPENTELEMETRY_INSTALLED:
                 "db.instance": "database_name",
             }
 
-            expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com",
-                "net.host.name": "spanner.googleapis.com",
-            }
+            expected_attributes = enrich_with_otel_scope(
+                {
+                    "db.type": "spanner",
+                    "db.url": "spanner.googleapis.com",
+                    "net.host.name": "spanner.googleapis.com",
+                }
+            )
             expected_attributes.update(extra_attributes)
 
             with _opentelemetry_tracing.trace_call(
@@ -80,11 +86,13 @@ if HAS_OPENTELEMETRY_INSTALLED:
         def test_trace_error(self):
             extra_attributes = {"db.instance": "database_name"}
 
-            expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com",
-                "net.host.name": "spanner.googleapis.com",
-            }
+            expected_attributes = enrich_with_otel_scope(
+                {
+                    "db.type": "spanner",
+                    "db.url": "spanner.googleapis.com",
+                    "net.host.name": "spanner.googleapis.com",
+                }
+            )
             expected_attributes.update(extra_attributes)
 
             with self.assertRaises(GoogleAPICallError):
@@ -106,11 +114,13 @@ if HAS_OPENTELEMETRY_INSTALLED:
         def test_trace_grpc_error(self):
             extra_attributes = {"db.instance": "database_name"}
 
-            expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com:443",
-                "net.host.name": "spanner.googleapis.com:443",
-            }
+            expected_attributes = enrich_with_otel_scope(
+                {
+                    "db.type": "spanner",
+                    "db.url": "spanner.googleapis.com:443",
+                    "net.host.name": "spanner.googleapis.com:443",
+                }
+            )
             expected_attributes.update(extra_attributes)
 
             with self.assertRaises(GoogleAPICallError):
@@ -129,11 +139,13 @@ if HAS_OPENTELEMETRY_INSTALLED:
         def test_trace_codeless_error(self):
             extra_attributes = {"db.instance": "database_name"}
 
-            expected_attributes = {
-                "db.type": "spanner",
-                "db.url": "spanner.googleapis.com:443",
-                "net.host.name": "spanner.googleapis.com:443",
-            }
+            expected_attributes = enrich_with_otel_scope(
+                {
+                    "db.type": "spanner",
+                    "db.url": "spanner.googleapis.com:443",
+                    "net.host.name": "spanner.googleapis.com:443",
+                }
+            )
             expected_attributes.update(extra_attributes)
 
             with self.assertRaises(GoogleAPICallError):

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -14,7 +14,11 @@
 
 
 import unittest
-from tests._helpers import OpenTelemetryBase, StatusCode
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCode,
+    enrich_with_otel_scope,
+)
 from google.cloud.spanner_v1 import RequestOptions
 
 TABLE_NAME = "citizens"
@@ -29,6 +33,7 @@ BASE_ATTRIBUTES = {
     "db.instance": "testing",
     "net.host.name": "spanner.googleapis.com",
 }
+enrich_with_otel_scope(BASE_ATTRIBUTES)
 
 
 class _BaseTest(unittest.TestCase):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -19,7 +19,7 @@ import mock
 from tests._helpers import (
     OpenTelemetryBase,
     StatusCode,
-    HAS_OPENTELEMETRY_INSTALLED,
+    enrich_with_otel_scope,
 )
 
 
@@ -29,11 +29,6 @@ def _make_rpc_error(error_cls, trailing_metadata=None):
     grpc_error = mock.create_autospec(grpc.Call, instance=True)
     grpc_error.trailing_metadata.return_value = trailing_metadata
     return error_cls("error", errors=(grpc_error,))
-
-
-class _ConstantTime:
-    def time(self):
-        return 1
 
 
 class TestSession(OpenTelemetryBase):
@@ -51,6 +46,7 @@ class TestSession(OpenTelemetryBase):
         "db.instance": DATABASE_NAME,
         "net.host.name": "spanner.googleapis.com",
     }
+    enrich_with_otel_scope(BASE_ATTRIBUTES)
 
     def _getTargetClass(self):
         from google.cloud.spanner_v1.session import Session
@@ -1337,17 +1333,9 @@ class TestSession(OpenTelemetryBase):
             return _results.pop(0)
 
         with mock.patch("time.time", _time):
-            if HAS_OPENTELEMETRY_INSTALLED:
-                with mock.patch("opentelemetry.util._time", _ConstantTime()):
-                    with mock.patch("time.sleep") as sleep_mock:
-                        with self.assertRaises(Aborted):
-                            session.run_in_transaction(
-                                unit_of_work, "abc", timeout_secs=1
-                            )
-            else:
-                with mock.patch("time.sleep") as sleep_mock:
-                    with self.assertRaises(Aborted):
-                        session.run_in_transaction(unit_of_work, "abc", timeout_secs=1)
+            with mock.patch("time.sleep") as sleep_mock:
+                with self.assertRaises(Aborted):
+                    session.run_in_transaction(unit_of_work, "abc", timeout_secs=1)
 
         sleep_mock.assert_not_called()
 
@@ -1418,15 +1406,9 @@ class TestSession(OpenTelemetryBase):
             return _results.pop(0)
 
         with mock.patch("time.time", _time):
-            if HAS_OPENTELEMETRY_INSTALLED:
-                with mock.patch("opentelemetry.util._time", _ConstantTime()):
-                    with mock.patch("time.sleep") as sleep_mock:
-                        with self.assertRaises(Aborted):
-                            session.run_in_transaction(unit_of_work, timeout_secs=8)
-            else:
-                with mock.patch("time.sleep") as sleep_mock:
-                    with self.assertRaises(Aborted):
-                        session.run_in_transaction(unit_of_work, timeout_secs=8)
+            with mock.patch("time.sleep") as sleep_mock:
+                with self.assertRaises(Aborted):
+                    session.run_in_transaction(unit_of_work, timeout_secs=8)
 
         # unpacking call args into list
         call_args = [call_[0][0] for call_ in sleep_mock.call_args_list]

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -21,6 +21,7 @@ from tests._helpers import (
     OpenTelemetryBase,
     StatusCode,
     HAS_OPENTELEMETRY_INSTALLED,
+    enrich_with_otel_scope,
 )
 from google.cloud.spanner_v1.param_types import INT64
 from google.api_core.retry import Retry
@@ -46,6 +47,8 @@ BASE_ATTRIBUTES = {
     "db.instance": "testing",
     "net.host.name": "spanner.googleapis.com",
 }
+enrich_with_otel_scope(BASE_ATTRIBUTES)
+
 DIRECTED_READ_OPTIONS = {
     "include_replicas": {
         "replica_selections": [
@@ -530,12 +533,14 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
                 self.assertEqual(span.name, name)
                 self.assertEqual(
                     dict(span.attributes),
-                    {
-                        "db.type": "spanner",
-                        "db.url": "spanner.googleapis.com",
-                        "db.instance": "testing",
-                        "net.host.name": "spanner.googleapis.com",
-                    },
+                    enrich_with_otel_scope(
+                        {
+                            "db.type": "spanner",
+                            "db.url": "spanner.googleapis.com",
+                            "db.instance": "testing",
+                            "net.host.name": "spanner.googleapis.com",
+                        }
+                    ),
                 )
 
 

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -21,7 +21,11 @@ from google.cloud.spanner_v1 import TypeCode
 from google.api_core.retry import Retry
 from google.api_core import gapic_v1
 
-from tests._helpers import OpenTelemetryBase, StatusCode
+from tests._helpers import (
+    OpenTelemetryBase,
+    StatusCode,
+    enrich_with_otel_scope,
+)
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -58,6 +62,7 @@ class TestTransaction(OpenTelemetryBase):
         "db.instance": "testing",
         "net.host.name": "spanner.googleapis.com",
     }
+    enrich_with_otel_scope(BASE_ATTRIBUTES)
 
     def _getTargetClass(self):
         from google.cloud.spanner_v1.transaction import Transaction


### PR DESCRIPTION
This change non-invasively introduces dependencies of opentelemetry
bringing in the latest dependencies and modernizing them.

While here also brought in modern span attributes:
* otel.scope.name
* otel.scope.version

Also added a modernized example and updated the docs.

Updates #1170
Fixes #1173
Built from PR #1172