### PR TITLE
test: fix timestamp verification in system test

### DIFF
--- a/tests/system/_sample_data.py
+++ b/tests/system/_sample_data.py
@@ -72,11 +72,15 @@ def _assert_timestamp(value, nano_value):
     assert value.tzinfo is None
     assert nano_value.tzinfo is UTC
 
-    assert value.year == nano_value.year
-    assert value.month == nano_value.month
-    assert value.day == nano_value.day
-    assert value.hour == nano_value.hour
-    assert value.minute == nano_value.minute
+    # In round-trip, timestamps acquire a timezone value.
+    # Setting the timezone on the expected value so the assertions don't fail when run outside of UTC.
+    utc_value = value.astimezone(UTC)
+
+    assert utc_value.year == nano_value.year
+    assert utc_value.month == nano_value.month
+    assert utc_value.day == nano_value.day
+    assert utc_value.hour == nano_value.hour
+    assert utc_value.minute == nano_value.minute
     assert value.second == nano_value.second
     assert value.microsecond == nano_value.microsecond
 

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -2361,17 +2361,12 @@ def test_execute_sql_w_timestamp_bindings(sessions_database, database_dialect):
 
     timestamps = [timestamp_1, timestamp_2]
 
-    # In round-trip, timestamps acquire a timezone value.
-    expected_timestamps = [timestamp.replace(tzinfo=UTC) for timestamp in timestamps]
-
     _bind_test_helper(
         sessions_database,
         database_dialect,
         spanner_v1.param_types.TIMESTAMP,
         timestamp_1,
         timestamps,
-        expected_timestamps,
-        recurse_into_lists=False,
     )
 
 


### PR DESCRIPTION
Currently, the `test_batch_insert_then_read_all_datatypes` and `test_execute_sql_w_timestamp_bindings` tests fail when run outside of the UTC timezone. This is frustrating when running tests locally for those who are based in a different timezone.

This PR moves the handling of the timezones to `_assert_timestamp`. All datetime objects created without a timezone are assumed to be in local time. By asserting that it does not have a timezone first, we can safely convert it to UTC which should match the value returned from Spanner.