### PR TITLE
fix: add PROTO in streaming chunks

### DIFF
--- a/google/cloud/spanner_v1/streamed.py
+++ b/google/cloud/spanner_v1/streamed.py
@@ -345,6 +345,8 @@ _MERGE_BY_TYPE = {
     TypeCode.TIMESTAMP: _merge_string,
     TypeCode.NUMERIC: _merge_string,
     TypeCode.JSON: _merge_string,
+    TypeCode.PROTO: _merge_string,
+    TypeCode.ENUM: _merge_string,
 }
 
 


### PR DESCRIPTION
b/372956316
When the row size exceeds a certain limit, the rows are divided into chunks and sent to the client in multiple parts. The client is responsible for merging these chunks to reconstruct the full row. 
However, for PROTO and ENUM types, this chunk-merging logic was not implemented, causing a KeyError: 13 when attempting to merge proto chunks.


#### Sample to reproduce the test case
[Python file](https://gist.github.com/harshachinta/95a81eeda81c422814353a5995d01e20)
[proto file
](https://gist.github.com/harshachinta/fd15bf558bd4f40443411ddd164638cc)

#### Steps to generate descriptors.pb and code file from proto
```
protoc --proto_path=testdata/ --include_imports --descriptor_set_out=testdata/descriptors.pb --python_out=testdata/ testdata/wrapper.proto
```
