### PR TITLE
tracing: enable OpenTelemetry as a first class dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,11 @@ dependencies = [
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
     "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "grpc-interceptor >= 0.15.4",
+    "opentelemetry-api >= 1.22.0",
+    "opentelemetry-sdk >= 1.22.0",
+    "opentelemetry-semantic-conventions >= 0.43b0",
 ]
 extras = {
-    "tracing": [
-        "opentelemetry-api >= 1.22.0",
-        "opentelemetry-sdk >= 1.22.0",
-        "opentelemetry-semantic-conventions >= 0.43b0",
-    ],
     "libcst": "libcst >= 0.2.5",
 }
 

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -305,18 +305,14 @@ def sessions_to_delete():
 
 @pytest.fixture(scope="function")
 def ot_exporter():
-    if ot_helpers.HAS_OPENTELEMETRY_INSTALLED:
-        ot_helpers.use_test_ot_exporter()
-        ot_exporter = ot_helpers.get_test_ot_exporter()
+    ot_helpers.use_test_ot_exporter()
+    ot_exporter = ot_helpers.get_test_ot_exporter()
 
-        ot_exporter.clear()  # XXX?
+    ot_exporter.clear()  # XXX?
 
-        yield ot_exporter
+    yield ot_exporter
 
-        ot_exporter.clear()
-
-    else:
-        yield None
+    ot_exporter.clear()
 
 
 def assert_no_spans(ot_exporter):
@@ -1127,10 +1123,6 @@ def test_transaction_batch_update_wo_statements(sessions_database, sessions_to_d
             transaction.batch_update([])
 
 
-@pytest.mark.skipif(
-    not ot_helpers.HAS_OPENTELEMETRY_INSTALLED,
-    reason="trace requires OpenTelemetry",
-)
 def test_transaction_batch_update_w_parent_span(
     sessions_database, sessions_to_delete, ot_exporter, database_dialect
 ):

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -3,18 +3,14 @@ import mock
 import unittest
 import sys
 
-try:
-    from opentelemetry import trace as trace_api
-    from opentelemetry.trace.status import StatusCode
-except ImportError:
-    pass
+from opentelemetry import trace as trace_api
+from opentelemetry.trace.status import StatusCode
 
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.spanner_v1 import _opentelemetry_tracing
 
 from tests._helpers import (
     OpenTelemetryBase,
-    HAS_OPENTELEMETRY_INSTALLED,
     enrich_with_otel_scope,
 )
 
@@ -33,128 +29,110 @@ def _make_session():
     return mock.Mock(autospec=Session, instance=True)
 
 
-# Skip all of these tests if we don't have OpenTelemetry
-if HAS_OPENTELEMETRY_INSTALLED:
+class TestTracing(OpenTelemetryBase):
+    def test_trace_call(self):
+        extra_attributes = {
+            "attribute1": "value1",
+            # Since our database is mocked, we have to override the db.instance parameter so it is a string
+            "db.instance": "database_name",
+        }
 
-    class TestNoTracing(unittest.TestCase):
-        def setUp(self):
-            self._temp_opentelemetry = sys.modules["opentelemetry"]
-
-            sys.modules["opentelemetry"] = None
-            importlib.reload(_opentelemetry_tracing)
-
-        def tearDown(self):
-            sys.modules["opentelemetry"] = self._temp_opentelemetry
-            importlib.reload(_opentelemetry_tracing)
-
-        def test_no_trace_call(self):
-            with _opentelemetry_tracing.trace_call("Test", _make_session()) as no_span:
-                self.assertIsNone(no_span)
-
-    class TestTracing(OpenTelemetryBase):
-        def test_trace_call(self):
-            extra_attributes = {
-                "attribute1": "value1",
-                # Since our database is mocked, we have to override the db.instance parameter so it is a string
-                "db.instance": "database_name",
+        expected_attributes = enrich_with_otel_scope(
+            {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com",
+                "net.host.name": "spanner.googleapis.com",
             }
+        )
+        expected_attributes.update(extra_attributes)
 
-            expected_attributes = enrich_with_otel_scope(
-                {
-                    "db.type": "spanner",
-                    "db.url": "spanner.googleapis.com",
-                    "net.host.name": "spanner.googleapis.com",
-                }
-            )
-            expected_attributes.update(extra_attributes)
+        with _opentelemetry_tracing.trace_call(
+            "CloudSpanner.Test", _make_session(), extra_attributes
+        ) as span:
+            span.set_attribute("after_setup_attribute", 1)
 
+        expected_attributes["after_setup_attribute"] = 1
+
+        span_list = self.ot_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(span.attributes, expected_attributes)
+        self.assertEqual(span.name, "CloudSpanner.Test")
+        self.assertEqual(span.status.status_code, StatusCode.OK)
+
+    def test_trace_error(self):
+        extra_attributes = {"db.instance": "database_name"}
+
+        expected_attributes = enrich_with_otel_scope(
+            {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com",
+                "net.host.name": "spanner.googleapis.com",
+            }
+        )
+        expected_attributes.update(extra_attributes)
+
+        with self.assertRaises(GoogleAPICallError):
             with _opentelemetry_tracing.trace_call(
                 "CloudSpanner.Test", _make_session(), extra_attributes
             ) as span:
-                span.set_attribute("after_setup_attribute", 1)
+                from google.api_core.exceptions import InvalidArgument
 
-            expected_attributes["after_setup_attribute"] = 1
+                raise _make_rpc_error(InvalidArgument)
 
-            span_list = self.ot_exporter.get_finished_spans()
-            self.assertEqual(len(span_list), 1)
-            span = span_list[0]
-            self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
-            self.assertEqual(span.attributes, expected_attributes)
-            self.assertEqual(span.name, "CloudSpanner.Test")
-            self.assertEqual(span.status.status_code, StatusCode.OK)
+        span_list = self.ot_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
+        self.assertEqual(dict(span.attributes), expected_attributes)
+        self.assertEqual(span.name, "CloudSpanner.Test")
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
-        def test_trace_error(self):
-            extra_attributes = {"db.instance": "database_name"}
+    def test_trace_grpc_error(self):
+        extra_attributes = {"db.instance": "database_name"}
 
-            expected_attributes = enrich_with_otel_scope(
-                {
-                    "db.type": "spanner",
-                    "db.url": "spanner.googleapis.com",
-                    "net.host.name": "spanner.googleapis.com",
-                }
-            )
-            expected_attributes.update(extra_attributes)
+        expected_attributes = enrich_with_otel_scope(
+            {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com:443",
+                "net.host.name": "spanner.googleapis.com:443",
+            }
+        )
+        expected_attributes.update(extra_attributes)
 
-            with self.assertRaises(GoogleAPICallError):
-                with _opentelemetry_tracing.trace_call(
-                    "CloudSpanner.Test", _make_session(), extra_attributes
-                ) as span:
-                    from google.api_core.exceptions import InvalidArgument
+        with self.assertRaises(GoogleAPICallError):
+            with _opentelemetry_tracing.trace_call(
+                "CloudSpanner.Test", _make_session(), extra_attributes
+            ) as span:
+                from google.api_core.exceptions import DataLoss
 
-                    raise _make_rpc_error(InvalidArgument)
+                raise DataLoss("error")
 
-            span_list = self.ot_exporter.get_finished_spans()
-            self.assertEqual(len(span_list), 1)
-            span = span_list[0]
-            self.assertEqual(span.kind, trace_api.SpanKind.CLIENT)
-            self.assertEqual(dict(span.attributes), expected_attributes)
-            self.assertEqual(span.name, "CloudSpanner.Test")
-            self.assertEqual(span.status.status_code, StatusCode.ERROR)
+        span_list = self.ot_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)
 
-        def test_trace_grpc_error(self):
-            extra_attributes = {"db.instance": "database_name"}
+    def test_trace_codeless_error(self):
+        extra_attributes = {"db.instance": "database_name"}
 
-            expected_attributes = enrich_with_otel_scope(
-                {
-                    "db.type": "spanner",
-                    "db.url": "spanner.googleapis.com:443",
-                    "net.host.name": "spanner.googleapis.com:443",
-                }
-            )
-            expected_attributes.update(extra_attributes)
+        expected_attributes = enrich_with_otel_scope(
+            {
+                "db.type": "spanner",
+                "db.url": "spanner.googleapis.com:443",
+                "net.host.name": "spanner.googleapis.com:443",
+            }
+        )
+        expected_attributes.update(extra_attributes)
 
-            with self.assertRaises(GoogleAPICallError):
-                with _opentelemetry_tracing.trace_call(
-                    "CloudSpanner.Test", _make_session(), extra_attributes
-                ) as span:
-                    from google.api_core.exceptions import DataLoss
+        with self.assertRaises(GoogleAPICallError):
+            with _opentelemetry_tracing.trace_call(
+                "CloudSpanner.Test", _make_session(), extra_attributes
+            ) as span:
+                raise GoogleAPICallError("error")
 
-                    raise DataLoss("error")
-
-            span_list = self.ot_exporter.get_finished_spans()
-            self.assertEqual(len(span_list), 1)
-            span = span_list[0]
-            self.assertEqual(span.status.status_code, StatusCode.ERROR)
-
-        def test_trace_codeless_error(self):
-            extra_attributes = {"db.instance": "database_name"}
-
-            expected_attributes = enrich_with_otel_scope(
-                {
-                    "db.type": "spanner",
-                    "db.url": "spanner.googleapis.com:443",
-                    "net.host.name": "spanner.googleapis.com:443",
-                }
-            )
-            expected_attributes.update(extra_attributes)
-
-            with self.assertRaises(GoogleAPICallError):
-                with _opentelemetry_tracing.trace_call(
-                    "CloudSpanner.Test", _make_session(), extra_attributes
-                ) as span:
-                    raise GoogleAPICallError("error")
-
-            span_list = self.ot_exporter.get_finished_spans()
-            self.assertEqual(len(span_list), 1)
-            span = span_list[0]
-            self.assertEqual(span.status.status_code, StatusCode.ERROR)
+        span_list = self.ot_exporter.get_finished_spans()
+        self.assertEqual(len(span_list), 1)
+        span = span_list[0]
+        self.assertEqual(span.status.status_code, StatusCode.ERROR)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -312,15 +312,13 @@ class TestSession(OpenTelemetryBase):
             ],
         )
 
+        wantAttributes = dict(session_found=True)
+        wantAttributes.update(TestSession.BASE_ATTRIBUTES)
         self.assertSpanAttributes(
             "CloudSpanner.GetSession",
-            attributes=dict(TestSession.BASE_ATTRIBUTES, session_found=True),
+            attributes=wantAttributes,
         )
 
-    @mock.patch(
-        "google.cloud.spanner_v1._opentelemetry_tracing.HAS_OPENTELEMETRY_INSTALLED",
-        False,
-    )
     def test_exists_hit_wo_span(self):
         session_pb = self._make_session_pb(self.SESSION_NAME)
         gax_api = self._make_spanner_api()
@@ -340,7 +338,13 @@ class TestSession(OpenTelemetryBase):
             ],
         )
 
-        self.assertNoSpans()
+        wantAttributes = dict(session_found=True)
+        wantAttributes.update(TestSession.BASE_ATTRIBUTES)
+        self.assertSpanAttributes(
+            "CloudSpanner.GetSession",
+            status=StatusCode.OK,
+            attributes=wantAttributes,
+        )
 
     def test_exists_miss(self):
         from google.api_core.exceptions import NotFound
@@ -362,15 +366,13 @@ class TestSession(OpenTelemetryBase):
             ],
         )
 
+        wantAttributes = dict(session_found=False)
+        wantAttributes.update(TestSession.BASE_ATTRIBUTES)
         self.assertSpanAttributes(
             "CloudSpanner.GetSession",
-            attributes=dict(TestSession.BASE_ATTRIBUTES, session_found=False),
+            attributes=wantAttributes,
         )
 
-    @mock.patch(
-        "google.cloud.spanner_v1._opentelemetry_tracing.HAS_OPENTELEMETRY_INSTALLED",
-        False,
-    )
     def test_exists_miss_wo_span(self):
         from google.api_core.exceptions import NotFound
 
@@ -391,7 +393,13 @@ class TestSession(OpenTelemetryBase):
             ],
         )
 
-        self.assertNoSpans()
+        wantAttributes = dict(session_found=False)
+        wantAttributes.update(TestSession.BASE_ATTRIBUTES)
+        self.assertSpanAttributes(
+            "CloudSpanner.GetSession",
+            status=StatusCode.OK,
+            attributes=wantAttributes,
+        )
 
     def test_exists_error(self):
         from google.api_core.exceptions import Unknown


### PR DESCRIPTION
This change attempts to make OpenTelemetry a first class dependency used without any guards.