### PR TITLE
fix: allow setting connection.read_only to same value

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -232,7 +232,7 @@ class Connection:
         Args:
             value (bool): True for ReadOnly mode, False for ReadWrite.
         """
-        if self._spanner_transaction_started:
+        if self._read_only != value and self._spanner_transaction_started:
             raise ValueError(
                 "Connection read/write mode can't be changed while a transaction is in progress. "
                 "Commit or rollback the current transaction and try again."

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -138,6 +138,10 @@ class TestConnection(unittest.TestCase):
         ):
             connection.read_only = False
 
+        # Verify that we can set the value to the same value as it already has.
+        connection.read_only = True
+        self.assertTrue(connection.read_only)
+
         connection._spanner_transaction_started = False
         connection.read_only = False
         self.assertFalse(connection.read_only)


### PR DESCRIPTION
Setting the read_only value of a connection to the same value as the current value should be allowed during a transaction, as it does not change anything. SQLAlchemy regularly does this if engine options have been specified.

Fixes https://github.com/googleapis/python-spanner-sqlalchemy/issues/493
