### PR TITLE
feat: add connection variable for ignoring transaction warnings

### DIFF
--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -300,6 +300,19 @@ class TestConnection(unittest.TestCase):
             CLIENT_TRANSACTION_NOT_STARTED_WARNING, UserWarning, stacklevel=2
         )
 
+    @mock.patch.object(warnings, "warn")
+    def test_commit_in_autocommit_mode_with_ignore_warnings(self, mock_warn):
+        conn = self._make_connection(
+            DatabaseDialect.DATABASE_DIALECT_UNSPECIFIED,
+            ignore_transaction_warnings=True,
+        )
+        assert conn._ignore_transaction_warnings
+        conn._autocommit = True
+
+        conn.commit()
+
+        assert not mock_warn.warn.called
+
     def test_commit_database_error(self):
         from google.cloud.spanner_dbapi import Connection
 


### PR DESCRIPTION
Adds a connection variable for ignoring transaction warnings. Also adds a **kwargs argument to the connect function. This will be used for further connection variables in the future.

Fixes https://github.com/googleapis/python-spanner-sqlalchemy/issues/494