### PR TITLE
fix: allow setting staleness to same value in tx

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -277,7 +277,7 @@ class Connection:
         Args:
             value (dict): Staleness type and value.
         """
-        if self._spanner_transaction_started:
+        if self._spanner_transaction_started and value != self._staleness:
             raise ValueError(
                 "`staleness` option can't be changed while a transaction is in progress. "
                 "Commit or rollback the current transaction and try again."

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,7 +33,6 @@ ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
-DEFAULT_MOCK_SERVER_TESTS_PYTHON_VERSION = "3.12"
 
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.7",
@@ -232,34 +231,6 @@ def unit(session, protobuf_implementation):
         env={
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
         },
-    )
-
-
-@nox.session(python=DEFAULT_MOCK_SERVER_TESTS_PYTHON_VERSION)
-def mockserver(session):
-    # Install all test dependencies, then install this package in-place.
-
-    constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
-    )
-    # install_unittest_dependencies(session, "-c", constraints_path)
-    standard_deps = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_DEPENDENCIES
-    session.install(*standard_deps, "-c", constraints_path)
-    session.install("-e", ".", "-c", constraints_path)
-
-    # Run py.test against the mockserver tests.
-    session.run(
-        "py.test",
-        "--quiet",
-        f"--junitxml=unit_{session.python}_sponge_log.xml",
-        "--cov=google",
-        "--cov=tests/unit",
-        "--cov-append",
-        "--cov-config=.coveragerc",
-        "--cov-report=",
-        "--cov-fail-under=0",
-        os.path.join("tests", "mockserver_tests"),
-        *session.posargs,
     )
 
 

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -669,6 +669,20 @@ class TestConnection(unittest.TestCase):
         with self.assertRaises(ValueError):
             connection.staleness = {"read_timestamp": datetime.datetime(2021, 9, 21)}
 
+    def test_staleness_inside_transaction_same_value(self):
+        """
+        Verify that setting `staleness` to the same value in a transaction is allowed.
+        """
+        connection = self._make_connection()
+        connection.staleness = {"read_timestamp": datetime.datetime(2021, 9, 21)}
+        connection._spanner_transaction_started = True
+        connection._transaction = mock.Mock()
+
+        connection.staleness = {"read_timestamp": datetime.datetime(2021, 9, 21)}
+        self.assertEqual(
+            connection.staleness, {"read_timestamp": datetime.datetime(2021, 9, 21)}
+        )
+
     def test_staleness_multi_use(self):
         """
         Check that `staleness` option is correctly


### PR DESCRIPTION
Repeatedly setting the staleness property of a connection in a transaction to the same value caused an error. This made it harder to use this property in SQLAlchemy.

Updates https://github.com/googleapis/python-spanner-sqlalchemy/issues/495