### PR TITLE
fix: dbapi raised AttributeError with [] as arguments

### DIFF
--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -308,7 +308,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         :raises ValueError:
             If ``params`` is None but ``param_types`` is not None.
         """
-        if params is not None:
+        if params:
             return Struct(
                 fields={key: _make_value_pb(value) for key, value in params.items()}
             )


### PR DESCRIPTION
If the cursor.execute(sql, args) function was called with an empty array instead of None, it would raise an AttributeError like this:

AttributeError: 'list' object has no attribute 'items'

This is for example automatically done by SQLAlchemy when executing a raw statement on a dbapi connection.
