### PR TITLE
feat: add updated span events + trace more methods

### DIFF
--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -103,7 +103,6 @@ def trace_call(name, session=None, extra_attributes=None, observability_options=
 
     if not enable_extended_tracing:
         attributes.pop("db.statement", False)
-        attributes.pop("sql", False)
 
     with tracer.start_as_current_span(
         name, kind=trace.SpanKind.CLIENT, attributes=attributes
@@ -136,16 +135,3 @@ def get_current_span():
 def add_span_event(span, event_name, event_attributes=None):
     if span:
         span.add_event(event_name, event_attributes)
-
-
-def add_event_on_current_span(event_name, event_attributes=None, span=None):
-    if not span:
-        span = get_current_span()
-
-    add_span_event(span, event_name, event_attributes)
-
-
-def record_span_exception_and_status(span, exc):
-    if span:
-        span.set_status(Status(StatusCode.ERROR, str(exc)))
-        span.record_exception(exc)

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -62,9 +62,6 @@ def trace_call(name, session=None, extra_attributes=None, observability_options=
         yield None
         return
 
-    if session:
-        session._last_use_time = datetime.now()
-
     tracer_provider = None
 
     # By default enable_extended_tracing=True because in a bid to minimize
@@ -104,16 +101,6 @@ def trace_call(name, session=None, extra_attributes=None, observability_options=
     if not enable_extended_tracing:
         attributes.pop("db.statement", False)
         attributes.pop("sql", False)
-    else:
-        # Otherwise there are places where the annotated sql was inserted
-        # directly from the arguments as "sql", and transform those into "db.statement".
-        db_statement = attributes.get("db.statement", None)
-        if not db_statement:
-            sql = attributes.get("sql", None)
-            if sql:
-                attributes = attributes.copy()
-                attributes.pop("sql", False)
-                attributes["db.statement"] = sql
 
     with tracer.start_as_current_span(
         name, kind=trace.SpanKind.CLIENT, attributes=attributes

--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -57,6 +57,9 @@ def get_tracer(tracer_provider=None):
 
 @contextmanager
 def trace_call(name, session=None, extra_attributes=None, observability_options=None):
+    if session:
+        session._last_use_time = datetime.now()
+
     if not (HAS_OPENTELEMETRY_INSTALLED and name):
         # Empty context manager. Users will have to check if the generated value is None or a span
         yield None

--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -26,10 +26,7 @@ from google.cloud.spanner_v1._helpers import (
     _metadata_with_prefix,
     _metadata_with_leader_aware_routing,
 )
-from google.cloud.spanner_v1._opentelemetry_tracing import (
-    add_event_on_current_span,
-    trace_call,
-)
+from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
 from google.cloud.spanner_v1 import RequestOptions
 from google.cloud.spanner_v1._helpers import _retry
 from google.cloud.spanner_v1._helpers import _check_rst_stream_error
@@ -73,10 +70,8 @@ class _BatchBase(_SessionWrapper):
         :param values: Values to be modified.
         """
         self._mutations.append(Mutation(insert=_make_write_pb(table, columns, values)))
-        add_event_on_current_span(
-            "insert mutations added",
-            dict(table=table, columns=columns),
-        )
+        # TODO: Decide if we should add a span event per mutation:
+        # https://github.com/googleapis/python-spanner/issues/1269
 
     def update(self, table, columns, values):
         """Update one or more existing table rows.
@@ -91,10 +86,8 @@ class _BatchBase(_SessionWrapper):
         :param values: Values to be modified.
         """
         self._mutations.append(Mutation(update=_make_write_pb(table, columns, values)))
-        add_event_on_current_span(
-            "update mutations added",
-            dict(table=table, columns=columns),
-        )
+        # TODO: Decide if we should add a span event per mutation:
+        # https://github.com/googleapis/python-spanner/issues/1269
 
     def insert_or_update(self, table, columns, values):
         """Insert/update one or more table rows.
@@ -111,10 +104,8 @@ class _BatchBase(_SessionWrapper):
         self._mutations.append(
             Mutation(insert_or_update=_make_write_pb(table, columns, values))
         )
-        add_event_on_current_span(
-            "insert_or_update mutations added",
-            dict(table=table, columns=columns),
-        )
+        # TODO: Decide if we should add a span event per mutation:
+        # https://github.com/googleapis/python-spanner/issues/1269
 
     def replace(self, table, columns, values):
         """Replace one or more table rows.
@@ -129,10 +120,8 @@ class _BatchBase(_SessionWrapper):
         :param values: Values to be modified.
         """
         self._mutations.append(Mutation(replace=_make_write_pb(table, columns, values)))
-        add_event_on_current_span(
-            "replace mutations added",
-            dict(table=table, columns=columns),
-        )
+        # TODO: Decide if we should add a span event per mutation:
+        # https://github.com/googleapis/python-spanner/issues/1269
 
     def delete(self, table, keyset):
         """Delete one or more table rows.
@@ -145,10 +134,8 @@ class _BatchBase(_SessionWrapper):
         """
         delete = Mutation.Delete(table=table, key_set=keyset._to_pb())
         self._mutations.append(Mutation(delete=delete))
-        add_event_on_current_span(
-            "delete mutations added",
-            dict(table=table),
-        )
+        # TODO: Decide if we should add a span event per mutation:
+        # https://github.com/googleapis/python-spanner/issues/1269
 
 
 class Batch(_BatchBase):

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -485,8 +485,6 @@ class Session(object):
                 if txn_id:
                     span_attributes["transaction.id"] = txn_id
 
-                add_span_event(span, "Using Transaction", span_attributes)
-
                 try:
                     return_value = func(txn, *args, **kw)
                 except Aborted as exc:

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -479,14 +479,17 @@ class Session(object):
                 else:
                     txn = self._transaction
 
-                attempts += 1
-                span_attributes = {"attempt": attempts}
-                txn_id = getattr(txn, "_transaction_id", "") or ""
-                if txn_id:
-                    span_attributes["transaction.id"] = txn_id
+                span_attributes = dict()
 
                 try:
+                    attempts += 1
+                    span_attributes["attempt"] = attempts
+                    txn_id = getattr(txn, "_transaction_id", "") or ""
+                    if txn_id:
+                        span_attributes["transaction.id"] = txn_id
+
                     return_value = func(txn, *args, **kw)
+
                 except Aborted as exc:
                     del self._transaction
                     if span:

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -471,7 +471,6 @@ class Session(object):
         ) as span:
             while True:
                 if self._transaction is None:
-                    add_span_event(span, "Creating Transaction")
                     txn = self.transaction()
                     txn.transaction_tag = transaction_tag
                     txn.exclude_txn_from_change_streams = (
@@ -499,7 +498,7 @@ class Session(object):
                         record_span_exception_and_status(span, exc)
                         add_span_event(
                             span,
-                            "Transaction was aborted, retrying afresh",
+                            "Transaction was aborted in user operation, retrying",
                             attributes,
                         )
 
@@ -516,7 +515,7 @@ class Session(object):
                 except Exception:
                     add_span_event(
                         span,
-                        "Invoking Transaction.rollback(), not retrying",
+                        "User operation failed. Invoking Transaction.rollback(), not retrying",
                         span_attributes,
                     )
                     txn.rollback()
@@ -537,7 +536,7 @@ class Session(object):
                         record_span_exception_and_status(span, exc)
                         add_span_event(
                             span,
-                            "Transaction was aborted, retrying afresh",
+                            "Transaction got aborted during commit, retrying afresh",
                             attributes,
                         )
 

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -335,7 +335,7 @@ class _SnapshotBase(_SessionWrapper):
                 iterator = _restart_on_unavailable(
                     restart,
                     request,
-                    "CloudSpanner.ReadOnlyTransaction",
+                    f"CloudSpanner.{type(self).__name__}.read",
                     self._session,
                     trace_attributes,
                     transaction=self,
@@ -357,7 +357,7 @@ class _SnapshotBase(_SessionWrapper):
             iterator = _restart_on_unavailable(
                 restart,
                 request,
-                "CloudSpanner.ReadOnlyTransaction",
+                f"CloudSpanner.{type(self).__name__}.read",
                 self._session,
                 trace_attributes,
                 transaction=self,
@@ -578,7 +578,7 @@ class _SnapshotBase(_SessionWrapper):
         iterator = _restart_on_unavailable(
             restart,
             request,
-            "CloudSpanner.ReadWriteTransaction",
+            f"CloudSpanner.{type(self).__name__}.execute_streaming_sql",
             self._session,
             trace_attributes,
             transaction=self,
@@ -676,7 +676,7 @@ class _SnapshotBase(_SessionWrapper):
 
         trace_attributes = {"table_id": table, "columns": columns}
         with trace_call(
-            "CloudSpanner.PartitionReadOnlyTransaction",
+            f"CloudSpanner.{type(self).__name__}.partition_read",
             self._session,
             trace_attributes,
             observability_options=getattr(database, "observability_options", None),

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -926,7 +926,7 @@ class Snapshot(_SnapshotBase):
             )
         txn_selector = self._make_txn_selector()
         with trace_call(
-            "CloudSpanner.BeginTransaction",
+            f"CloudSpanner.{type(self).__name__}.begin",
             self._session,
             observability_options=getattr(database, "observability_options", None),
         ):

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -157,7 +157,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         )
         observability_options = getattr(database, "observability_options", None)
         with trace_call(
-            "CloudSpanner.BeginTransaction",
+            f"CloudSpanner.{type(self).__name__}.begin",
             self._session,
             observability_options=observability_options,
         ) as span:

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -199,7 +199,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 )
             observability_options = getattr(database, "observability_options", None)
             with trace_call(
-                "CloudSpanner.Rollback",
+                f"CloudSpanner.{type(self).__name__}.rollback",
                 self._session,
                 observability_options=observability_options,
             ):
@@ -278,7 +278,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         trace_attributes = {"num_mutations": len(self._mutations)}
         observability_options = getattr(database, "observability_options", None)
         with trace_call(
-            "CloudSpanner.Commit",
+            f"CloudSpanner.{type(self).__name__}.commit",
             self._session,
             trace_attributes,
             observability_options,
@@ -447,7 +447,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 response = self._execute_request(
                     method,
                     request,
-                    "CloudSpanner.ReadWriteTransaction",
+                    f"CloudSpanner.{type(self).__name__}.execute_update",
                     self._session,
                     trace_attributes,
                     observability_options=observability_options,
@@ -464,7 +464,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             response = self._execute_request(
                 method,
                 request,
-                "CloudSpanner.ReadWriteTransaction",
+                f"CloudSpanner.{type(self).__name__}.execute_update",
                 self._session,
                 trace_attributes,
                 observability_options=observability_options,

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -78,7 +78,8 @@ class OpenTelemetryBase(unittest.TestCase):
 
     def assertNoSpans(self):
         if HAS_OPENTELEMETRY_INSTALLED:
-            span_list = self.ot_exporter.get_finished_spans()
+            span_list = self.get_finished_spans()
+            print("got_spans", [span.name for span in span_list])
             self.assertEqual(len(span_list), 0)
 
     def assertSpanAttributes(
@@ -119,11 +120,16 @@ class OpenTelemetryBase(unittest.TestCase):
 
     def get_finished_spans(self):
         if HAS_OPENTELEMETRY_INSTALLED:
-            return list(
+            span_list = list(
                 filter(
                     lambda span: span and span.name,
                     self.ot_exporter.get_finished_spans(),
                 )
             )
+            # Sort the spans by their start time in the hierarchy.
+            return sorted(span_list, key=lambda span: span.start_time)
         else:
             return []
+
+    def reset(self):
+        self.tearDown()

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -79,7 +79,6 @@ class OpenTelemetryBase(unittest.TestCase):
     def assertNoSpans(self):
         if HAS_OPENTELEMETRY_INSTALLED:
             span_list = self.get_finished_spans()
-            print("got_spans", [span.name for span in span_list])
             self.assertEqual(len(span_list), 0)
 
     def assertSpanAttributes(

--- a/tests/system/_helpers.py
+++ b/tests/system/_helpers.py
@@ -137,3 +137,21 @@ def cleanup_old_instances(spanner_client):
 
 def unique_id(prefix, separator="-"):
     return f"{prefix}{system.unique_resource_id(separator)}"
+
+
+class FauxCall:
+    def __init__(self, code, details="FauxCall"):
+        self._code = code
+        self._details = details
+
+    def initial_metadata(self):
+        return {}
+
+    def trailing_metadata(self):
+        return {}
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -248,17 +248,12 @@ def test_transaction_abort_then_retry_spans():
         ("Starting Commit", {}),
         ("Commit Done", {}),
         (
-            "exception",
-            {
-                "exception.type": "google.api_core.exceptions.Aborted",
-                "exception.message": "409 Thrown from ClientInterceptor for testing",
-                "exception.stacktrace": "EPHEMERAL",
-                "exception.escaped": "False",
-            },
-        ),
-        (
             "Transaction was aborted in user operation, retrying",
-            {"delay_seconds": "EPHEMERAL", "attempt": 1},
+            {
+                "delay_seconds": "EPHEMERAL",
+                "cause": "409 Thrown from ClientInterceptor for testing",
+                "attempt": 1,
+            },
         ),
         ("Acquiring session", {"kind": "BurstyPool"}),
         ("Waiting for a session to become available", {"kind": "BurstyPool"}),
@@ -274,11 +269,7 @@ def test_transaction_abort_then_retry_spans():
         ("CloudSpanner.Transaction.execute_streaming_sql", codes.OK, None),
         ("CloudSpanner.Transaction.execute_streaming_sql", codes.OK, None),
         ("CloudSpanner.Transaction.commit", codes.OK, None),
-        (
-            "CloudSpanner.Session.run_in_transaction",
-            codes.ERROR,
-            "409 Thrown from ClientInterceptor for testing",
-        ),
+        ("CloudSpanner.Session.run_in_transaction", codes.OK, None),
         ("CloudSpanner.Database.run_in_transaction", codes.OK, None),
     ]
     assert got_statuses == want_statuses

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -105,7 +105,10 @@ def test_observability_options_propagation():
             len(from_inject_spans) >= 2
         )  # "Expecting at least 2 spans from the injected trace exporter"
         gotNames = [span.name for span in from_inject_spans]
-        wantNames = ["CloudSpanner.CreateSession", "CloudSpanner.ReadWriteTransaction"]
+        wantNames = [
+            "CloudSpanner.CreateSession",
+            "CloudSpanner.Snapshot.execute_streaming_sql",
+        ]
         assert gotNames == wantNames
 
         # Check for conformance of enable_extended_tracing

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -131,6 +131,161 @@ def test_observability_options_propagation():
     test_propagation(False)
 
 
+@pytest.mark.skipif(
+    not _helpers.USE_EMULATOR,
+    reason="Emulator needed to run this tests",
+)
+@pytest.mark.skipif(
+    not HAS_OTEL_INSTALLED,
+    reason="Tracing requires OpenTelemetry",
+)
+def test_transaction_abort_then_retry_spans():
+    from google.auth.credentials import AnonymousCredentials
+    from google.api_core.exceptions import Aborted
+    from google.rpc import code_pb2
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+    from opentelemetry.trace.status import StatusCode
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+    from opentelemetry import trace
+
+    PROJECT = _helpers.EMULATOR_PROJECT
+    CONFIGURATION_NAME = "config-name"
+    INSTANCE_ID = _helpers.INSTANCE_ID
+    DISPLAY_NAME = "display-name"
+    DATABASE_ID = _helpers.unique_id("temp_db")
+    NODE_COUNT = 5
+    LABELS = {"test": "true"}
+
+    counters = dict(aborted=0)
+    already_aborted = False
+
+    def select_in_txn(txn):
+        from google.rpc import error_details_pb2
+
+        results = txn.execute_sql("SELECT 1")
+        for row in results:
+            _ = row
+
+        if counters["aborted"] == 0:
+            counters["aborted"] = 1
+            raise Aborted(
+                "Thrown from ClientInterceptor for testing",
+                errors=[_helpers.FauxCall(code_pb2.ABORTED)],
+            )
+
+    tracer_provider = TracerProvider(sampler=ALWAYS_ON)
+    trace_exporter = InMemorySpanExporter()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(trace_exporter))
+    observability_options = dict(
+        tracer_provider=tracer_provider,
+        enable_extended_tracing=True,
+    )
+
+    client = Client(
+        project=PROJECT,
+        observability_options=observability_options,
+        credentials=AnonymousCredentials(),
+    )
+
+    instance = client.instance(
+        INSTANCE_ID,
+        CONFIGURATION_NAME,
+        display_name=DISPLAY_NAME,
+        node_count=NODE_COUNT,
+        labels=LABELS,
+    )
+
+    try:
+        instance.create()
+    except Exception:
+        pass
+
+    db = instance.database(DATABASE_ID)
+    try:
+        db.create()
+    except Exception:
+        pass
+
+    db.run_in_transaction(select_in_txn)
+
+    span_list = trace_exporter.get_finished_spans()
+    got_span_names = [span.name for span in span_list]
+    want_span_names = [
+        "CloudSpanner.CreateSession",
+        "CloudSpanner.Transaction.execute_streaming_sql",
+        "CloudSpanner.Transaction.execute_streaming_sql",
+        "CloudSpanner.Transaction.commit",
+        "CloudSpanner.Session.run_in_transaction",
+        "CloudSpanner.Database.run_in_transaction",
+    ]
+
+    assert got_span_names == want_span_names
+
+    got_events = []
+    got_statuses = []
+
+    # Some event attributes are noisy/highly ephemeral
+    # and can't be directly compared against.
+    imprecise_event_attributes = ["exception.stacktrace", "delay_seconds"]
+    for span in span_list:
+        got_statuses.append(
+            (span.name, span.status.status_code, span.status.description)
+        )
+        for event in span.events:
+            evt_attributes = event.attributes.copy()
+            for attr_name in imprecise_event_attributes:
+                if attr_name in evt_attributes:
+                    evt_attributes[attr_name] = "EPHEMERAL"
+
+            got_events.append((event.name, evt_attributes))
+
+    # Check for the series of events
+    want_events = [
+        ("Starting Commit", {}),
+        ("Commit Done", {}),
+        ("Using Transaction", {"attempt": 1}),
+        (
+            "exception",
+            {
+                "exception.type": "google.api_core.exceptions.Aborted",
+                "exception.message": "409 Thrown from ClientInterceptor for testing",
+                "exception.stacktrace": "EPHEMERAL",
+                "exception.escaped": "False",
+            },
+        ),
+        (
+            "Transaction was aborted in user operation, retrying",
+            {"delay_seconds": "EPHEMERAL", "attempt": 1},
+        ),
+        ("Using Transaction", {"attempt": 2}),
+        ("Acquiring session", {"kind": "BurstyPool"}),
+        ("Waiting for a session to become available", {"kind": "BurstyPool"}),
+        ("No sessions available in pool. Creating session", {"kind": "BurstyPool"}),
+        ("Creating Session", {}),
+    ]
+    assert got_events == want_events
+
+    # Check for the statues.
+    codes = StatusCode
+    want_statuses = [
+        ("CloudSpanner.CreateSession", codes.OK, None),
+        ("CloudSpanner.Transaction.execute_streaming_sql", codes.OK, None),
+        ("CloudSpanner.Transaction.execute_streaming_sql", codes.OK, None),
+        ("CloudSpanner.Transaction.commit", codes.OK, None),
+        (
+            "CloudSpanner.Session.run_in_transaction",
+            codes.ERROR,
+            "409 Thrown from ClientInterceptor for testing",
+        ),
+        ("CloudSpanner.Database.run_in_transaction", codes.OK, None),
+    ]
+    assert got_statuses == want_statuses
+
+
 def _make_credentials():
     from google.auth.credentials import AnonymousCredentials
 

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -247,7 +247,6 @@ def test_transaction_abort_then_retry_spans():
     want_events = [
         ("Starting Commit", {}),
         ("Commit Done", {}),
-        ("Using Transaction", {"attempt": 1}),
         (
             "exception",
             {
@@ -261,7 +260,6 @@ def test_transaction_abort_then_retry_spans():
             "Transaction was aborted in user operation, retrying",
             {"delay_seconds": "EPHEMERAL", "attempt": 1},
         ),
-        ("Using Transaction", {"attempt": 2}),
         ("Acquiring session", {"kind": "BurstyPool"}),
         ("Waiting for a session to become available", {"kind": "BurstyPool"}),
         ("No sessions available in pool. Creating session", {"kind": "BurstyPool"}),

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -230,7 +230,7 @@ def test_transaction_abort_then_retry_spans():
 
     # Some event attributes are noisy/highly ephemeral
     # and can't be directly compared against.
-    imprecise_event_attributes = ["exception.stacktrace", "delay_seconds"]
+    imprecise_event_attributes = ["exception.stacktrace", "delay_seconds", "cause"]
     for span in span_list:
         got_statuses.append(
             (span.name, span.status.status_code, span.status.description)
@@ -249,11 +249,7 @@ def test_transaction_abort_then_retry_spans():
         ("Commit Done", {}),
         (
             "Transaction was aborted in user operation, retrying",
-            {
-                "delay_seconds": "EPHEMERAL",
-                "cause": "409 Thrown from ClientInterceptor for testing",
-                "attempt": 1,
-            },
+            {"delay_seconds": "EPHEMERAL", "cause": "EPHEMERAL", "attempt": 1},
         ),
         ("Acquiring session", {"kind": "BurstyPool"}),
         ("Waiting for a session to become available", {"kind": "BurstyPool"}),

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -150,7 +150,6 @@ def test_transaction_abort_then_retry_spans():
     from opentelemetry.trace.status import StatusCode
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.sampling import ALWAYS_ON
-    from opentelemetry import trace
 
     PROJECT = _helpers.EMULATOR_PROJECT
     CONFIGURATION_NAME = "config-name"
@@ -161,11 +160,8 @@ def test_transaction_abort_then_retry_spans():
     LABELS = {"test": "true"}
 
     counters = dict(aborted=0)
-    already_aborted = False
 
     def select_in_txn(txn):
-        from google.rpc import error_details_pb2
-
         results = txn.execute_sql("SELECT 1")
         for row in results:
             _ = row

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -212,7 +212,7 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
             batch.commit()
 
         self.assertSpanAttributes(
-            "CloudSpanner.Commit",
+            "CloudSpanner.Batch.commit",
             status=StatusCode.ERROR,
             attributes=dict(BASE_ATTRIBUTES, num_mutations=1),
         )
@@ -261,7 +261,8 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         self.assertEqual(max_commit_delay, None)
 
         self.assertSpanAttributes(
-            "CloudSpanner.Commit", attributes=dict(BASE_ATTRIBUTES, num_mutations=1)
+            "CloudSpanner.Batch.commit",
+            attributes=dict(BASE_ATTRIBUTES, num_mutations=1),
         )
 
     def _test_commit_with_options(
@@ -327,7 +328,8 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         self.assertEqual(actual_request_options, expected_request_options)
 
         self.assertSpanAttributes(
-            "CloudSpanner.Commit", attributes=dict(BASE_ATTRIBUTES, num_mutations=1)
+            "CloudSpanner.Batch.commit",
+            attributes=dict(BASE_ATTRIBUTES, num_mutations=1),
         )
 
         self.assertEqual(max_commit_delay_in, max_commit_delay)
@@ -438,7 +440,8 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
         self.assertEqual(request_options, RequestOptions())
 
         self.assertSpanAttributes(
-            "CloudSpanner.Commit", attributes=dict(BASE_ATTRIBUTES, num_mutations=1)
+            "CloudSpanner.Batch.commit",
+            attributes=dict(BASE_ATTRIBUTES, num_mutations=1),
         )
 
     def test_context_mgr_failure(self):

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -245,11 +245,9 @@ class TestFixedSizePool(OpenTelemetryBase):
         span_list = self.get_finished_spans()
         got_span_names = [span.name for span in span_list]
         want_span_names = ["CloudSpanner.FixedPool.BatchCreateSessions", "pool.Get"]
-        print("got", got_span_names)
         assert got_span_names == want_span_names
 
         attrs = TestFixedSizePool.BASE_ATTRIBUTES.copy()
-        attrs["db.instance"] = ""
 
         # Check for the overall spans.
         self.assertSpanAttributes(
@@ -492,10 +490,7 @@ class TestBurstyPool(OpenTelemetryBase):
 
         span_list = self.get_finished_spans()
         got_span_names = [span.name for span in span_list]
-        want_span_names = [
-            "pool.Get",
-        ]
-        print("got_spans", got_span_names)
+        want_span_names = ["pool.Get"]
         assert got_span_names == want_span_names
 
         create_span = span_list[-1]
@@ -836,15 +831,12 @@ class TestPingingPool(OpenTelemetryBase):
         assert got_span_names == want_span_names
 
         attrs = TestPingingPool.BASE_ATTRIBUTES.copy()
-        attrs["db.instance"] = ""
         self.assertSpanAttributes(
             "CloudSpanner.PingingPool.BatchCreateSessions",
             attributes=attrs,
             span=span_list[-1],
         )
-        wantEventNames = [
-            'Requested for 4 sessions, returned 4'
-        ]
+        wantEventNames = ["Requested for 4 sessions, returned 4"]
         self.assertSpanEvents(
             "CloudSpanner.PingingPool.BatchCreateSessions", wantEventNames
         )
@@ -1151,6 +1143,10 @@ class _Database(object):
         # to avoid reversing the order of putting
         # sessions into pool (important for order tests)
         return self._sessions.pop(0)
+
+    @property
+    def observability_options(self):
+        return dict(db_name=self.name)
 
 
 class _Queue(object):

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -243,7 +243,7 @@ class TestFixedSizePool(OpenTelemetryBase):
         database._sessions.extend(SESSIONS)
         pool.bind(database)
 
-        with trace_call("pool.Get", SESSIONS[0]) as span:
+        with trace_call("pool.Get", SESSIONS[0]):
             pool.get()
 
         span_list = self.get_finished_spans()

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -558,8 +558,11 @@ class TestSession(OpenTelemetryBase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        attrs = {"session.id": session._session_id, "session.name": session.name}
+        attrs.update(TestSession.BASE_ATTRIBUTES)
         self.assertSpanAttributes(
-            "CloudSpanner.DeleteSession", attributes=TestSession.BASE_ATTRIBUTES
+            "CloudSpanner.DeleteSession",
+            attributes=attrs,
         )
 
     def test_delete_miss(self):
@@ -580,10 +583,13 @@ class TestSession(OpenTelemetryBase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        attrs = {"session.id": session._session_id, "session.name": session.name}
+        attrs.update(TestSession.BASE_ATTRIBUTES)
+
         self.assertSpanAttributes(
             "CloudSpanner.DeleteSession",
             status=StatusCode.ERROR,
-            attributes=TestSession.BASE_ATTRIBUTES,
+            attributes=attrs,
         )
 
     def test_delete_error(self):
@@ -604,10 +610,13 @@ class TestSession(OpenTelemetryBase):
             metadata=[("google-cloud-resource-prefix", database.name)],
         )
 
+        attrs = {"session.id": session._session_id, "session.name": session.name}
+        attrs.update(TestSession.BASE_ATTRIBUTES)
+
         self.assertSpanAttributes(
             "CloudSpanner.DeleteSession",
             status=StatusCode.ERROR,
-            attributes=TestSession.BASE_ATTRIBUTES,
+            attributes=attrs,
         )
 
     def test_snapshot_not_created(self):

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -616,7 +616,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
             list(derived.read(TABLE_NAME, COLUMNS, keyset))
 
         self.assertSpanAttributes(
-            "CloudSpanner.ReadOnlyTransaction",
+            "CloudSpanner._Derived.read",
             status=StatusCode.ERROR,
             attributes=dict(
                 BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
@@ -773,7 +773,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.ReadOnlyTransaction",
+            "CloudSpanner._Derived.read",
             attributes=dict(
                 BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
             ),
@@ -868,7 +868,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
         self.assertEqual(derived._execute_sql_count, 1)
 
         self.assertSpanAttributes(
-            "CloudSpanner.ReadWriteTransaction",
+            "CloudSpanner._Derived.execute_streaming_sql",
             status=StatusCode.ERROR,
             attributes=dict(BASE_ATTRIBUTES, **{"db.statement": SQL_QUERY}),
         )
@@ -1024,7 +1024,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
         self.assertEqual(derived._execute_sql_count, sql_count + 1)
 
         self.assertSpanAttributes(
-            "CloudSpanner.ReadWriteTransaction",
+            "CloudSpanner._Derived.execute_streaming_sql",
             status=StatusCode.OK,
             attributes=dict(BASE_ATTRIBUTES, **{"db.statement": SQL_QUERY_WITH_PARAM}),
         )
@@ -1195,7 +1195,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.PartitionReadOnlyTransaction",
+            "CloudSpanner._Derived.partition_read",
             status=StatusCode.OK,
             attributes=dict(
                 BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)
@@ -1226,7 +1226,7 @@ class Test_SnapshotBase(OpenTelemetryBase):
             list(derived.partition_read(TABLE_NAME, COLUMNS, keyset))
 
         self.assertSpanAttributes(
-            "CloudSpanner.PartitionReadOnlyTransaction",
+            "CloudSpanner._Derived.partition_read",
             status=StatusCode.ERROR,
             attributes=dict(
                 BASE_ATTRIBUTES, table_id=TABLE_NAME, columns=tuple(COLUMNS)

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -1697,7 +1697,7 @@ class TestSnapshot(OpenTelemetryBase):
             snapshot.begin()
 
         self.assertSpanAttributes(
-            "CloudSpanner.BeginTransaction",
+            "CloudSpanner.Snapshot.begin",
             status=StatusCode.ERROR,
             attributes=BASE_ATTRIBUTES,
         )
@@ -1755,7 +1755,7 @@ class TestSnapshot(OpenTelemetryBase):
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.BeginTransaction",
+            "CloudSpanner.Snapshot.begin",
             status=StatusCode.OK,
             attributes=BASE_ATTRIBUTES,
         )
@@ -1791,7 +1791,7 @@ class TestSnapshot(OpenTelemetryBase):
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.BeginTransaction",
+            "CloudSpanner.Snapshot.begin",
             status=StatusCode.OK,
             attributes=BASE_ATTRIBUTES,
         )

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -266,7 +266,7 @@ class TestTransaction(OpenTelemetryBase):
         self.assertFalse(transaction.rolled_back)
 
         self.assertSpanAttributes(
-            "CloudSpanner.Rollback",
+            "CloudSpanner.Transaction.rollback",
             status=StatusCode.ERROR,
             attributes=TestTransaction.BASE_ATTRIBUTES,
         )
@@ -299,7 +299,8 @@ class TestTransaction(OpenTelemetryBase):
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.Rollback", attributes=TestTransaction.BASE_ATTRIBUTES
+            "CloudSpanner.Transaction.rollback",
+            attributes=TestTransaction.BASE_ATTRIBUTES,
         )
 
     def test_commit_not_begun(self):
@@ -345,7 +346,7 @@ class TestTransaction(OpenTelemetryBase):
         self.assertIsNone(transaction.committed)
 
         self.assertSpanAttributes(
-            "CloudSpanner.Commit",
+            "CloudSpanner.Transaction.commit",
             status=StatusCode.ERROR,
             attributes=dict(TestTransaction.BASE_ATTRIBUTES, num_mutations=1),
         )
@@ -427,7 +428,7 @@ class TestTransaction(OpenTelemetryBase):
             self.assertEqual(transaction.commit_stats.mutation_count, 4)
 
         self.assertSpanAttributes(
-            "CloudSpanner.Commit",
+            "CloudSpanner.Transaction.commit",
             attributes=dict(
                 TestTransaction.BASE_ATTRIBUTES,
                 num_mutations=len(transaction._mutations),

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -162,7 +162,7 @@ class TestTransaction(OpenTelemetryBase):
             transaction.begin()
 
         self.assertSpanAttributes(
-            "CloudSpanner.BeginTransaction",
+            "CloudSpanner.Transaction.begin",
             status=StatusCode.ERROR,
             attributes=TestTransaction.BASE_ATTRIBUTES,
         )
@@ -195,7 +195,7 @@ class TestTransaction(OpenTelemetryBase):
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.BeginTransaction", attributes=TestTransaction.BASE_ATTRIBUTES
+            "CloudSpanner.Transaction.begin", attributes=TestTransaction.BASE_ATTRIBUTES
         )
 
     def test_begin_w_retry(self):


### PR DESCRIPTION
This change carves out parts of PR googleapis/python-spanner#1241 in smaller pieces to ease with smaller reviews.
This change adds more span events, updates important spans to make them more distinct like changing:

"CloudSpanner.ReadWriteTransaction" to more direct and more pointed spans like:
* CloudSpanner.Transaction.execute_streaming_sql

Also added important spans:
* CloudSpanner.Database.run_in_transaction
* CloudSpanner.Session.run_in_transaction