### PR TITLE
perf: add option for last_statement

### DIFF
--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -229,7 +229,10 @@ class Cursor(object):
         self.connection._transaction = transaction
         self.connection._snapshot = None
         self._result_set = transaction.execute_sql(
-            sql, params=params, param_types=get_param_types(params)
+            sql,
+            params=params,
+            param_types=get_param_types(params),
+            last_statement=True,
         )
         self._itr = PeekIterator(self._result_set)
         self._row_count = None

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -389,6 +389,7 @@ class _SnapshotBase(_SessionWrapper):
         query_mode=None,
         query_options=None,
         request_options=None,
+        last_statement=False,
         partition=None,
         retry=gapic_v1.method.DEFAULT,
         timeout=gapic_v1.method.DEFAULT,
@@ -431,6 +432,19 @@ class _SnapshotBase(_SessionWrapper):
                 (Optional) Common options for this request.
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.spanner_v1.types.RequestOptions`.
+
+        :type last_statement: bool
+        :param last_statement:
+                If set to true, this option marks the end of the transaction. The
+                transaction should be committed or aborted after this statement
+                executes, and attempts to execute any other requests against this
+                transaction (including reads and queries) will be rejected. Mixing
+                mutations with statements that are marked as the last statement is
+                not allowed.
+                For DML statements, setting this option may cause some error
+                reporting to be deferred until commit time (e.g. validation of
+                unique constraints). Given this, successful execution of a DML
+                statement should not be assumed until the transaction commits.
 
         :type partition: bytes
         :param partition: (Optional) one of the partition tokens returned
@@ -536,6 +550,7 @@ class _SnapshotBase(_SessionWrapper):
             seqno=self._execute_sql_count,
             query_options=query_options,
             request_options=request_options,
+            last_statement=last_statement,
             data_boost_enabled=data_boost_enabled,
             directed_read_options=directed_read_options,
         )

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -349,6 +349,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         query_mode=None,
         query_options=None,
         request_options=None,
+        last_statement=False,
         *,
         retry=gapic_v1.method.DEFAULT,
         timeout=gapic_v1.method.DEFAULT,
@@ -384,6 +385,19 @@ class Transaction(_SnapshotBase, _BatchBase):
                 (Optional) Common options for this request.
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.spanner_v1.types.RequestOptions`.
+
+        :type last_statement: bool
+        :param last_statement:
+                If set to true, this option marks the end of the transaction. The
+                transaction should be committed or aborted after this statement
+                executes, and attempts to execute any other requests against this
+                transaction (including reads and queries) will be rejected. Mixing
+                mutations with statements that are marked as the last statement is
+                not allowed.
+                For DML statements, setting this option may cause some error
+                reporting to be deferred until commit time (e.g. validation of
+                unique constraints). Given this, successful execution of a DML
+                statement should not be assumed until the transaction commits.
 
         :type retry: :class:`~google.api_core.retry.Retry`
         :param retry: (Optional) The retry settings for this request.
@@ -433,6 +447,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             query_options=query_options,
             seqno=seqno,
             request_options=request_options,
+            last_statement=last_statement,
         )
 
         method = functools.partial(
@@ -478,6 +493,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         self,
         statements,
         request_options=None,
+        last_statement=False,
         *,
         retry=gapic_v1.method.DEFAULT,
         timeout=gapic_v1.method.DEFAULT,
@@ -501,6 +517,19 @@ class Transaction(_SnapshotBase, _BatchBase):
                 (Optional) Common options for this request.
                 If a dict is provided, it must be of the same form as the protobuf
                 message :class:`~google.cloud.spanner_v1.types.RequestOptions`.
+
+        :type last_statement: bool
+        :param last_statement:
+                If set to true, this option marks the end of the transaction. The
+                transaction should be committed or aborted after this statement
+                executes, and attempts to execute any other requests against this
+                transaction (including reads and queries) will be rejected. Mixing
+                mutations with statements that are marked as the last statement is
+                not allowed.
+                For DML statements, setting this option may cause some error
+                reporting to be deferred until commit time (e.g. validation of
+                unique constraints). Given this, successful execution of a DML
+                statement should not be assumed until the transaction commits.
 
         :type retry: :class:`~google.api_core.retry.Retry`
         :param retry: (Optional) The retry settings for this request.
@@ -558,6 +587,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             statements=parsed,
             seqno=seqno,
             request_options=request_options,
+            last_statements=last_statement,
         )
 
         method = functools.partial(

--- a/tests/mockserver_tests/test_dbapi_autocommit.py
+++ b/tests/mockserver_tests/test_dbapi_autocommit.py
@@ -51,7 +51,7 @@ class TestDbapiAutoCommit(MockServerTestBase):
         )
         self.assertEqual(1, len(requests))
         self.assertFalse(requests[0].last_statement, requests[0])
-        self.assertIsNotNone(requests[0].transaction, requests[0]);
+        self.assertIsNotNone(requests[0].transaction, requests[0])
         self.assertIsNotNone(requests[0].transaction.single_use, requests[0])
         self.assertTrue(requests[0].transaction.single_use.read_only, requests[0])
 

--- a/tests/mockserver_tests/test_dbapi_autocommit.py
+++ b/tests/mockserver_tests/test_dbapi_autocommit.py
@@ -1,0 +1,127 @@
+# Copyright 2025 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud.spanner_dbapi import Connection
+from google.cloud.spanner_v1 import (
+    ExecuteSqlRequest,
+    TypeCode,
+    CommitRequest,
+    ExecuteBatchDmlRequest,
+)
+from tests.mockserver_tests.mock_server_test_base import (
+    MockServerTestBase,
+    add_single_result,
+    add_update_count,
+)
+
+
+class TestDbapiAutoCommit(MockServerTestBase):
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        add_single_result(
+            "select name from singers", "name", TypeCode.STRING, [("Some Singer",)]
+        )
+        add_update_count("insert into singers (id, name) values (1, 'Some Singer')", 1)
+
+    def test_select_autocommit(self):
+        connection = Connection(self.instance, self.database)
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute("select name from singers")
+            result_list = cursor.fetchall()
+            for _ in result_list:
+                pass
+        requests = list(
+            filter(
+                lambda msg: isinstance(msg, ExecuteSqlRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(requests))
+        self.assertFalse(requests[0].last_statement, requests[0])
+        self.assertIsNotNone(requests[0].transaction, requests[0]);
+        self.assertIsNotNone(requests[0].transaction.single_use, requests[0])
+        self.assertTrue(requests[0].transaction.single_use.read_only, requests[0])
+
+    def test_dml_autocommit(self):
+        connection = Connection(self.instance, self.database)
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute("insert into singers (id, name) values (1, 'Some Singer')")
+            self.assertEqual(1, cursor.rowcount)
+        requests = list(
+            filter(
+                lambda msg: isinstance(msg, ExecuteSqlRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(requests))
+        self.assertTrue(requests[0].last_statement, requests[0])
+        commit_requests = list(
+            filter(
+                lambda msg: isinstance(msg, CommitRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(commit_requests))
+
+    def test_executemany_autocommit(self):
+        connection = Connection(self.instance, self.database)
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.executemany(
+                "insert into singers (id, name) values (1, 'Some Singer')", [(), ()]
+            )
+            self.assertEqual(2, cursor.rowcount)
+        requests = list(
+            filter(
+                lambda msg: isinstance(msg, ExecuteBatchDmlRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(requests))
+        self.assertTrue(requests[0].last_statements, requests[0])
+        commit_requests = list(
+            filter(
+                lambda msg: isinstance(msg, CommitRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(commit_requests))
+
+    def test_batch_dml_autocommit(self):
+        connection = Connection(self.instance, self.database)
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute("start batch dml")
+            cursor.execute("insert into singers (id, name) values (1, 'Some Singer')")
+            cursor.execute("insert into singers (id, name) values (1, 'Some Singer')")
+            cursor.execute("run batch")
+            self.assertEqual(2, cursor.rowcount)
+        requests = list(
+            filter(
+                lambda msg: isinstance(msg, ExecuteBatchDmlRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(requests))
+        self.assertTrue(requests[0].last_statements, requests[0])
+        commit_requests = list(
+            filter(
+                lambda msg: isinstance(msg, CommitRequest),
+                self.spanner_service.requests,
+            )
+        )
+        self.assertEqual(1, len(commit_requests))

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -148,7 +148,7 @@ class TestCursor(unittest.TestCase):
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 1}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 2}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 3}, {"a0": INT64}),
-            ]
+            ], last_statement=True,
         )
         self.assertEqual(cursor._row_count, 3)
 
@@ -539,7 +539,7 @@ class TestCursor(unittest.TestCase):
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 1}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 2}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 3}, {"a0": INT64}),
-            ]
+            ], last_statement=True,
         )
 
     def test_executemany_update_batch_autocommit(self):
@@ -582,7 +582,7 @@ class TestCursor(unittest.TestCase):
                     {"a0": 3, "a1": "c"},
                     {"a0": INT64, "a1": STRING},
                 ),
-            ]
+            ], last_statement=True,
         )
 
     def test_executemany_insert_batch_non_autocommit(self):
@@ -659,7 +659,7 @@ class TestCursor(unittest.TestCase):
                     {"a0": 5, "a1": 6, "a2": 7, "a3": 8},
                     {"a0": INT64, "a1": INT64, "a2": INT64, "a3": INT64},
                 ),
-            ]
+            ], last_statement=True,
         )
         transaction.commit.assert_called_once()
 

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -148,7 +148,8 @@ class TestCursor(unittest.TestCase):
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 1}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 2}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 3}, {"a0": INT64}),
-            ], last_statement=True,
+            ],
+            last_statement=True,
         )
         self.assertEqual(cursor._row_count, 3)
 
@@ -539,7 +540,8 @@ class TestCursor(unittest.TestCase):
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 1}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 2}, {"a0": INT64}),
                 ("DELETE FROM table WHERE col1 = @a0", {"a0": 3}, {"a0": INT64}),
-            ], last_statement=True,
+            ],
+            last_statement=True,
         )
 
     def test_executemany_update_batch_autocommit(self):
@@ -582,7 +584,8 @@ class TestCursor(unittest.TestCase):
                     {"a0": 3, "a1": "c"},
                     {"a0": INT64, "a1": STRING},
                 ),
-            ], last_statement=True,
+            ],
+            last_statement=True,
         )
 
     def test_executemany_insert_batch_non_autocommit(self):
@@ -659,7 +662,8 @@ class TestCursor(unittest.TestCase):
                     {"a0": 5, "a1": 6, "a2": 7, "a3": 8},
                     {"a0": INT64, "a1": INT64, "a2": INT64, "a3": INT64},
                 ),
-            ], last_statement=True,
+            ],
+            last_statement=True,
         )
         transaction.commit.assert_called_once()
 


### PR DESCRIPTION
Adds an option to indicate that a statement is the last statement in a read/write transaction. Setting this option allows Spanner to optimize the execution of the statement, and defer some validations until the Commit RPC that should follow directly after this statement.

The last_statement option is automatically used by the dbapi driver when a statement is executed in autocommit mode.
