### PR TITLE
build: update system tests to test protobuf implementation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -339,6 +339,12 @@ def system(session, protobuf_implementation, database_dialect):
 
     install_systemtest_dependencies(session, "-c", constraints_path)
 
+    # TODO(https://github.com/googleapis/synthtool/issues/1976):
+    # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
+    # The 'cpp' implementation requires Protobuf<4.
+    if protobuf_implementation == "cpp":
+        session.install("protobuf<4")
+
     # Run py.test against the system tests.
     if system_test_exists:
         session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -294,8 +294,18 @@ def install_systemtest_dependencies(session, *constraints):
 
 
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
-@nox.parametrize("database_dialect", ["GOOGLE_STANDARD_SQL", "POSTGRESQL"])
-def system(session, database_dialect):
+@nox.parametrize(
+    "protobuf_implementation,database_dialect",
+    [
+        ("python", "GOOGLE_STANDARD_SQL"),
+        ("python", "POSTGRESQL"),
+        ("upb", "GOOGLE_STANDARD_SQL"),
+        ("upb", "POSTGRESQL"),
+        ("cpp", "GOOGLE_STANDARD_SQL"),
+        ("cpp", "POSTGRESQL"),
+    ],
+)
+def system(session, protobuf_implementation, database_dialect):
     """Run the system test suite."""
     constraints_path = str(
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
@@ -338,6 +348,7 @@ def system(session, database_dialect):
             system_test_path,
             *session.posargs,
             env={
+                "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
                 "SPANNER_DATABASE_DIALECT": database_dialect,
                 "SKIP_BACKUP_TESTS": "true",
             },
@@ -350,6 +361,7 @@ def system(session, database_dialect):
             system_test_folder_path,
             *session.posargs,
             env={
+                "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
                 "SPANNER_DATABASE_DIALECT": database_dialect,
                 "SKIP_BACKUP_TESTS": "true",
             },

--- a/tests/system/test_database_api.py
+++ b/tests/system/test_database_api.py
@@ -294,7 +294,8 @@ def test_iam_policy(
 
     new_policy = temp_db.get_iam_policy(3)
     assert new_policy.version == 3
-    assert new_policy.bindings == [new_binding]
+    assert len(new_policy.bindings) == 1
+    assert new_policy.bindings[0] == new_binding
 
 
 def test_table_not_found(shared_instance):


### PR DESCRIPTION
Updates system tests to run with `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION` which tests the following protobuf implementations: `python`, `cpp`, `upb`. `cpp` can be removed once support for Protobuf 3.x is removed from setup.py.

See https://github.com/protocolbuffers/protobuf/tree/main/python#implementation-backends

Also fixes a failing test when `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` is used, which could be a bug in `protobuf`. If this looks like a bug, we can file an issue upstream.