### PR TITLE
feat: add SQL statement for begin transaction isolation level

### DIFF
--- a/tests/mockserver_tests/test_dbapi_isolation_level.py
+++ b/tests/mockserver_tests/test_dbapi_isolation_level.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.api_core.exceptions import Unknown
 from google.cloud.spanner_dbapi import Connection
 from google.cloud.spanner_v1 import (
     BeginTransactionRequest,
@@ -141,3 +142,9 @@ class TestDbapiIsolationLevel(MockServerTestBase):
             self.assertEqual(1, len(begin_requests))
             self.assertEqual(begin_requests[0].options.isolation_level, level)
             MockServerTestBase.spanner_service.clear_requests()
+
+    def test_begin_invalid_isolation_level(self):
+        connection = Connection(self.instance, self.database)
+        with connection.cursor() as cursor:
+            with self.assertRaises(Unknown):
+                cursor.execute("begin isolation level does_not_exist")

--- a/tests/mockserver_tests/test_dbapi_isolation_level.py
+++ b/tests/mockserver_tests/test_dbapi_isolation_level.py
@@ -117,3 +117,27 @@ class TestDbapiIsolationLevel(MockServerTestBase):
             self.assertEqual(1, len(begin_requests))
             self.assertEqual(begin_requests[0].options.isolation_level, level)
             MockServerTestBase.spanner_service.clear_requests()
+
+    def test_begin_isolation_level(self):
+        connection = Connection(self.instance, self.database)
+        for level in [
+            TransactionOptions.IsolationLevel.REPEATABLE_READ,
+            TransactionOptions.IsolationLevel.SERIALIZABLE,
+        ]:
+            isolation_level_name = level.name.replace("_", " ")
+            with connection.cursor() as cursor:
+                cursor.execute(f"begin isolation level {isolation_level_name}")
+                cursor.execute(
+                    "insert into singers (id, name) values (1, 'Some Singer')"
+                )
+                self.assertEqual(1, cursor.rowcount)
+            connection.commit()
+            begin_requests = list(
+                filter(
+                    lambda msg: isinstance(msg, BeginTransactionRequest),
+                    self.spanner_service.requests,
+                )
+            )
+            self.assertEqual(1, len(begin_requests))
+            self.assertEqual(begin_requests[0].options.isolation_level, level)
+            MockServerTestBase.spanner_service.clear_requests()

--- a/tests/unit/spanner_dbapi/test_client_side_statement_executor.py
+++ b/tests/unit/spanner_dbapi/test_client_side_statement_executor.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from google.cloud.spanner_dbapi.client_side_statement_executor import (
+    _get_isolation_level,
+)
+from google.cloud.spanner_dbapi.parse_utils import classify_statement
+from google.cloud.spanner_v1 import TransactionOptions
+
+
+class TestParseUtils(unittest.TestCase):
+    def test_get_isolation_level(self):
+        self.assertIsNone(_get_isolation_level(classify_statement("begin")))
+        self.assertEqual(
+            TransactionOptions.IsolationLevel.SERIALIZABLE,
+            _get_isolation_level(
+                classify_statement("begin isolation level serializable")
+            ),
+        )
+        self.assertEqual(
+            TransactionOptions.IsolationLevel.SERIALIZABLE,
+            _get_isolation_level(
+                classify_statement(
+                    "begin  transaction  isolation    level     serializable    "
+                )
+            ),
+        )
+        self.assertEqual(
+            TransactionOptions.IsolationLevel.REPEATABLE_READ,
+            _get_isolation_level(
+                classify_statement("begin isolation level repeatable read")
+            ),
+        )
+        self.assertEqual(
+            TransactionOptions.IsolationLevel.REPEATABLE_READ,
+            _get_isolation_level(
+                classify_statement(
+                    "begin    transaction  isolation    level   repeatable    read "
+                )
+            ),
+        )

--- a/tests/unit/spanner_dbapi/test_parse_utils.py
+++ b/tests/unit/spanner_dbapi/test_parse_utils.py
@@ -63,8 +63,28 @@ class TestParseUtils(unittest.TestCase):
             ("commit", StatementType.CLIENT_SIDE),
             ("begin", StatementType.CLIENT_SIDE),
             ("start", StatementType.CLIENT_SIDE),
+            ("begin isolation level serializable", StatementType.CLIENT_SIDE),
+            ("start isolation level serializable", StatementType.CLIENT_SIDE),
+            ("begin isolation level repeatable read", StatementType.CLIENT_SIDE),
+            ("start isolation level repeatable read", StatementType.CLIENT_SIDE),
             ("begin transaction", StatementType.CLIENT_SIDE),
             ("start transaction", StatementType.CLIENT_SIDE),
+            (
+                "begin transaction isolation level serializable",
+                StatementType.CLIENT_SIDE,
+            ),
+            (
+                "start transaction isolation level serializable",
+                StatementType.CLIENT_SIDE,
+            ),
+            (
+                "begin transaction isolation level repeatable read",
+                StatementType.CLIENT_SIDE,
+            ),
+            (
+                "start transaction isolation level repeatable read",
+                StatementType.CLIENT_SIDE,
+            ),
             ("rollback", StatementType.CLIENT_SIDE),
             (" commit   TRANSACTION ", StatementType.CLIENT_SIDE),
             (" rollback TRANSACTION ", StatementType.CLIENT_SIDE),
@@ -84,6 +104,16 @@ class TestParseUtils(unittest.TestCase):
             ("udpate table set col2=1 where col1 = 2", StatementType.UNKNOWN),
             ("begin foo", StatementType.UNKNOWN),
             ("begin transaction foo", StatementType.UNKNOWN),
+            ("begin transaction isolation level", StatementType.UNKNOWN),
+            ("begin transaction repeatable read", StatementType.UNKNOWN),
+            (
+                "begin transaction isolation level repeatable read foo",
+                StatementType.UNKNOWN,
+            ),
+            (
+                "begin transaction isolation level unspecified",
+                StatementType.UNKNOWN,
+            ),
             ("commit foo", StatementType.UNKNOWN),
             ("commit transaction foo", StatementType.UNKNOWN),
             ("rollback foo", StatementType.UNKNOWN),
@@ -99,6 +129,50 @@ class TestParseUtils(unittest.TestCase):
             self.assertEqual(
                 classify_statement(query).statement_type, want_class, query
             )
+
+    def test_begin_isolation_level(self):
+        parsed_statement = classify_statement("begin")
+        self.assertEqual(
+            parsed_statement,
+            ParsedStatement(
+                StatementType.CLIENT_SIDE,
+                Statement("begin"),
+                ClientSideStatementType.BEGIN,
+                [],
+            ),
+        )
+        parsed_statement = classify_statement("begin isolation level serializable")
+        self.assertEqual(
+            parsed_statement,
+            ParsedStatement(
+                StatementType.CLIENT_SIDE,
+                Statement("begin isolation level serializable"),
+                ClientSideStatementType.BEGIN,
+                ["serializable"],
+            ),
+        )
+        parsed_statement = classify_statement("begin isolation level repeatable read")
+        self.assertEqual(
+            parsed_statement,
+            ParsedStatement(
+                StatementType.CLIENT_SIDE,
+                Statement("begin isolation level repeatable read"),
+                ClientSideStatementType.BEGIN,
+                ["repeatable read"],
+            ),
+        )
+        parsed_statement = classify_statement(
+            "begin isolation    level   repeatable    read    "
+        )
+        self.assertEqual(
+            parsed_statement,
+            ParsedStatement(
+                StatementType.CLIENT_SIDE,
+                Statement("begin isolation    level   repeatable    read"),
+                ClientSideStatementType.BEGIN,
+                ["repeatable    read"],
+            ),
+        )
 
     def test_partition_query_classify_stmt(self):
         parsed_statement = classify_statement(


### PR DESCRIPTION
Adds an additional option to the `begin [transaction]` SQL statement to specify the isolation level of that transaction. The following format is now supported:

```
{begin | start} [transaction] [isolation level {repeatable read | serializable}]
```
