### PR TITLE
 feat: Add support for multiplexed sessions - part 2 (read-only transactions)

### DIFF
--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -192,7 +192,9 @@ class Database(object):
             pool = BurstyPool(database_role=database_role)
         pool.bind(self)
 
-        self._session_manager = DatabaseSessionsManager(database=self, pool=pool)
+        self._session_manager = DatabaseSessionsManager(
+            database=self, pool=pool, logger=self.logger
+        )
 
     @classmethod
     def from_pb(cls, database_pb, instance, pool=None):

--- a/google/cloud/spanner_v1/session_options.py
+++ b/google/cloud/spanner_v1/session_options.py
@@ -11,8 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import datetime
 import os
+
+from google.cloud.spanner_v1._opentelemetry_tracing import (
+    get_current_span,
+    add_span_event,
+)
 
 
 class SessionOptions(object):
@@ -22,9 +26,12 @@ class SessionOptions(object):
     * read-only transactions (:meth:`use_multiplexed_for_read_only`)
     * partitioned transactions (:meth:`use_multiplexed_for_partitioned`)
     * read/write transactions (:meth:`use_multiplexed_for_read_write`).
-    """
 
-    MULTIPLEXED_SESSIONS_REFRESH_INTERVAL = datetime.timedelta(days=7)
+    The use of multiplexed session can be disabled for corresponding transaction types by calling:
+    * :meth:`disable_multiplexed_for_read_only`
+    * :meth:`disable_multiplexed_for_partitioned`
+    * :meth:`disable_multiplexed_for_read_write`.
+    """
 
     # Environment variables for multiplexed sessions
     ENV_VAR_ENABLE_MULTIPLEXED = "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS"
@@ -61,6 +68,13 @@ class SessionOptions(object):
 
     def disable_multiplexed_for_read_only(self) -> None:
         """Disables the use of multiplexed sessions for read-only transactions."""
+
+        current_span = get_current_span()
+        add_span_event(
+            current_span,
+            "Disabling use of multiplexed session for read-only transactions",
+        )
+
         self._is_multiplexed_enabled_for_read_only = False
 
     def use_multiplexed_for_partitioned(self) -> bool:
@@ -81,6 +95,13 @@ class SessionOptions(object):
 
     def disable_multiplexed_for_partitioned(self) -> None:
         """Disables the use of multiplexed sessions for read-only transactions."""
+
+        current_span = get_current_span()
+        add_span_event(
+            current_span,
+            "Disabling use of multiplexed session for partitioned transactions",
+        )
+
         self._is_multiplexed_enabled_for_partitioned = False
 
     def use_multiplexed_for_read_write(self) -> bool:
@@ -101,6 +122,13 @@ class SessionOptions(object):
 
     def disable_multiplexed_for_read_write(self) -> None:
         """Disables the use of multiplexed sessions for read/write transactions."""
+
+        current_span = get_current_span()
+        add_span_event(
+            current_span,
+            "Disabling use of multiplexed session for read/write transactions",
+        )
+
         self._is_multiplexed_enabled_for_read_write = False
 
     @staticmethod
@@ -108,5 +136,5 @@ class SessionOptions(object):
         """Returns the value of the given environment variable as a boolean.
         True values are '1' and 'true' (case-insensitive); all other values are considered false.
         """
-        env_var = os.getenv(name, "").lower()
+        env_var = os.getenv(name, "").lower().strip()
         return env_var in ["1", "true"]

--- a/tests/unit/test_database_session_manager.py
+++ b/tests/unit/test_database_session_manager.py
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import datetime
+import time
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, DEFAULT, PropertyMock
+
+from google.api_core.exceptions import (
+    MethodNotImplemented,
+    BadRequest,
+    FailedPrecondition,
+)
 
 from google.cloud.spanner_v1 import SpannerClient
 from google.cloud.spanner_v1.client import Client
 from google.cloud.spanner_v1.database import Database
+from google.cloud.spanner_v1.database_sessions_manager import DatabaseSessionsManager
 from google.cloud.spanner_v1.instance import Instance
-from google.cloud.spanner_v1.session import Session
 from google.cloud.spanner_v1.session_options import SessionOptions
 
 
@@ -29,8 +37,20 @@ class TestDatabaseSessionManager(TestCase):
 
         self._mocks = {
             "create_session": patch.object(SpannerClient, "create_session").start(),
-            "get_session": patch.object(SpannerClient, "get_session").start(),
             "delete_session": patch.object(SpannerClient, "delete_session").start(),
+            # Mock faster polling and refresh intervals for tests.
+            "polling_interval": patch.object(
+                DatabaseSessionsManager,
+                "_MAINTENANCE_THREAD_POLLING_INTERVAL",
+                new_callable=PropertyMock,
+                return_value=datetime.timedelta(seconds=1),
+            ).start(),
+            "refresh_interval": patch.object(
+                DatabaseSessionsManager,
+                "_MAINTENANCE_THREAD_REFRESH_INTERVAL",
+                new_callable=PropertyMock,
+                return_value=datetime.timedelta(seconds=2),
+            ).start(),
         }
 
     def tearDown(self):
@@ -56,10 +76,21 @@ class TestDatabaseSessionManager(TestCase):
         self._enable_multiplexed_env_vars()
         session_manager = self._build_database_session_manager()
 
-        with self.assertRaises(NotImplementedError):
-            session_manager.get_session_for_read_only()
+        # Session is created.
+        session_1 = session_manager.get_session_for_read_only()
+        self.assertTrue(session_1.is_multiplexed)
+        session_manager.put_session(session_1)
 
-    def test_partitioned_non_multiplexed(self):
+        # Session is re-used.
+        session_2 = session_manager.get_session_for_read_only()
+        self.assertEqual(session_1, session_2)
+        session_manager.put_session(session_2)
+
+        # Verify that pool was not used.
+        session_manager._pool.get.assert_not_called()
+        session_manager._pool.put.assert_not_called()
+
+    def test_partitioned_pooled(self):
         self._disable_multiplexed_env_vars()
         session_manager = self._build_database_session_manager()
 
@@ -79,7 +110,7 @@ class TestDatabaseSessionManager(TestCase):
         with self.assertRaises(NotImplementedError):
             session_manager.get_session_for_partitioned()
 
-    def test_read_write_non_multiplexed(self):
+    def test_read_write_pooled(self):
         self._disable_multiplexed_env_vars()
         session_manager = self._build_database_session_manager()
 
@@ -99,13 +130,113 @@ class TestDatabaseSessionManager(TestCase):
         with self.assertRaises(NotImplementedError):
             session_manager.get_session_for_read_write()
 
-    def test_put_multiplexed(self):
+    def test_multiplexed_maintenance(self):
+        self._enable_multiplexed_env_vars()
         session_manager = self._build_database_session_manager()
 
-        with self.assertRaises(NotImplementedError):
-            session_manager.put_session(
-                Session(database=session_manager._database, is_multiplexed=True)
+        # Maintenance thread is started.
+        session_1 = session_manager.get_session_for_read_only()
+        self.assertTrue(session_1.is_multiplexed)
+
+        # Wait for maintenance thread to execute.
+        def create_session_condition():
+            return self._mocks["create_session"].call_count > 1
+
+        self.assert_true_with_timeout(create_session_condition)
+
+        # Verify that maintenance thread created new multiplexed session.
+        session_2 = session_manager.get_session_for_read_only()
+        self.assertTrue(session_2.is_multiplexed)
+        self.assertNotEqual(session_1, session_2)
+
+    def test_multiplexed_maintenance_terminates_not_implemented(self):
+        self._enable_multiplexed_env_vars()
+        session_manager = self._build_database_session_manager()
+
+        # Maintenance thread is started.
+        session_1 = session_manager.get_session_for_read_only()
+        self.assertTrue(session_1.is_multiplexed)
+
+        # Multiplexed sessions not implemented.
+        create_session_mock = self._mocks["create_session"]
+        create_session_mock.side_effect = MethodNotImplemented(
+            "Multiplexed sessions not implemented"
+        )
+
+        # Wait for maintenance thread to terminate.
+        thread = session_manager._multiplexed_session_maintenance_thread
+
+        def thread_terminated_condition():
+            return not thread.is_alive()
+
+        self.assert_true_with_timeout(thread_terminated_condition)
+
+        # Verify that multiplexed sessions are disabled.
+        session_options = session_manager._database._instance._client.session_options
+        self.assertFalse(session_options.use_multiplexed_for_read_only())
+        self.assertFalse(session_options.use_multiplexed_for_partitioned())
+        self.assertFalse(session_options.use_multiplexed_for_read_write())
+
+    def test_multiplexed_maintenance_terminates_disabled(self):
+        self._enable_multiplexed_env_vars()
+        session_manager = self._build_database_session_manager()
+
+        # Maintenance thread is started.
+        session_1 = session_manager.get_session_for_read_only()
+        self.assertTrue(session_1.is_multiplexed)
+
+        session_manager._is_multiplexed_sessions_disabled_event.set()
+
+        # Wait for maintenance thread to terminate.
+        thread = session_manager._multiplexed_session_maintenance_thread
+
+        def thread_terminated_condition():
+            return not thread.is_alive()
+
+        self.assert_true_with_timeout(thread_terminated_condition)
+
+    def test_multiplexed_exception_method_not_implemented(self):
+        self._enable_multiplexed_env_vars()
+        session_manager = self._build_database_session_manager()
+
+        # Multiplexed sessions not implemented.
+        self._mocks["create_session"].side_effect = [
+            MethodNotImplemented("Test MethodNotImplemented"),
+            DEFAULT,
+        ]
+
+        # Get session from pool.
+        session = session_manager.get_session_for_read_only()
+        self.assertFalse(session.is_multiplexed)
+        session_manager._pool.get.assert_called_once()
+
+        # Return session to pool.
+        session_manager.put_session(session)
+        session_manager._pool.put.assert_called_once_with(session)
+
+        # Verify that multiplexed session are disabled.
+        session_options = session_manager._database._instance._client.session_options
+        self.assertFalse(session_options.use_multiplexed_for_read_only())
+        self.assertFalse(session_options.use_multiplexed_for_partitioned())
+        self.assertFalse(session_options.use_multiplexed_for_read_write())
+
+    def test_exception_bad_request(self):
+        session_manager = self._build_database_session_manager()
+
+        # Verify that BadRequest is not caught.
+        with self.assertRaises(BadRequest):
+            self._mocks["create_session"].side_effect = BadRequest("Test BadRequest")
+            session_manager.get_session_for_read_only()
+
+    def test_exception_failed_precondition(self):
+        session_manager = self._build_database_session_manager()
+
+        # Verify that FailedPrecondition is not caught.
+        with self.assertRaises(FailedPrecondition):
+            self._mocks["create_session"].side_effect = FailedPrecondition(
+                "Test FailedPrecondition"
             )
+            session_manager.get_session_for_read_only()
 
     @staticmethod
     def _build_database_session_manager():
@@ -138,3 +269,16 @@ class TestDatabaseSessionManager(TestCase):
         """Sets environment variables to disable multiplexed sessions."""
 
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "true"
+
+    @staticmethod
+    def assert_true_with_timeout(condition):
+        """Asserts that the given condition is met within a timeout period."""
+
+        sleep_seconds = 0.1
+        timeout_seconds = 10
+
+        start_time = time.time()
+        while not condition() and time.time() - start_time < timeout_seconds:
+            time.sleep(sleep_seconds)
+
+        assert condition()

--- a/tests/unit/test_session_options.py
+++ b/tests/unit/test_session_options.py
@@ -87,7 +87,7 @@ class TestSessionOptions(TestCase):
 
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
 
-        true_values = ["1", "true", "True", "TRUE"]
+        true_values = ["1", " 1", " 1", "true", "True", "TRUE", " true "]
         for value in true_values:
             os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = value
             self.assertTrue(session_options.use_multiplexed_for_read_only())


### PR DESCRIPTION
 feat: Add support for multiplexed sessions - part 2 (read-only transactions)
- Enabled use of multiplexed sessions for read-only transactions
- Add maintenance threads for refreshing multiplexed sessions

