### PR TITLE
feat: Add support for multiplexed sessions - part 3 (partitioned transactions)

### DIFF
--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -20,7 +20,7 @@ import time
 
 from google.cloud.exceptions import NotFound
 from google.cloud.spanner_v1 import BatchCreateSessionsRequest
-from google.cloud.spanner_v1 import Session
+from google.cloud.spanner_v1 import Session as SessionPB
 from google.cloud.spanner_v1._helpers import (
     _metadata_with_prefix,
     _metadata_with_leader_aware_routing,
@@ -33,6 +33,7 @@ from google.cloud.spanner_v1._opentelemetry_tracing import (
 from warnings import warn
 
 from google.cloud.spanner_v1.metrics.metrics_capture import MetricsCapture
+from google.cloud.spanner_v1.session import Session
 
 _NOW = datetime.datetime.utcnow  # unit tests may replace
 
@@ -130,8 +131,9 @@ class AbstractSessionPool(object):
         :rtype: :class:`~google.cloud.spanner_v1.session.Session`
         :returns: new session instance.
         """
-        return self._database.session(
-            labels=self.labels, database_role=self.database_role
+        database_role = self.database_role or self._database.database_role
+        return Session(
+            database=self._database, labels=self.labels, database_role=database_role
         )
 
 
@@ -225,7 +227,7 @@ class FixedSizePool(AbstractSessionPool):
         request = BatchCreateSessionsRequest(
             database=database.name,
             session_count=requested_session_count,
-            session_template=Session(creator_role=self.database_role),
+            session_template=SessionPB(creator_role=self.database_role),
         )
 
         observability_options = getattr(self._database, "observability_options", None)
@@ -518,7 +520,7 @@ class PingingPool(AbstractSessionPool):
         request = BatchCreateSessionsRequest(
             database=database.name,
             session_count=self.size,
-            session_template=Session(creator_role=self.database_role),
+            session_template=SessionPB(creator_role=self.database_role),
         )
 
         span_event_attributes = {"kind": type(self).__name__}

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -300,11 +300,6 @@ class Session(object):
         if self._session_id is None:
             raise ValueError("Session has not been created.")
 
-        if self.is_multiplexed:
-            raise NotImplementedError(
-                "Multiplexed sessions do not yet support read-only transactions."
-            )
-
         return Snapshot(self, **kw)
 
     def read(self, table, columns, keyset, index="", limit=0, column_info=None):

--- a/tests/_builders.py
+++ b/tests/_builders.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Google LLC All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default identifiers.
+PROJECT_ID = "project-id"
+INSTANCE_ID = "instance-id"
+DATABASE_ID = "database-id"
+SESSION_ID = "session-id"
+TRANSACTION_ID = b"transaction-id"
+
+# Default names.
+INSTANCE_NAME = "projects/" + PROJECT_ID + "/instances/" + INSTANCE_ID
+DATABASE_NAME = INSTANCE_NAME + "/databases/" + DATABASE_ID
+SESSION_NAME = DATABASE_NAME + "/sessions/" + SESSION_ID
+
+
+def build_database(**database_kwargs):
+    """Builds and returns a database for testing using the given arguments.
+    If a required argument is not provided, a default value will be used."""
+    from google.cloud.spanner_v1 import Session as SessionProto
+    from google.cloud.spanner_v1 import SpannerClient
+    from google.cloud.spanner_v1 import Transaction as TransactionProto
+    from google.cloud.spanner_v1.database import Database
+    from mock.mock import create_autospec
+
+    instance = _build_instance()
+    database = Database(database_id=DATABASE_ID, instance=instance)
+
+    # Mock API calls. Callers can override this to test specific behaviours.
+    api = database._spanner_api = create_autospec(SpannerClient, instance=True)
+    api.create_session.return_value = SessionProto(name=SESSION_NAME)
+    api.begin_transaction.return_value = TransactionProto(id=TRANSACTION_ID)
+
+    return database
+
+
+def build_session(**session_kwargs):
+    """Builds and returns a session for testing using the given arguments.
+    If a required argument is not provided, a default value will be used."""
+    from google.cloud.spanner_v1.session import Session
+
+    if not session_kwargs.get("database"):
+        session_kwargs["database"] = build_database()
+
+    return Session(**session_kwargs)
+
+
+def _build_client():
+    """Builds and returns a client for testing."""
+    from google.cloud.spanner_v1 import Client
+
+    return Client(project=PROJECT_ID)
+
+
+def _build_instance(**instance_kwargs):
+    """Builds and returns an instance for testing."""
+    from google.cloud.spanner_v1.instance import Instance
+
+    client = _build_client()
+    return Instance(instance_id=INSTANCE_ID, client=client)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,7 +1,9 @@
+import os
 import unittest
 import mock
 
 from google.cloud.spanner_v1 import gapic_version
+from google.cloud.spanner_v1.session_options import SessionOptions
 
 LIB_VERSION = gapic_version.__version__
 
@@ -149,3 +151,20 @@ class OpenTelemetryBase(unittest.TestCase):
                 got_all_events.append((event.name, evt_attributes))
 
         return got_all_events
+
+
+def enable_multiplexed_sessions() -> None:
+    """Sets environment variables to enable multiplexed sessions for all transaction types.
+    The caller is responsible for resetting the environment variables after use."""
+
+    os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "true"
+    os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_PARTITIONED] = "true"
+    os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_READ_WRITE] = "true"
+    os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
+
+
+def disable_multiplexed_sessions() -> None:
+    """Sets environment variables to disable multiplexed sessions for all transactions types.
+    The caller is responsible for resetting the environment variables after use."""
+
+    os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "true"

--- a/tests/system/test_observability_options.py
+++ b/tests/system/test_observability_options.py
@@ -233,7 +233,7 @@ def test_transaction_abort_then_retry_spans(mock_session_multiplexed, mock_sessi
         ("No sessions available in pool. Creating session", {"kind": "BurstyPool"}),
         ("Creating Session", {}),
         ("Using session", {"id": session_id, "multiplexed": session_multiplexed}),
-        ("Returned session", {"id": session_id, "multiplexed": session_multiplexed}),
+        ("Returning session", {"id": session_id, "multiplexed": session_multiplexed}),
         (
             "Transaction was aborted in user operation, retrying",
             {"delay_seconds": "EPHEMERAL", "cause": "EPHEMERAL", "attempt": 1},
@@ -426,7 +426,7 @@ def test_database_partitioned_error(mock_session_multiplexed, mock_session_id):
         ("Creating Session", {}),
         ("Using session", {"id": session_id, "multiplexed": session_multiplexed}),
         ("Starting BeginTransaction", {}),
-        ("Returned session", {"id": session_id, "multiplexed": session_multiplexed}),
+        ("Returning session", {"id": session_id, "multiplexed": session_multiplexed}),
         (
             "exception",
             {

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -33,7 +33,7 @@ from .testdata import singer_pb2
 from tests import _helpers as ot_helpers
 from . import _helpers
 from . import _sample_data
-
+from .._builders import build_session
 
 SOME_DATE = datetime.date(2011, 1, 17)
 SOME_TIME = datetime.datetime(1989, 1, 17, 17, 59, 12, 345612)
@@ -415,7 +415,7 @@ class _ReadAbortTrigger(object):
 
 
 def test_session_crud(sessions_database):
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     assert not session.exists()
 
     session.create()
@@ -587,7 +587,7 @@ def test_transaction_read_and_insert_then_rollback(
     sd = _sample_data
     db_name = sessions_database.name
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -722,7 +722,7 @@ def test_transaction_read_and_insert_or_update_then_commit(
     # [START spanner_test_dml_read_your_writes]
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -780,7 +780,7 @@ def test_transaction_execute_sql_w_dml_read_rollback(
     # [START spanner_test_dml_rollback_txn_not_committed]
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -814,7 +814,7 @@ def test_transaction_execute_update_read_commit(sessions_database, sessions_to_d
     # [START spanner_test_dml_read_your_writes]
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -846,7 +846,7 @@ def test_transaction_execute_update_then_insert_commit(
     # [START spanner_test_dml_update]
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -879,7 +879,7 @@ def test_transaction_execute_sql_dml_returning(
 ):
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -910,7 +910,7 @@ def test_transaction_execute_update_dml_returning(
 ):
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -938,7 +938,7 @@ def test_transaction_batch_update_dml_returning(
 ):
     sd = _sample_data
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -970,7 +970,7 @@ def test_transaction_batch_update_success(
     sd = _sample_data
     param_types = spanner_v1.param_types
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -1027,7 +1027,7 @@ def test_transaction_batch_update_and_execute_dml(
     sd = _sample_data
     param_types = spanner_v1.param_types
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -1087,7 +1087,7 @@ def test_transaction_batch_update_w_syntax_error(
     sd = _sample_data
     param_types = spanner_v1.param_types
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -1132,7 +1132,7 @@ def test_transaction_batch_update_w_syntax_error(
 
 
 def test_transaction_batch_update_wo_statements(sessions_database, sessions_to_delete):
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 
@@ -1155,7 +1155,7 @@ def test_transaction_batch_update_w_parent_span(
     param_types = spanner_v1.param_types
     tracer = trace.get_tracer(__name__)
 
-    session = sessions_database.session()
+    session = build_session(database=sessions_database)
     session.create()
     sessions_to_delete.append(session)
 

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -41,6 +41,7 @@ from google.cloud.spanner_v1.client import Client
 from google.cloud.spanner_v1.instance import Instance
 from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1.session import Session
+from google.cloud.spanner_v1.session_options import TransactionType
 
 PROJECT = "test-project"
 INSTANCE = "test-instance"
@@ -147,14 +148,14 @@ class TestConnection(unittest.TestCase):
         session_manager = database._session_manager
 
         session = Session(database=database)
-        session_manager.get_session_for_read_only = mock.Mock(return_value=session)
+        session_manager.get_session = mock.Mock(return_value=session)
 
         read_only_connection = Connection(
             instance="instance-id", database=database, read_only=True
         )
         read_only_connection._session_checkout()
 
-        session_manager.get_session_for_read_only.assert_called_once_with()
+        session_manager.get_session.assert_called_once_with(TransactionType.READ_ONLY)
         self.assertEqual(read_only_connection._session, session)
 
     def test__session_checkout_read_write(self):
@@ -164,14 +165,14 @@ class TestConnection(unittest.TestCase):
         session_manager = database._session_manager
 
         session = Session(database=database)
-        session_manager.get_session_for_read_write = mock.Mock(return_value=session)
+        session_manager.get_session = mock.Mock(return_value=session)
 
         read_write_connection = Connection(
             instance="instance-id", database=database, read_only=False
         )
         read_write_connection._session_checkout()
 
-        session_manager.get_session_for_read_write.assert_called_once_with()
+        session_manager.get_session.assert_called_once_with(TransactionType.READ_WRITE)
         self.assertEqual(read_write_connection._session, session)
 
     def test_session_checkout_database_error(self):

--- a/tests/unit/test_database_session_manager.py
+++ b/tests/unit/test_database_session_manager.py
@@ -14,8 +14,9 @@
 import os
 import datetime
 import time
+from threading import Thread
 from unittest import TestCase
-from unittest.mock import Mock, patch, DEFAULT, PropertyMock
+from unittest.mock import Mock, DEFAULT, patch
 
 from google.api_core.exceptions import (
     MethodNotImplemented,
@@ -23,48 +24,33 @@ from google.api_core.exceptions import (
     FailedPrecondition,
 )
 
-from google.cloud.spanner_v1 import SpannerClient
-from google.cloud.spanner_v1.client import Client
-from google.cloud.spanner_v1.database import Database
 from google.cloud.spanner_v1.database_sessions_manager import DatabaseSessionsManager
-from google.cloud.spanner_v1.instance import Instance
-from google.cloud.spanner_v1.session_options import SessionOptions
+from google.cloud.spanner_v1.session_options import TransactionType
+from tests._helpers import disable_multiplexed_sessions, enable_multiplexed_sessions
 
 
+# Shorten polling and refresh intervals for testing.
+@patch.multiple(
+    DatabaseSessionsManager,
+    _MAINTENANCE_THREAD_POLLING_INTERVAL=datetime.timedelta(seconds=1),
+    _MAINTENANCE_THREAD_REFRESH_INTERVAL=datetime.timedelta(seconds=2),
+)
 class TestDatabaseSessionManager(TestCase):
     def setUp(self):
         self._original_env = dict(os.environ)
-
-        self._mocks = {
-            "create_session": patch.object(SpannerClient, "create_session").start(),
-            "delete_session": patch.object(SpannerClient, "delete_session").start(),
-            # Mock faster polling and refresh intervals for tests.
-            "polling_interval": patch.object(
-                DatabaseSessionsManager,
-                "_MAINTENANCE_THREAD_POLLING_INTERVAL",
-                new_callable=PropertyMock,
-                return_value=datetime.timedelta(seconds=1),
-            ).start(),
-            "refresh_interval": patch.object(
-                DatabaseSessionsManager,
-                "_MAINTENANCE_THREAD_REFRESH_INTERVAL",
-                new_callable=PropertyMock,
-                return_value=datetime.timedelta(seconds=2),
-            ).start(),
-        }
+        self._build_session_manager()
 
     def tearDown(self):
+        self._cleanup_database_session_manager()
         os.environ.clear()
         os.environ.update(self._original_env)
 
-        patch.stopall()
-
     def test_read_only_pooled(self):
-        self._disable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        disable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Get session from pool.
-        session = session_manager.get_session_for_read_only()
+        session = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertFalse(session.is_multiplexed)
         session_manager._pool.get.assert_called_once()
 
@@ -73,16 +59,16 @@ class TestDatabaseSessionManager(TestCase):
         session_manager._pool.put.assert_called_once_with(session)
 
     def test_read_only_multiplexed(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Session is created.
-        session_1 = session_manager.get_session_for_read_only()
+        session_1 = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertTrue(session_1.is_multiplexed)
         session_manager.put_session(session_1)
 
         # Session is re-used.
-        session_2 = session_manager.get_session_for_read_only()
+        session_2 = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertEqual(session_1, session_2)
         session_manager.put_session(session_2)
 
@@ -91,11 +77,11 @@ class TestDatabaseSessionManager(TestCase):
         session_manager._pool.put.assert_not_called()
 
     def test_partitioned_pooled(self):
-        self._disable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        disable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Get session from pool.
-        session = session_manager.get_session_for_partitioned()
+        session = session_manager.get_session(TransactionType.PARTITIONED)
         self.assertFalse(session.is_multiplexed)
         session_manager._pool.get.assert_called_once()
 
@@ -104,18 +90,29 @@ class TestDatabaseSessionManager(TestCase):
         session_manager._pool.put.assert_called_once_with(session)
 
     def test_partitioned_multiplexed(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
-        with self.assertRaises(NotImplementedError):
-            session_manager.get_session_for_partitioned()
+        # Session is created.
+        session_1 = session_manager.get_session(TransactionType.PARTITIONED)
+        self.assertTrue(session_1.is_multiplexed)
+        session_manager.put_session(session_1)
+
+        # Session is re-used.
+        session_2 = session_manager.get_session(TransactionType.PARTITIONED)
+        self.assertEqual(session_1, session_2)
+        session_manager.put_session(session_2)
+
+        # Verify that pool was not used.
+        session_manager._pool.get.assert_not_called()
+        session_manager._pool.put.assert_not_called()
 
     def test_read_write_pooled(self):
-        self._disable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        disable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Get session from pool.
-        session = session_manager.get_session_for_read_write()
+        session = session_manager.get_session(TransactionType.READ_WRITE)
         self.assertFalse(session.is_multiplexed)
         session_manager._pool.get.assert_called_once()
 
@@ -124,89 +121,81 @@ class TestDatabaseSessionManager(TestCase):
         session_manager._pool.put.assert_called_once_with(session)
 
     def test_read_write_multiplexed(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         with self.assertRaises(NotImplementedError):
-            session_manager.get_session_for_read_write()
+            session_manager.get_session(TransactionType.READ_WRITE)
 
-    def test_multiplexed_maintenance(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+    def test_multiplexed_maintenance(self, *_):
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Maintenance thread is started.
-        session_1 = session_manager.get_session_for_read_only()
+        session_1 = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertTrue(session_1.is_multiplexed)
 
         # Wait for maintenance thread to execute.
-        def create_session_condition():
-            return self._mocks["create_session"].call_count > 1
+        api = session_manager._database.spanner_api
 
-        self.assert_true_with_timeout(create_session_condition)
+        def create_session_condition():
+            return api.create_session.call_count > 1
+
+        self._assert_true_with_timeout(create_session_condition)
 
         # Verify that maintenance thread created new multiplexed session.
-        session_2 = session_manager.get_session_for_read_only()
+        session_2 = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertTrue(session_2.is_multiplexed)
         self.assertNotEqual(session_1, session_2)
 
     def test_multiplexed_maintenance_terminates_not_implemented(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Maintenance thread is started.
-        session_1 = session_manager.get_session_for_read_only()
+        session_1 = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertTrue(session_1.is_multiplexed)
 
         # Multiplexed sessions not implemented.
-        create_session_mock = self._mocks["create_session"]
-        create_session_mock.side_effect = MethodNotImplemented(
-            "Multiplexed sessions not implemented"
-        )
+        api = session_manager._database.spanner_api
+        api.create_session.side_effect = MethodNotImplemented("test")
 
-        # Wait for maintenance thread to terminate.
+        # Verify that maintenance thread is terminated.
         thread = session_manager._multiplexed_session_maintenance_thread
+        self._assert_thread_terminated(thread)
 
-        def thread_terminated_condition():
-            return not thread.is_alive()
-
-        self.assert_true_with_timeout(thread_terminated_condition)
-
-        # Verify that multiplexed sessions are disabled.
-        session_options = session_manager._database._instance._client.session_options
-        self.assertFalse(session_options.use_multiplexed_for_read_only())
-        self.assertFalse(session_options.use_multiplexed_for_partitioned())
-        self.assertFalse(session_options.use_multiplexed_for_read_write())
+        # Verify that multiplexed session are disabled.
+        session_options = session_manager._database.session_options
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_ONLY))
+        self.assertFalse(session_options.use_multiplexed(TransactionType.PARTITIONED))
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_WRITE))
 
     def test_multiplexed_maintenance_terminates_disabled(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Maintenance thread is started.
-        session_1 = session_manager.get_session_for_read_only()
+        session_1 = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertTrue(session_1.is_multiplexed)
 
         session_manager._is_multiplexed_sessions_disabled_event.set()
 
-        # Wait for maintenance thread to terminate.
         thread = session_manager._multiplexed_session_maintenance_thread
-
-        def thread_terminated_condition():
-            return not thread.is_alive()
-
-        self.assert_true_with_timeout(thread_terminated_condition)
+        self._assert_thread_terminated(thread)
 
     def test_multiplexed_exception_method_not_implemented(self):
-        self._enable_multiplexed_env_vars()
-        session_manager = self._build_database_session_manager()
+        enable_multiplexed_sessions()
+        session_manager = self._session_manager
 
         # Multiplexed sessions not implemented.
-        self._mocks["create_session"].side_effect = [
+        api = session_manager._database.spanner_api
+        api.create_session.side_effect = [
             MethodNotImplemented("Test MethodNotImplemented"),
             DEFAULT,
         ]
 
         # Get session from pool.
-        session = session_manager.get_session_for_read_only()
+        session = session_manager.get_session(TransactionType.READ_ONLY)
         self.assertFalse(session.is_multiplexed)
         session_manager._pool.get.assert_called_once()
 
@@ -215,37 +204,36 @@ class TestDatabaseSessionManager(TestCase):
         session_manager._pool.put.assert_called_once_with(session)
 
         # Verify that multiplexed session are disabled.
-        session_options = session_manager._database._instance._client.session_options
-        self.assertFalse(session_options.use_multiplexed_for_read_only())
-        self.assertFalse(session_options.use_multiplexed_for_partitioned())
-        self.assertFalse(session_options.use_multiplexed_for_read_write())
+        session_options = session_manager._database.session_options
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_ONLY))
+        self.assertFalse(session_options.use_multiplexed(TransactionType.PARTITIONED))
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_WRITE))
 
     def test_exception_bad_request(self):
-        session_manager = self._build_database_session_manager()
+        session_manager = self._session_manager
+
+        api = session_manager._database.spanner_api
+        api.create_session.side_effect = BadRequest("test")
 
         # Verify that BadRequest is not caught.
         with self.assertRaises(BadRequest):
-            self._mocks["create_session"].side_effect = BadRequest("Test BadRequest")
-            session_manager.get_session_for_read_only()
+            session_manager.get_session(TransactionType.READ_ONLY)
 
     def test_exception_failed_precondition(self):
-        session_manager = self._build_database_session_manager()
+        session_manager = self._session_manager
+
+        api = session_manager._database.spanner_api
+        api.create_session.side_effect = FailedPrecondition("test")
 
         # Verify that FailedPrecondition is not caught.
         with self.assertRaises(FailedPrecondition):
-            self._mocks["create_session"].side_effect = FailedPrecondition(
-                "Test FailedPrecondition"
-            )
-            session_manager.get_session_for_read_only()
+            session_manager.get_session(TransactionType.READ_ONLY)
 
-    @staticmethod
-    def _build_database_session_manager():
-        """Builds and returns a new database session manager for testing."""
+    def _build_session_manager(self) -> DatabaseSessionsManager:
+        """Builds a new database session manager for testing."""
+        from tests._builders import build_database
 
-        client = Client(project="project-id")
-        instance = Instance(instance_id="instance-id", client=client)
-
-        database = Database(database_id="database-id", instance=instance)
+        database = build_database()
         session_manager = database._session_manager
 
         # Mock the session pool.
@@ -253,25 +241,22 @@ class TestDatabaseSessionManager(TestCase):
         pool.get = Mock(wraps=pool.get)
         pool.put = Mock(wraps=pool.put)
 
-        return session_manager
+        self._session_manager = session_manager
 
-    @staticmethod
-    def _enable_multiplexed_env_vars():
-        """Sets environment variables to enable multiplexed sessions."""
+    def _cleanup_database_session_manager(self) -> None:
+        """Cleans up the database session manager after testing."""
 
-        os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "true"
-        os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_PARTITIONED] = "true"
-        os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_READ_WRITE] = "true"
-        os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
+        # If the maintenance thread is still alive, disable multiplexed sessions and
+        # wait for the thread to terminate. We need to do this to ensure that the
+        # thread is properly cleaned up and does not interfere with other tests.
+        session_manager = self._session_manager
+        thread = session_manager._multiplexed_session_maintenance_thread
 
-    @staticmethod
-    def _disable_multiplexed_env_vars():
-        """Sets environment variables to disable multiplexed sessions."""
+        if thread and thread.is_alive():
+            session_manager._is_multiplexed_sessions_disabled_event.set()
+            self._assert_thread_terminated(thread)
 
-        os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "true"
-
-    @staticmethod
-    def assert_true_with_timeout(condition):
+    def _assert_true_with_timeout(self, condition):
         """Asserts that the given condition is met within a timeout period."""
 
         sleep_seconds = 0.1
@@ -281,4 +266,12 @@ class TestDatabaseSessionManager(TestCase):
         while not condition() and time.time() - start_time < timeout_seconds:
             time.sleep(sleep_seconds)
 
-        assert condition()
+        self.assertTrue(condition())
+
+    def _assert_thread_terminated(self, thread: Thread):
+        """Asserts that the maintenance thread is terminated."""
+
+        def _is_thread_terminated():
+            return not thread.is_alive()
+
+        self._assert_true_with_timeout(_is_thread_terminated)

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -540,7 +540,6 @@ class TestInstance(unittest.TestCase):
         self.assertIs(database._instance, instance)
         self.assertEqual(list(database.ddl_statements), [])
         self.assertIsInstance(database._session_manager._pool, BurstyPool)
-        self.assertIsNone(database._logger)
         self.assertIs(database._session_manager._pool._database, database)
         self.assertIsNone(database.database_role)
 

--- a/tests/unit/test_session_options.py
+++ b/tests/unit/test_session_options.py
@@ -12,77 +12,110 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from logging import Logger
 from unittest import TestCase
-from google.cloud.spanner_v1.session_options import SessionOptions
+
+from google.cloud.spanner_v1.session_options import SessionOptions, TransactionType
 
 
 class TestSessionOptions(TestCase):
+    _logger = Logger("test_session_options_logger")
+
     @classmethod
     def setUpClass(cls):
+        # Save the original environment variables.
         cls._original_env = dict(os.environ)
 
     @classmethod
     def tearDownClass(cls):
+        # Restore environment variables.
         os.environ.clear()
         os.environ.update(cls._original_env)
 
     def test_use_multiplexed_for_read_only(self):
         session_options = SessionOptions()
+        transaction_type = TransactionType.READ_ONLY
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "false"
-        self.assertFalse(session_options.use_multiplexed_for_read_only())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "true"
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "true"
-        self.assertFalse(session_options.use_multiplexed_for_read_only())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
-        self.assertTrue(session_options.use_multiplexed_for_read_only())
+        self.assertTrue(session_options.use_multiplexed(transaction_type))
 
-        session_options.disable_multiplexed_for_read_only()
-        self.assertFalse(session_options.use_multiplexed_for_read_only())
+        session_options.disable_multiplexed(self._logger, transaction_type)
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
     def test_use_multiplexed_for_partitioned(self):
         session_options = SessionOptions()
+        transaction_type = TransactionType.PARTITIONED
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "false"
-        self.assertFalse(session_options.use_multiplexed_for_partitioned())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "true"
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_PARTITIONED] = "false"
-        self.assertFalse(session_options.use_multiplexed_for_partitioned())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_PARTITIONED] = "true"
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "true"
-        self.assertFalse(session_options.use_multiplexed_for_partitioned())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
-        self.assertTrue(session_options.use_multiplexed_for_partitioned())
+        self.assertTrue(session_options.use_multiplexed(transaction_type))
 
-        session_options.disable_multiplexed_for_partitioned()
-        self.assertFalse(session_options.use_multiplexed_for_partitioned())
+        session_options.disable_multiplexed(self._logger, transaction_type)
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
     def test_use_multiplexed_for_read_write(self):
         session_options = SessionOptions()
+        transaction_type = TransactionType.READ_WRITE
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "false"
-        self.assertFalse(session_options.use_multiplexed_for_read_write())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "true"
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_READ_WRITE] = "false"
-        self.assertFalse(session_options.use_multiplexed_for_read_write())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_READ_WRITE] = "true"
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "true"
-        self.assertFalse(session_options.use_multiplexed_for_read_write())
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
-        self.assertTrue(session_options.use_multiplexed_for_read_write())
+        self.assertTrue(session_options.use_multiplexed(transaction_type))
 
-        session_options.disable_multiplexed_for_read_write()
-        self.assertFalse(session_options.use_multiplexed_for_read_write())
+        session_options.disable_multiplexed(self._logger, transaction_type)
+        self.assertFalse(session_options.use_multiplexed(transaction_type))
 
-    def test_supported_env_var_values(self):
+    def test_disable_multiplexed_all(self):
+        session_options = SessionOptions()
+
+        os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = "true"
+        os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_PARTITIONED] = "true"
+        os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED_FOR_READ_WRITE] = "true"
+        os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
+
+        session_options.disable_multiplexed(self._logger)
+
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_ONLY))
+        self.assertFalse(session_options.use_multiplexed(TransactionType.PARTITIONED))
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_WRITE))
+
+    def test_unsupported_transaction_type(self):
+        session_options = SessionOptions()
+        unsupported_type = "UNSUPPORTED_TRANSACTION_TYPE"
+
+        with self.assertRaises(ValueError):
+            session_options.use_multiplexed(unsupported_type)
+
+        with self.assertRaises(ValueError):
+            session_options.disable_multiplexed(self._logger, unsupported_type)
+
+    def test_env_var_values(self):
         session_options = SessionOptions()
 
         os.environ[SessionOptions.ENV_VAR_FORCE_DISABLE_MULTIPLEXED] = "false"
@@ -90,12 +123,12 @@ class TestSessionOptions(TestCase):
         true_values = ["1", " 1", " 1", "true", "True", "TRUE", " true "]
         for value in true_values:
             os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = value
-            self.assertTrue(session_options.use_multiplexed_for_read_only())
+            self.assertTrue(session_options.use_multiplexed(TransactionType.READ_ONLY))
 
         false_values = ["", "0", "false", "False", "FALSE"]
         for value in false_values:
             os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED] = value
-            self.assertFalse(session_options.use_multiplexed_for_read_only())
+            self.assertFalse(session_options.use_multiplexed(TransactionType.READ_ONLY))
 
         del os.environ[SessionOptions.ENV_VAR_ENABLE_MULTIPLEXED]
-        self.assertFalse(session_options.use_multiplexed_for_read_only())
+        self.assertFalse(session_options.use_multiplexed(TransactionType.READ_ONLY))


### PR DESCRIPTION
feat: Add support for multiplexed sessions - part 3 (partitioned transactions)
- Enable use of multiplexed sessions for partitioned transactions.
- Add handling for partitioned transaction exceptions.
- Add transaction type enumeration.