### PR TITLE
chore(x-goog-spanner-request-id): plug in functionality after test scaffolding

### DIFF
--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -26,7 +26,6 @@ from google.cloud.spanner_v1._helpers import (
     _metadata_with_prefix,
     _metadata_with_leader_aware_routing,
     _merge_Transaction_Options,
-    AtomicCounter,
 )
 from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
 from google.cloud.spanner_v1 import RequestOptions
@@ -250,6 +249,7 @@ class Batch(_BatchBase):
             observability_options=observability_options,
             metadata=metadata,
         ), MetricsCapture():
+
             def wrapped_method(*args, **kwargs):
                 method = functools.partial(
                     api.commit,

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -806,7 +806,9 @@ class Database(object):
 
     @property
     def _nth_client_id(self):
-        return self._instance._client._nth_client_id
+        if self._instance and self._instance._client:
+            return self._instance._client._nth_client_id
+        return 0
 
     def session(self, labels=None, database_role=None):
         """Factory to create a session for this database.
@@ -1028,7 +1030,6 @@ class Database(object):
         )
         future = api.restore_database(
             request=request,
-            # TODO: Infer the channel_id being used.
             metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
         )
         return future

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -53,6 +53,7 @@ from google.cloud.spanner_v1._helpers import _merge_query_options
 from google.cloud.spanner_v1._helpers import (
     _metadata_with_prefix,
     _metadata_with_leader_aware_routing,
+    _metadata_with_request_id,
 )
 from google.cloud.spanner_v1.batch import Batch
 from google.cloud.spanner_v1.batch import MutationGroups
@@ -151,6 +152,9 @@ class Database(object):
 
     _spanner_api: SpannerClient = None
 
+    __transport_lock = threading.Lock()
+    __transports_to_channel_id = dict()
+
     def __init__(
         self,
         database_id,
@@ -188,6 +192,7 @@ class Database(object):
             self._instance._client.default_transaction_options
         )
         self._proto_descriptors = proto_descriptors
+        self._channel_id = 0  # It'll be created when _spanner_api is created.
 
         if pool is None:
             pool = BurstyPool(database_role=database_role)
@@ -446,7 +451,25 @@ class Database(object):
                 client_info=client_info,
                 client_options=client_options,
             )
+
+            with self.__transport_lock:
+                transport = self._spanner_api._transport
+                channel_id = self.__transports_to_channel_id.get(transport, None)
+                if channel_id is None:
+                    channel_id = len(self.__transports_to_channel_id) + 1
+                    self.__transports_to_channel_id[transport] = channel_id
+                self._channel_id = channel_id
+
         return self._spanner_api
+
+    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+        return _metadata_with_request_id(
+            self._nth_client_id,
+            self._channel_id,
+            nth_request,
+            nth_attempt,
+            prior_metadata,
+        )
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -490,7 +513,10 @@ class Database(object):
             database_dialect=self._database_dialect,
             proto_descriptors=self._proto_descriptors,
         )
-        future = api.create_database(request=request, metadata=metadata)
+        future = api.create_database(
+            request=request,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
         return future
 
     def exists(self):
@@ -506,7 +532,12 @@ class Database(object):
         metadata = _metadata_with_prefix(self.name)
 
         try:
-            api.get_database_ddl(database=self.name, metadata=metadata)
+            api.get_database_ddl(
+                database=self.name,
+                metadata=self.metadata_with_request_id(
+                    self._next_nth_request, 1, metadata
+                ),
+            )
         except NotFound:
             return False
         return True
@@ -523,10 +554,16 @@ class Database(object):
         """
         api = self._instance._client.database_admin_api
         metadata = _metadata_with_prefix(self.name)
-        response = api.get_database_ddl(database=self.name, metadata=metadata)
+        response = api.get_database_ddl(
+            database=self.name,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
         self._ddl_statements = tuple(response.statements)
         self._proto_descriptors = response.proto_descriptors
-        response = api.get_database(name=self.name, metadata=metadata)
+        response = api.get_database(
+            name=self.name,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
         self._state = DatabasePB.State(response.state)
         self._create_time = response.create_time
         self._restore_info = response.restore_info
@@ -571,7 +608,10 @@ class Database(object):
             proto_descriptors=proto_descriptors,
         )
 
-        future = api.update_database_ddl(request=request, metadata=metadata)
+        future = api.update_database_ddl(
+            request=request,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
         return future
 
     def update(self, fields):
@@ -609,7 +649,9 @@ class Database(object):
         metadata = _metadata_with_prefix(self.name)
 
         future = api.update_database(
-            database=database_pb, update_mask=field_mask, metadata=metadata
+            database=database_pb,
+            update_mask=field_mask,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
         )
 
         return future
@@ -622,7 +664,10 @@ class Database(object):
         """
         api = self._instance._client.database_admin_api
         metadata = _metadata_with_prefix(self.name)
-        api.drop_database(database=self.name, metadata=metadata)
+        api.drop_database(
+            database=self.name,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
 
     def execute_partitioned_dml(
         self,
@@ -711,7 +756,13 @@ class Database(object):
                 with SessionCheckout(self._pool) as session:
                     add_span_event(span, "Starting BeginTransaction")
                     txn = api.begin_transaction(
-                        session=session.name, options=txn_options, metadata=metadata
+                        session=session.name,
+                        options=txn_options,
+                        metadata=self.metadata_with_request_id(
+                            self._next_nth_request,
+                            1,
+                            metadata,
+                        ),
                     )
 
                     txn_selector = TransactionSelector(id=txn.id)
@@ -724,6 +775,7 @@ class Database(object):
                         query_options=query_options,
                         request_options=request_options,
                     )
+
                     method = functools.partial(
                         api.execute_streaming_sql,
                         metadata=metadata,
@@ -736,6 +788,7 @@ class Database(object):
                         metadata=metadata,
                         transaction_selector=txn_selector,
                         observability_options=self.observability_options,
+                        request_id_manager=self,
                     )
 
                     result_set = StreamedResultSet(iterator)
@@ -744,6 +797,16 @@ class Database(object):
                     return result_set.stats.row_count_lower_bound
 
         return _retry_on_aborted(execute_pdml, DEFAULT_RETRY_BACKOFF)()
+
+    @property
+    def _next_nth_request(self):
+        if self._instance and self._instance._client:
+            return self._instance._client._next_nth_request
+        return 1
+
+    @property
+    def _nth_client_id(self):
+        return self._instance._client._nth_client_id
 
     def session(self, labels=None, database_role=None):
         """Factory to create a session for this database.
@@ -965,7 +1028,8 @@ class Database(object):
         )
         future = api.restore_database(
             request=request,
-            metadata=metadata,
+            # TODO: Infer the channel_id being used.
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
         )
         return future
 
@@ -1034,7 +1098,10 @@ class Database(object):
             parent=self.name,
             page_size=page_size,
         )
-        return api.list_database_roles(request=request, metadata=metadata)
+        return api.list_database_roles(
+            request=request,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
 
     def table(self, table_id):
         """Factory to create a table object within this database.
@@ -1118,7 +1185,10 @@ class Database(object):
                 requested_policy_version=policy_version
             ),
         )
-        response = api.get_iam_policy(request=request, metadata=metadata)
+        response = api.get_iam_policy(
+            request=request,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
         return response
 
     def set_iam_policy(self, policy):
@@ -1140,7 +1210,10 @@ class Database(object):
             resource=self.name,
             policy=policy,
         )
-        response = api.set_iam_policy(request=request, metadata=metadata)
+        response = api.set_iam_policy(
+            request=request,
+            metadata=self.metadata_with_request_id(self._next_nth_request, 1, metadata),
+        )
         return response
 
     @property

--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -256,7 +256,9 @@ class FixedSizePool(AbstractSessionPool):
                 )
                 resp = api.batch_create_sessions(
                     request=request,
-                    metadata=metadata,
+                    metadata=database.metadata_with_request_id(
+                        database._next_nth_request, 1, metadata
+                    ),
                 )
 
                 add_span_event(
@@ -561,7 +563,9 @@ class PingingPool(AbstractSessionPool):
             while returned_session_count < self.size:
                 resp = api.batch_create_sessions(
                     request=request,
-                    metadata=metadata,
+                    metadata=database.metadata_with_request_id(
+                        database._next_nth_request, 1, metadata
+                    ),
                 )
 
                 add_span_event(

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -252,9 +252,7 @@ class Session(object):
 
         database = self._database
         api = database.spanner_api
-        metadata = database.metadata_with_request_id(
-            database._next_nth_request, 1, _metadata_with_prefix(database.name)
-        )
+        metadata = _metadata_with_prefix(database.name)
         observability_options = getattr(self._database, "observability_options", None)
         with trace_call(
             "CloudSpanner.DeleteSession",
@@ -268,7 +266,9 @@ class Session(object):
         ), MetricsCapture():
             api.delete_session(
                 name=self.name,
-                metadata=metadata,
+                metadata=database.metadata_with_request_id(
+                    database._next_nth_request, 1, metadata
+                ),
             )
 
     def ping(self):

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -170,7 +170,9 @@ class Session(object):
         ), MetricsCapture():
             session_pb = api.create_session(
                 request=request,
-                metadata=metadata,
+                metadata=self._database.metadata_with_request_id(
+                    self._database._next_nth_request, 1, metadata
+                ),
             )
         self._session_id = session_pb.name.split("/")[-1]
 
@@ -195,7 +197,8 @@ class Session(object):
             current_span, "Checking if Session exists", {"session.id": self._session_id}
         )
 
-        api = self._database.spanner_api
+        database = self._database
+        api = database.spanner_api
         metadata = _metadata_with_prefix(self._database.name)
         if self._database._route_to_leader_enabled:
             metadata.append(
@@ -212,7 +215,12 @@ class Session(object):
             metadata=metadata,
         ) as span, MetricsCapture():
             try:
-                api.get_session(name=self.name, metadata=metadata)
+                api.get_session(
+                    name=self.name,
+                    metadata=database.metadata_with_request_id(
+                        database._next_nth_request, 1, metadata
+                    ),
+                )
                 if span:
                     span.set_attribute("session_found", True)
             except NotFound:
@@ -242,8 +250,11 @@ class Session(object):
             current_span, "Deleting Session", {"session.id": self._session_id}
         )
 
-        api = self._database.spanner_api
-        metadata = _metadata_with_prefix(self._database.name)
+        database = self._database
+        api = database.spanner_api
+        metadata = database.metadata_with_request_id(
+            database._next_nth_request, 1, _metadata_with_prefix(database.name)
+        )
         observability_options = getattr(self._database, "observability_options", None)
         with trace_call(
             "CloudSpanner.DeleteSession",
@@ -255,7 +266,10 @@ class Session(object):
             observability_options=observability_options,
             metadata=metadata,
         ), MetricsCapture():
-            api.delete_session(name=self.name, metadata=metadata)
+            api.delete_session(
+                name=self.name,
+                metadata=metadata,
+            )
 
     def ping(self):
         """Ping the session to keep it alive by executing "SELECT 1".
@@ -264,10 +278,17 @@ class Session(object):
         """
         if self._session_id is None:
             raise ValueError("Session ID not set by back-end")
-        api = self._database.spanner_api
-        metadata = _metadata_with_prefix(self._database.name)
+        database = self._database
+        api = database.spanner_api
         request = ExecuteSqlRequest(session=self.name, sql="SELECT 1")
-        api.execute_sql(request=request, metadata=metadata)
+        api.execute_sql(
+            request=request,
+            metadata=database.metadata_with_request_id(
+                database._next_nth_request,
+                1,
+                _metadata_with_prefix(database.name),
+            ),
+        )
         self._last_use_time = datetime.now()
 
     def snapshot(self, **kw):

--- a/google/cloud/spanner_v1/testing/interceptors.py
+++ b/google/cloud/spanner_v1/testing/interceptors.py
@@ -72,7 +72,7 @@ X_GOOG_REQUEST_ID = "x-goog-spanner-request-id"
 
 class XGoogRequestIDHeaderInterceptor(ClientInterceptor):
     # TODO:(@odeke-em): delete this guard when PR #1367 is merged.
-    X_GOOG_REQUEST_ID_FUNCTIONALITY_MERGED = False
+    X_GOOG_REQUEST_ID_FUNCTIONALITY_MERGED = True
 
     def __init__(self):
         self._unary_req_segments = []

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -186,13 +186,12 @@ class Transaction(_SnapshotBase, _BatchBase):
             nth_request = database._next_nth_request
 
             def wrapped_method(*args, **kwargs):
-                attempt.increment()
                 method = functools.partial(
                     api.begin_transaction,
                     session=self._session.name,
                     options=txn_options,
                     metadata=database.metadata_with_request_id(
-                        nth_request, attempt.value, metadata
+                        nth_request, attempt.increment(), metadata
                     ),
                 )
                 return method(*args, **kwargs)

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -32,6 +32,7 @@ from google.cloud.spanner_v1 import ExecuteBatchDmlRequest
 from google.cloud.spanner_v1 import ExecuteSqlRequest
 from google.cloud.spanner_v1 import TransactionSelector
 from google.cloud.spanner_v1 import TransactionOptions
+from google.cloud.spanner_v1._helpers import AtomicCounter
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
 from google.cloud.spanner_v1.batch import _BatchBase
 from google.cloud.spanner_v1._opentelemetry_tracing import add_span_event, trace_call
@@ -181,12 +182,20 @@ class Transaction(_SnapshotBase, _BatchBase):
             observability_options=observability_options,
             metadata=metadata,
         ) as span, MetricsCapture():
-            method = functools.partial(
-                api.begin_transaction,
-                session=self._session.name,
-                options=txn_options,
-                metadata=metadata,
-            )
+            attempt = AtomicCounter(0)
+            nth_request = database._next_nth_request
+
+            def wrapped_method(*args, **kwargs):
+                attempt.increment()
+                method = functools.partial(
+                    api.begin_transaction,
+                    session=self._session.name,
+                    options=txn_options,
+                    metadata=database.metadata_with_request_id(
+                        nth_request, attempt.value, metadata
+                    ),
+                )
+                return method(*args, **kwargs)
 
             def beforeNextRetry(nthRetry, delayInSeconds):
                 add_span_event(
@@ -196,7 +205,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 )
 
             response = _retry(
-                method,
+                wrapped_method,
                 allowed_exceptions={InternalServerError: _check_rst_stream_error},
                 beforeNextRetry=beforeNextRetry,
             )
@@ -217,6 +226,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                         database._route_to_leader_enabled
                     )
                 )
+
             observability_options = getattr(database, "observability_options", None)
             with trace_call(
                 f"CloudSpanner.{type(self).__name__}.rollback",
@@ -224,16 +234,26 @@ class Transaction(_SnapshotBase, _BatchBase):
                 observability_options=observability_options,
                 metadata=metadata,
             ), MetricsCapture():
-                method = functools.partial(
-                    api.rollback,
-                    session=self._session.name,
-                    transaction_id=self._transaction_id,
-                    metadata=metadata,
-                )
+                attempt = AtomicCounter(0)
+                nth_request = database._next_nth_request
+
+                def wrapped_method(*args, **kwargs):
+                    attempt.increment()
+                    method = functools.partial(
+                        api.rollback,
+                        session=self._session.name,
+                        transaction_id=self._transaction_id,
+                        metadata=database.metadata_with_request_id(
+                            nth_request, attempt.value, metadata
+                        ),
+                    )
+                    return method(*args, **kwargs)
+
                 _retry(
-                    method,
+                    wrapped_method,
                     allowed_exceptions={InternalServerError: _check_rst_stream_error},
                 )
+
         self.rolled_back = True
         del self._session._transaction
 
@@ -306,11 +326,19 @@ class Transaction(_SnapshotBase, _BatchBase):
 
             add_span_event(span, "Starting Commit")
 
-            method = functools.partial(
-                api.commit,
-                request=request,
-                metadata=metadata,
-            )
+            attempt = AtomicCounter(0)
+            nth_request = database._next_nth_request
+
+            def wrapped_method(*args, **kwargs):
+                attempt.increment()
+                method = functools.partial(
+                    api.commit,
+                    request=request,
+                    metadata=database.metadata_with_request_id(
+                        nth_request, attempt.value, metadata
+                    ),
+                )
+                return method(*args, **kwargs)
 
             def beforeNextRetry(nthRetry, delayInSeconds):
                 add_span_event(
@@ -320,7 +348,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 )
 
             response = _retry(
-                method,
+                wrapped_method,
                 allowed_exceptions={InternalServerError: _check_rst_stream_error},
                 beforeNextRetry=beforeNextRetry,
             )
@@ -469,19 +497,27 @@ class Transaction(_SnapshotBase, _BatchBase):
             last_statement=last_statement,
         )
 
-        method = functools.partial(
-            api.execute_sql,
-            request=request,
-            metadata=metadata,
-            retry=retry,
-            timeout=timeout,
-        )
+        nth_request = database._next_nth_request
+        attempt = AtomicCounter(0)
+
+        def wrapped_method(*args, **kwargs):
+            attempt.increment()
+            method = functools.partial(
+                api.execute_sql,
+                request=request,
+                metadata=database.metadata_with_request_id(
+                    nth_request, attempt.value, metadata
+                ),
+                retry=retry,
+                timeout=timeout,
+            )
+            return method(*args, **kwargs)
 
         if self._transaction_id is None:
             # lock is added to handle the inline begin for first rpc
             with self._lock:
                 response = self._execute_request(
-                    method,
+                    wrapped_method,
                     request,
                     metadata,
                     f"CloudSpanner.{type(self).__name__}.execute_update",
@@ -499,7 +535,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                     self._transaction_id = response.metadata.transaction.id
         else:
             response = self._execute_request(
-                method,
+                wrapped_method,
                 request,
                 metadata,
                 f"CloudSpanner.{type(self).__name__}.execute_update",
@@ -611,19 +647,27 @@ class Transaction(_SnapshotBase, _BatchBase):
             last_statements=last_statement,
         )
 
-        method = functools.partial(
-            api.execute_batch_dml,
-            request=request,
-            metadata=metadata,
-            retry=retry,
-            timeout=timeout,
-        )
+        nth_request = database._next_nth_request
+        attempt = AtomicCounter(0)
+
+        def wrapped_method(*args, **kwargs):
+            attempt.increment()
+            method = functools.partial(
+                api.execute_batch_dml,
+                request=request,
+                metadata=database.metadata_with_request_id(
+                    nth_request, attempt.value, metadata
+                ),
+                retry=retry,
+                timeout=timeout,
+            )
+            return method(*args, **kwargs)
 
         if self._transaction_id is None:
             # lock is added to handle the inline begin for first rpc
             with self._lock:
                 response = self._execute_request(
-                    method,
+                    wrapped_method,
                     request,
                     metadata,
                     "CloudSpanner.DMLTransaction",
@@ -642,7 +686,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                         break
         else:
             response = self._execute_request(
-                method,
+                wrapped_method,
                 request,
                 metadata,
                 "CloudSpanner.DMLTransaction",

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -38,8 +38,10 @@ from google.cloud.spanner_v1.keyset import KeySet
 from google.rpc.status_pb2 import Status
 
 from google.cloud.spanner_v1._helpers import (
+    AtomicCounter,
     _metadata_with_request_id,
 )
+from google.cloud.spanner_v1.request_id_header import REQ_RAND_PROCESS_ID
 
 TABLE_NAME = "citizens"
 COLUMNS = ["email", "first_name", "last_name", "age"]
@@ -252,6 +254,10 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
         self.assertEqual(request_options, RequestOptions())
@@ -346,6 +352,10 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
         self.assertEqual(actual_request_options, expected_request_options)
@@ -456,6 +466,10 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
         self.assertEqual(request_options, RequestOptions())
@@ -582,12 +596,6 @@ class TestMutationGroups(_BaseTest, OpenTelemetryBase):
                 "traceparent is missing in metadata",
             )
 
-        # expected_metadata.append(
-        #     (
-        #         "x-goog-spanner-request-id",
-        #         f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
-        #     )
-        # )
         # Remove traceparent from actual metadata for comparison
         filtered_metadata = [item for item in metadata if item[0] != "traceparent"]
 
@@ -647,7 +655,7 @@ class _Session(object):
 class _Database(object):
     name = "testing"
     _route_to_leader_enabled = True
-    NTH_CLIENT = 1
+    NTH_CLIENT_ID = AtomicCounter()
 
     def __init__(self, enable_end_to_end_tracing=False):
         self.name = "testing"
@@ -656,15 +664,12 @@ class _Database(object):
             self.observability_options = dict(enable_end_to_end_tracing=True)
         self.default_transaction_options = DefaultTransactionOptions()
         self._nth_request = 0
+        self._nth_client_id = _Database.NTH_CLIENT_ID.increment()
 
     @property
     def _next_nth_request(self):
         self._nth_request += 1
         return self._nth_request
-
-    @property
-    def _nth_client_id(self):
-        return 1
 
     def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
         return _metadata_with_request_id(

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -2063,6 +2063,10 @@ class TestBatchCheckout(_BaseTest):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
 
@@ -2110,6 +2114,10 @@ class TestBatchCheckout(_BaseTest):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
 
@@ -2155,6 +2163,10 @@ class TestBatchCheckout(_BaseTest):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -30,6 +30,11 @@ from google.cloud.spanner_v1 import (
     DirectedReadOptions,
     DefaultTransactionOptions,
 )
+from google.cloud.spanner_v1._helpers import (
+    AtomicCounter,
+    _metadata_with_request_id,
+)
+from google.cloud.spanner_v1.request_id_header import REQ_RAND_PROCESS_ID
 
 DML_WO_PARAM = """
 DELETE FROM citizens
@@ -549,7 +554,13 @@ class TestDatabase(_BaseTest):
 
         api.create_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_create_already_exists(self):
@@ -576,7 +587,13 @@ class TestDatabase(_BaseTest):
 
         api.create_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_create_instance_not_found(self):
@@ -602,7 +619,13 @@ class TestDatabase(_BaseTest):
 
         api.create_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_create_success(self):
@@ -638,7 +661,13 @@ class TestDatabase(_BaseTest):
 
         api.create_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_create_success_w_encryption_config_dict(self):
@@ -675,7 +704,13 @@ class TestDatabase(_BaseTest):
 
         api.create_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_create_success_w_proto_descriptors(self):
@@ -710,7 +745,13 @@ class TestDatabase(_BaseTest):
 
         api.create_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_exists_grpc_error(self):
@@ -728,7 +769,13 @@ class TestDatabase(_BaseTest):
 
         api.get_database_ddl.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_exists_not_found(self):
@@ -745,7 +792,13 @@ class TestDatabase(_BaseTest):
 
         api.get_database_ddl.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_exists_success(self):
@@ -764,7 +817,13 @@ class TestDatabase(_BaseTest):
 
         api.get_database_ddl.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_reload_grpc_error(self):
@@ -782,7 +841,13 @@ class TestDatabase(_BaseTest):
 
         api.get_database_ddl.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_reload_not_found(self):
@@ -800,7 +865,13 @@ class TestDatabase(_BaseTest):
 
         api.get_database_ddl.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_reload_success(self):
@@ -859,11 +930,23 @@ class TestDatabase(_BaseTest):
 
         api.get_database_ddl.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
         api.get_database.assert_called_once_with(
             name=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.2.1",
+                ),
+            ],
         )
 
     def test_update_ddl_grpc_error(self):
@@ -889,7 +972,13 @@ class TestDatabase(_BaseTest):
 
         api.update_database_ddl.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_update_ddl_not_found(self):
@@ -915,7 +1004,13 @@ class TestDatabase(_BaseTest):
 
         api.update_database_ddl.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_update_ddl(self):
@@ -942,7 +1037,13 @@ class TestDatabase(_BaseTest):
 
         api.update_database_ddl.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_update_ddl_w_operation_id(self):
@@ -969,7 +1070,13 @@ class TestDatabase(_BaseTest):
 
         api.update_database_ddl.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_update_success(self):
@@ -995,7 +1102,13 @@ class TestDatabase(_BaseTest):
         api.update_database.assert_called_once_with(
             database=expected_database,
             update_mask=field_mask,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_update_ddl_w_proto_descriptors(self):
@@ -1023,7 +1136,13 @@ class TestDatabase(_BaseTest):
 
         api.update_database_ddl.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_drop_grpc_error(self):
@@ -1041,7 +1160,13 @@ class TestDatabase(_BaseTest):
 
         api.drop_database.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_drop_not_found(self):
@@ -1059,7 +1184,13 @@ class TestDatabase(_BaseTest):
 
         api.drop_database.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_drop_success(self):
@@ -1076,7 +1207,13 @@ class TestDatabase(_BaseTest):
 
         api.drop_database.assert_called_once_with(
             database=self.DATABASE_NAME,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def _execute_partitioned_dml_helper(
@@ -1149,17 +1286,33 @@ class TestDatabase(_BaseTest):
             exclude_txn_from_change_streams=exclude_txn_from_change_streams,
         )
 
-        api.begin_transaction.assert_called_with(
-            session=session.name,
-            options=txn_options,
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
-            ],
-        )
         if retried:
+            api.begin_transaction.assert_called_with(
+                session=session.name,
+                options=txn_options,
+                metadata=[
+                    ("google-cloud-resource-prefix", database.name),
+                    ("x-goog-spanner-route-to-leader", "true"),
+                    (
+                        "x-goog-spanner-request-id",
+                        f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.3.1",
+                    ),
+                ],
+            )
             self.assertEqual(api.begin_transaction.call_count, 2)
         else:
+            api.begin_transaction.assert_called_with(
+                session=session.name,
+                options=txn_options,
+                metadata=[
+                    ("google-cloud-resource-prefix", database.name),
+                    ("x-goog-spanner-route-to-leader", "true"),
+                    (
+                        "x-goog-spanner-request-id",
+                        f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                    ),
+                ],
+            )
             self.assertEqual(api.begin_transaction.call_count, 1)
 
         if params:
@@ -1191,18 +1344,11 @@ class TestDatabase(_BaseTest):
             request_options=expected_request_options,
         )
 
-        api.execute_streaming_sql.assert_any_call(
-            request=expected_request,
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
-            ],
-        )
         if retried:
             expected_retry_transaction = TransactionSelector(
                 id=self.RETRY_TRANSACTION_ID
             )
-            expected_request = ExecuteSqlRequest(
+            expected_request_with_retry = ExecuteSqlRequest(
                 session=self.SESSION_NAME,
                 sql=dml,
                 transaction=expected_retry_transaction,
@@ -1211,15 +1357,47 @@ class TestDatabase(_BaseTest):
                 query_options=expected_query_options,
                 request_options=expected_request_options,
             )
-            api.execute_streaming_sql.assert_called_with(
-                request=expected_request,
-                metadata=[
-                    ("google-cloud-resource-prefix", database.name),
-                    ("x-goog-spanner-route-to-leader", "true"),
+
+            self.assertEqual(
+                api.execute_streaming_sql.call_args_list,
+                [
+                    mock.call(
+                        request=expected_request,
+                        metadata=[
+                            ("google-cloud-resource-prefix", database.name),
+                            ("x-goog-spanner-route-to-leader", "true"),
+                            (
+                                "x-goog-spanner-request-id",
+                                f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.2.1",
+                            ),
+                        ],
+                    ),
+                    mock.call(
+                        request=expected_request_with_retry,
+                        metadata=[
+                            ("google-cloud-resource-prefix", database.name),
+                            ("x-goog-spanner-route-to-leader", "true"),
+                            (
+                                "x-goog-spanner-request-id",
+                                f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.4.1",
+                            ),
+                        ],
+                    ),
                 ],
             )
             self.assertEqual(api.execute_streaming_sql.call_count, 2)
         else:
+            api.execute_streaming_sql.assert_any_call(
+                request=expected_request,
+                metadata=[
+                    ("google-cloud-resource-prefix", database.name),
+                    ("x-goog-spanner-route-to-leader", "true"),
+                    (
+                        "x-goog-spanner-request-id",
+                        f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.2.1",
+                    ),
+                ],
+            )
             self.assertEqual(api.execute_streaming_sql.call_count, 1)
 
     def test_execute_partitioned_dml_wo_params(self):
@@ -1490,7 +1668,13 @@ class TestDatabase(_BaseTest):
 
         api.restore_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_restore_not_found(self):
@@ -1516,7 +1700,13 @@ class TestDatabase(_BaseTest):
 
         api.restore_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_restore_success(self):
@@ -1553,7 +1743,13 @@ class TestDatabase(_BaseTest):
 
         api.restore_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_restore_success_w_encryption_config_dict(self):
@@ -1594,7 +1790,13 @@ class TestDatabase(_BaseTest):
 
         api.restore_database.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_restore_w_invalid_encryption_config_dict(self):
@@ -1741,7 +1943,13 @@ class TestDatabase(_BaseTest):
 
         api.list_database_roles.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
     def test_list_database_roles_defaults(self):
@@ -1762,7 +1970,13 @@ class TestDatabase(_BaseTest):
 
         api.list_database_roles.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
         self.assertIsNotNone(resp)
 
@@ -3113,6 +3327,8 @@ def _make_database_admin_api():
 
 
 class _Client(object):
+    NTH_CLIENT = AtomicCounter()
+
     def __init__(
         self,
         project=TestDatabase.PROJECT_ID,
@@ -3135,6 +3351,12 @@ class _Client(object):
         self.directed_read_options = directed_read_options
         self.default_transaction_options = default_transaction_options
         self.observability_options = observability_options
+        self._nth_client_id = _Client.NTH_CLIENT.increment()
+        self._nth_request = AtomicCounter()
+
+    @property
+    def _next_nth_request(self):
+        return self._nth_request.increment()
 
 
 class _Instance(object):
@@ -3153,6 +3375,7 @@ class _Backup(object):
 class _Database(object):
     log_commit_stats = False
     _route_to_leader_enabled = True
+    NTH_CLIENT_ID = AtomicCounter()
 
     def __init__(self, name, instance=None):
         self.name = name
@@ -3163,6 +3386,25 @@ class _Database(object):
         self.logger = mock.create_autospec(Logger, instance=True)
         self._directed_read_options = None
         self.default_transaction_options = DefaultTransactionOptions()
+        self._nth_request = AtomicCounter()
+        self._nth_client_id = _Database.NTH_CLIENT_ID.increment()
+
+    @property
+    def _next_nth_request(self):
+        return self._nth_request.increment()
+
+    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+        return _metadata_with_request_id(
+            self._nth_client_id,
+            self._channel_id,
+            nth_request,
+            nth_attempt,
+            prior_metadata,
+        )
+
+    @property
+    def _channel_id(self):
+        return 1
 
 
 class _Pool(object):

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -24,7 +24,11 @@ from tests._helpers import (
     HAS_OPENTELEMETRY_INSTALLED,
     enrich_with_otel_scope,
 )
+from google.cloud.spanner_v1._helpers import (
+    _metadata_with_request_id,
+)
 from google.cloud.spanner_v1.param_types import INT64
+from google.cloud.spanner_v1.request_id_header import REQ_RAND_PROCESS_ID
 from google.api_core.retry import Retry
 
 TABLE_NAME = "citizens"
@@ -135,6 +139,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
             session,
             attributes,
             transaction=derived,
+            request_id_manager=None if not session else session._database,
         )
 
     def _make_item(self, value, resume_token=b"", metadata=None):
@@ -153,9 +158,17 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), [])
-        restart.assert_called_once_with(request=request, metadata=None)
+        restart.assert_called_once_with(
+            request=request,
+            metadata=[
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                )
+            ],
+        )
         self.assertNoSpans()
 
     def test_iteration_w_non_empty_raw(self):
@@ -167,9 +180,17 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(ITEMS))
-        restart.assert_called_once_with(request=request, metadata=None)
+        restart.assert_called_once_with(
+            request=request,
+            metadata=[
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                )
+            ],
+        )
         self.assertNoSpans()
 
     def test_iteration_w_raw_w_resume_tken(self):
@@ -186,9 +207,17 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(ITEMS))
-        restart.assert_called_once_with(request=request, metadata=None)
+        restart.assert_called_once_with(
+            request=request,
+            metadata=[
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                )
+            ],
+        )
         self.assertNoSpans()
 
     def test_iteration_w_raw_raising_unavailable_no_token(self):
@@ -207,7 +236,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(ITEMS))
         self.assertEqual(len(restart.mock_calls), 2)
         self.assertEqual(request.resume_token, b"")
@@ -234,7 +263,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(ITEMS))
         self.assertEqual(len(restart.mock_calls), 2)
         self.assertEqual(request.resume_token, b"")
@@ -256,10 +285,18 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         with self.assertRaises(InternalServerError):
             list(resumable)
-        restart.assert_called_once_with(request=request, metadata=None)
+        restart.assert_called_once_with(
+            request=request,
+            metadata=[
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                )
+            ],
+        )
         self.assertNoSpans()
 
     def test_iteration_w_raw_raising_unavailable(self):
@@ -278,7 +315,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(FIRST + LAST))
         self.assertEqual(len(restart.mock_calls), 2)
         self.assertEqual(request.resume_token, RESUME_TOKEN)
@@ -295,7 +332,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
             fail_after=True,
             error=InternalServerError(
                 "Received unexpected EOS on DATA frame from server"
-            )
+            ),
         )
         after = _MockIterator(*LAST)
         request = mock.Mock(test="test", spec=["test", "resume_token"])
@@ -304,7 +341,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(FIRST + LAST))
         self.assertEqual(len(restart.mock_calls), 2)
         self.assertEqual(request.resume_token, RESUME_TOKEN)
@@ -326,10 +363,18 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         with self.assertRaises(InternalServerError):
             list(resumable)
-        restart.assert_called_once_with(request=request, metadata=None)
+        restart.assert_called_once_with(
+            request=request,
+            metadata=[
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                )
+            ],
+        )
         self.assertNoSpans()
 
     def test_iteration_w_raw_raising_unavailable_after_token(self):
@@ -347,7 +392,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(FIRST + SECOND))
         self.assertEqual(len(restart.mock_calls), 2)
         self.assertEqual(request.resume_token, RESUME_TOKEN)
@@ -370,7 +415,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         session = _Session(database)
         derived = self._makeDerived(session)
         derived._multi_use = True
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(FIRST))
         self.assertEqual(len(restart.mock_calls), 1)
         begin_count = sum(
@@ -401,7 +446,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         session = _Session(database)
         derived = self._makeDerived(session)
         derived._multi_use = True
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(SECOND))
         self.assertEqual(len(restart.mock_calls), 2)
         begin_count = sum(
@@ -440,7 +485,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         derived = self._makeDerived(session)
         derived._multi_use = True
 
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
 
         self.assertEqual(list(resumable), list(FIRST + SECOND))
         self.assertEqual(len(restart.mock_calls), 2)
@@ -467,7 +512,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
             fail_after=True,
             error=InternalServerError(
                 "Received unexpected EOS on DATA frame from server"
-            )
+            ),
         )
         after = _MockIterator(*SECOND)
         request = mock.Mock(test="test", spec=["test", "resume_token"])
@@ -476,7 +521,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         self.assertEqual(list(resumable), list(FIRST + SECOND))
         self.assertEqual(len(restart.mock_calls), 2)
         self.assertEqual(request.resume_token, RESUME_TOKEN)
@@ -497,10 +542,18 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
         database.spanner_api = self._make_spanner_api()
         session = _Session(database)
         derived = self._makeDerived(session)
-        resumable = self._call_fut(derived, restart, request)
+        resumable = self._call_fut(derived, restart, request, session=session)
         with self.assertRaises(InternalServerError):
             list(resumable)
-        restart.assert_called_once_with(request=request, metadata=None)
+        restart.assert_called_once_with(
+            request=request,
+            metadata=[
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                )
+            ],
+        )
         self.assertNoSpans()
 
     def test_iteration_w_span_creation(self):
@@ -777,7 +830,13 @@ class Test_SnapshotBase(OpenTelemetryBase):
         )
         api.streaming_read.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
             retry=retry,
             timeout=timeout,
         )
@@ -1026,7 +1085,13 @@ class Test_SnapshotBase(OpenTelemetryBase):
         )
         api.execute_streaming_sql.assert_called_once_with(
             request=expected_request,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
+            ],
             timeout=timeout,
             retry=retry,
         )
@@ -1199,6 +1264,10 @@ class Test_SnapshotBase(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=retry,
             timeout=timeout,
@@ -1378,6 +1447,10 @@ class Test_SnapshotBase(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=retry,
             timeout=timeout,
@@ -1774,7 +1847,13 @@ class TestSnapshot(OpenTelemetryBase):
         api.begin_transaction.assert_called_once_with(
             session=session.name,
             options=expected_txn_options,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
         self.assertSpanAttributes(
@@ -1810,7 +1889,13 @@ class TestSnapshot(OpenTelemetryBase):
         api.begin_transaction.assert_called_once_with(
             session=session.name,
             options=expected_txn_options,
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
+            ],
         )
 
         self.assertSpanAttributes(
@@ -1835,6 +1920,7 @@ class _Instance(object):
 class _Database(object):
     def __init__(self, directed_read_options=None):
         self.name = "testing"
+        self._nth_request = 0
         self._instance = _Instance()
         self._route_to_leader_enabled = True
         self._directed_read_options = directed_read_options
@@ -1842,6 +1928,28 @@ class _Database(object):
     @property
     def observability_options(self):
         return dict(db_name=self.name)
+
+    @property
+    def _next_nth_request(self):
+        self._nth_request += 1
+        return self._nth_request
+
+    @property
+    def _nth_client_id(self):
+        return 1
+
+    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+        return _metadata_with_request_id(
+            self._nth_client_id,
+            self._channel_id,
+            nth_request,
+            nth_attempt,
+            prior_metadata,
+        )
+
+    @property
+    def _channel_id(self):
+        return 1
 
 
 class _Session(object):

--- a/tests/unit/test_spanner.py
+++ b/tests/unit/test_spanner.py
@@ -1008,7 +1008,6 @@ class TestTransaction(OpenTelemetryBase):
         )
 
         self.assertEqual(api.execute_batch_dml.call_count, 2)
-        print("\033[34marg_list", api.execute_batch_dml.call_args_list, "\033[00m")
         self.assertEqual(
             api.execute_batch_dml.call_args_list,
             [

--- a/tests/unit/test_spanner.py
+++ b/tests/unit/test_spanner.py
@@ -41,7 +41,11 @@ from google.cloud.spanner_v1._helpers import (
     _make_value_pb,
     _merge_query_options,
 )
-
+from google.cloud.spanner_v1._helpers import (
+    AtomicCounter,
+    _metadata_with_request_id,
+)
+from google.cloud.spanner_v1.request_id_header import REQ_RAND_PROCESS_ID
 import mock
 
 from google.api_core import gapic_v1
@@ -522,6 +526,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
         )
 
@@ -537,6 +545,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             timeout=TIMEOUT,
             retry=RETRY,
@@ -554,6 +566,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -570,6 +586,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -595,6 +615,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
         )
 
@@ -621,6 +645,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
         )
 
@@ -639,6 +667,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -653,6 +685,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.2.1",
+                ),
             ],
         )
 
@@ -669,6 +705,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
         )
 
@@ -682,6 +722,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.2.1",
+                ),
             ],
         )
 
@@ -698,6 +742,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
         )
 
@@ -711,6 +759,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.2.1",
+                ),
             ],
         )
 
@@ -732,6 +784,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=gapic_v1.method.DEFAULT,
             timeout=gapic_v1.method.DEFAULT,
@@ -755,6 +811,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -771,6 +831,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -782,6 +846,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.2.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -798,6 +866,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -810,6 +882,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.2.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -850,6 +926,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
             ],
         )
 
@@ -860,6 +940,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.2.1",
+                ),
             ],
         )
 
@@ -868,6 +952,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.3.1",
+                ),
             ],
             retry=RETRY,
             timeout=TIMEOUT,
@@ -903,6 +991,7 @@ class TestTransaction(OpenTelemetryBase):
             thread.join()
 
         self._execute_update_helper(transaction=transaction, api=api)
+        self.assertEqual(api.execute_sql.call_count, 1)
 
         api.execute_sql.assert_any_call(
             request=self._execute_update_expected_request(database, begin=False),
@@ -911,31 +1000,46 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.3.1",
+                ),
             ],
         )
 
-        api.execute_batch_dml.assert_any_call(
-            request=self._batch_update_expected_request(),
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
-            ],
-            retry=RETRY,
-            timeout=TIMEOUT,
-        )
-
-        api.execute_batch_dml.assert_any_call(
-            request=self._batch_update_expected_request(begin=False),
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
-            ],
-            retry=RETRY,
-            timeout=TIMEOUT,
-        )
-
-        self.assertEqual(api.execute_sql.call_count, 1)
         self.assertEqual(api.execute_batch_dml.call_count, 2)
+        print("\033[34marg_list", api.execute_batch_dml.call_args_list, "\033[00m")
+        self.assertEqual(
+            api.execute_batch_dml.call_args_list,
+            [
+                mock.call(
+                    request=self._batch_update_expected_request(),
+                    metadata=[
+                        ("google-cloud-resource-prefix", database.name),
+                        ("x-goog-spanner-route-to-leader", "true"),
+                        (
+                            "x-goog-spanner-request-id",
+                            f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                        ),
+                    ],
+                    retry=RETRY,
+                    timeout=TIMEOUT,
+                ),
+                mock.call(
+                    request=self._batch_update_expected_request(begin=False),
+                    metadata=[
+                        ("google-cloud-resource-prefix", database.name),
+                        ("x-goog-spanner-route-to-leader", "true"),
+                        (
+                            "x-goog-spanner-request-id",
+                            f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.2.1",
+                        ),
+                    ],
+                    retry=RETRY,
+                    timeout=TIMEOUT,
+                ),
+            ],
+        )
 
     def test_transaction_for_concurrent_statement_should_begin_one_transaction_with_read(
         self,
@@ -977,27 +1081,43 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.3.1",
+                ),
             ],
         )
 
-        api.streaming_read.assert_any_call(
-            request=self._read_helper_expected_request(),
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
+        self.assertEqual(
+            api.streaming_read.call_args_list,
+            [
+                mock.call(
+                    request=self._read_helper_expected_request(),
+                    metadata=[
+                        ("google-cloud-resource-prefix", database.name),
+                        ("x-goog-spanner-route-to-leader", "true"),
+                        (
+                            "x-goog-spanner-request-id",
+                            f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                        ),
+                    ],
+                    retry=RETRY,
+                    timeout=TIMEOUT,
+                ),
+                mock.call(
+                    request=self._read_helper_expected_request(begin=False),
+                    metadata=[
+                        ("google-cloud-resource-prefix", database.name),
+                        ("x-goog-spanner-route-to-leader", "true"),
+                        (
+                            "x-goog-spanner-request-id",
+                            f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.2.1",
+                        ),
+                    ],
+                    retry=RETRY,
+                    timeout=TIMEOUT,
+                ),
             ],
-            retry=RETRY,
-            timeout=TIMEOUT,
-        )
-
-        api.streaming_read.assert_any_call(
-            request=self._read_helper_expected_request(begin=False),
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
-            ],
-            retry=RETRY,
-            timeout=TIMEOUT,
         )
 
         self.assertEqual(api.execute_sql.call_count, 1)
@@ -1043,27 +1163,43 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.3.1",
+                ),
             ],
-        )
-        req = self._execute_sql_expected_request(database)
-        api.execute_streaming_sql.assert_any_call(
-            request=req,
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
-            ],
-            retry=RETRY,
-            timeout=TIMEOUT,
         )
 
-        api.execute_streaming_sql.assert_any_call(
-            request=self._execute_sql_expected_request(database, begin=False),
-            metadata=[
-                ("google-cloud-resource-prefix", database.name),
-                ("x-goog-spanner-route-to-leader", "true"),
+        self.assertEqual(
+            api.execute_streaming_sql.call_args_list,
+            [
+                mock.call(
+                    request=self._execute_sql_expected_request(database),
+                    metadata=[
+                        ("google-cloud-resource-prefix", database.name),
+                        ("x-goog-spanner-route-to-leader", "true"),
+                        (
+                            "x-goog-spanner-request-id",
+                            f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                        ),
+                    ],
+                    retry=RETRY,
+                    timeout=TIMEOUT,
+                ),
+                mock.call(
+                    request=self._execute_sql_expected_request(database, begin=False),
+                    metadata=[
+                        ("google-cloud-resource-prefix", database.name),
+                        ("x-goog-spanner-route-to-leader", "true"),
+                        (
+                            "x-goog-spanner-request-id",
+                            f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.2.1",
+                        ),
+                    ],
+                    retry=RETRY,
+                    timeout=TIMEOUT,
+                ),
             ],
-            retry=RETRY,
-            timeout=TIMEOUT,
         )
 
         self.assertEqual(api.execute_sql.call_count, 1)
@@ -1079,19 +1215,33 @@ class TestTransaction(OpenTelemetryBase):
 
         api.execute_streaming_sql.assert_called_once_with(
             request=self._execute_sql_expected_request(database=database),
-            metadata=[("google-cloud-resource-prefix", database.name)],
+            metadata=[
+                ("google-cloud-resource-prefix", database.name),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.1.1.1",
+                ),
+            ],
             timeout=TIMEOUT,
             retry=RETRY,
         )
 
 
 class _Client(object):
+    NTH_CLIENT = AtomicCounter()
+
     def __init__(self):
         from google.cloud.spanner_v1 import ExecuteSqlRequest
 
         self._query_options = ExecuteSqlRequest.QueryOptions(optimizer_version="1")
         self.directed_read_options = None
         self.default_transaction_options = DefaultTransactionOptions()
+        self._nth_client_id = _Client.NTH_CLIENT.increment()
+        self._nth_request = AtomicCounter()
+
+    @property
+    def _next_nth_request(self):
+        return self._nth_request.increment()
 
 
 class _Instance(object):
@@ -1106,6 +1256,27 @@ class _Database(object):
         self._route_to_leader_enabled = True
         self._directed_read_options = None
         self.default_transaction_options = DefaultTransactionOptions()
+
+    @property
+    def _next_nth_request(self):
+        return self._instance._client._next_nth_request
+
+    @property
+    def _nth_client_id(self):
+        return self._instance._client._nth_client_id
+
+    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+        return _metadata_with_request_id(
+            self._nth_client_id,
+            self._channel_id,
+            nth_request,
+            nth_attempt,
+            prior_metadata,
+        )
+
+    @property
+    def _channel_id(self):
+        return 1
 
 
 class _Session(object):

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -25,6 +25,7 @@ from google.cloud.spanner_v1._helpers import (
     AtomicCounter,
     _metadata_with_request_id,
 )
+from google.cloud.spanner_v1.request_id_header import REQ_RAND_PROCESS_ID
 
 from tests._helpers import (
     HAS_OPENTELEMETRY_INSTALLED,
@@ -201,11 +202,10 @@ class TestTransaction(OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
-                # TODO(@odeke-em): enable with PR #1367.
-                # (
-                #     "x-goog-spanner-request-id",
-                #     f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
-                # ),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                ),
             ],
         )
 
@@ -310,11 +310,10 @@ class TestTransaction(OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
-                # TODO(@odeke-em): enable with PR #1367.
-                # (
-                #     "x-goog-spanner-request-id",
-                #     f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
-                # ),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                ),
             ],
         )
 
@@ -506,11 +505,10 @@ class TestTransaction(OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
-                # TODO(@odeke-em): enable with PR #1367.
-                # (
-                #     "x-goog-spanner-request-id",
-                #     f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
-                # ),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                ),
             ],
         )
         self.assertEqual(actual_request_options, expected_request_options)
@@ -685,11 +683,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
-                # TODO(@odeke-em): enable with PR #1367.
-                # (
-                #     "x-goog-spanner-request-id",
-                #     f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
-                # ),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                ),
             ],
         )
 
@@ -883,11 +880,10 @@ class TestTransaction(OpenTelemetryBase):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
-                # TODO(@odeke-em): enable with PR #1367.
-                # (
-                #     "x-goog-spanner-request-id",
-                #     f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
-                # ),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                ),
             ],
             retry=retry,
             timeout=timeout,
@@ -1003,11 +999,10 @@ class TestTransaction(OpenTelemetryBase):
             [
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
-                # TODO(@odeke-em): enable with PR #1367.
-                # (
-                #     "x-goog-spanner-request-id",
-                #     f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.2.1",
-                # ),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.2.1",
+                ),
             ],
         )
 


### PR DESCRIPTION
This change chops down the load of the large changes for x-goog-spanner-request-id. It depends on PR googleapis/python-spanner#1366 and should only be merged after that PR.

Updates googleapis/google-cloud-python#15905
Requires PR googleapis/python-spanner#1366