### PR TITLE
build: reduce build time

### DIFF
--- a/.github/workflows/mock_server_tests.yaml
+++ b/.github/workflows/mock_server_tests.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
 name: Run Spanner tests against an in-mem mock server
 jobs:
-  system-tests:
+  mock-server-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+name: Presubmit checks
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+      - name: Install nox
+        run: python -m pip install nox
+      - name: Check formatting
+        run: nox -s lint
+      - name: Check lint setup
+        run: nox -s lint_setup_py
+  units:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{matrix.python}}
+      - name: Install nox
+        run: python -m pip install nox
+      - name: Run unit tests
+        run: nox -s unit-${{matrix.python}}

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -4,6 +4,9 @@ on:
       - main
   pull_request:
 name: Presubmit checks
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -19,14 +22,12 @@ jobs:
         run: python -m pip install nox
       - name: Check formatting
         run: nox -s lint
-      - name: Check lint setup
-        run: nox -s lint_setup_py
   units:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python: [3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout code

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -5,3 +5,8 @@ env_vars: {
     key: "RUN_SYSTEM_TESTS"
     value: "false"
 }
+# Only run a subset of all nox sessions
+env_vars: {
+    key: "NOX_SESSION"
+    value: "unit-3.8 unit-3.12 cover docs docfx"
+}

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,10 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Disable system tests.
-env_vars: {
-    key: "RUN_SYSTEM_TESTS"
-    value: "false"
-}
 # Only run a subset of all nox sessions
 env_vars: {
     key: "NOX_SESSION"

--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -17,6 +17,8 @@ import warnings
 
 from google.api_core.exceptions import Aborted
 from google.api_core.gapic_v1.client_info import ClientInfo
+from google.auth.credentials import AnonymousCredentials
+
 from google.cloud import spanner_v1 as spanner
 from google.cloud.spanner_dbapi import partition_helper
 from google.cloud.spanner_dbapi.batch_dml_executor import BatchMode, BatchDmlExecutor
@@ -784,11 +786,15 @@ def connect(
                 route_to_leader_enabled=route_to_leader_enabled,
             )
         else:
+            client_options = None
+            if isinstance(credentials, AnonymousCredentials):
+                client_options = kwargs.get("client_options")
             client = spanner.Client(
                 project=project,
                 credentials=credentials,
                 client_info=client_info,
                 route_to_leader_enabled=route_to_leader_enabled,
+                client_options=client_options,
             )
     else:
         if project is not None and client.project != project:

--- a/google/cloud/spanner_dbapi/transaction_helper.py
+++ b/google/cloud/spanner_dbapi/transaction_helper.py
@@ -162,7 +162,7 @@ class TransactionRetryHelper:
         self._last_statement_details_per_cursor[cursor] = last_statement_result_details
         self._statement_result_details_list.append(last_statement_result_details)
 
-    def retry_transaction(self):
+    def retry_transaction(self, default_retry_delay=None):
         """Retry the aborted transaction.
 
         All the statements executed in the original transaction
@@ -202,7 +202,9 @@ class TransactionRetryHelper:
                             raise RetryAborted(RETRY_ABORTED_ERROR, ex)
                 return
             except Aborted as ex:
-                delay = _get_retry_delay(ex.errors[0], attempt)
+                delay = _get_retry_delay(
+                    ex.errors[0], attempt, default_retry_delay=default_retry_delay
+                )
                 if delay:
                     time.sleep(delay)
 

--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -257,9 +257,11 @@ class Batch(_BatchBase):
             deadline = time.time() + kwargs.get(
                 "timeout_secs", DEFAULT_RETRY_TIMEOUT_SECS
             )
+            default_retry_delay = kwargs.get("default_retry_delay", None)
             response = _retry_on_aborted_exception(
                 method,
                 deadline=deadline,
+                default_retry_delay=default_retry_delay,
             )
         self.committed = response.commit_timestamp
         self.commit_stats = response.commit_stats

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -241,7 +241,9 @@ class Client(ClientWithProject):
                 meter_provider = MeterProvider(
                     metric_readers=[
                         PeriodicExportingMetricReader(
-                            CloudMonitoringMetricsExporter(),
+                            CloudMonitoringMetricsExporter(
+                                project_id=project, credentials=credentials
+                            ),
                             export_interval_millis=METRIC_EXPORT_INTERVAL_MS,
                         )
                     ]

--- a/google/cloud/spanner_v1/metrics/metrics_exporter.py
+++ b/google/cloud/spanner_v1/metrics/metrics_exporter.py
@@ -26,6 +26,7 @@ import logging
 from typing import Optional, List, Union, NoReturn, Tuple, Dict
 
 import google.auth
+from google.auth import credentials as ga_credentials
 from google.api.distribution_pb2 import (  # pylint: disable=no-name-in-module
     Distribution,
 )
@@ -111,6 +112,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
         self,
         project_id: Optional[str] = None,
         client: Optional["MetricServiceClient"] = None,
+        credentials: Optional[ga_credentials.Credentials] = None,
     ):
         """Initialize a custom exporter to send metrics for the Spanner Service Metrics."""
         # Default preferred_temporality is all CUMULATIVE so need to customize
@@ -121,6 +123,7 @@ class CloudMonitoringMetricsExporter(MetricExporter):
             transport=MetricServiceGrpcTransport(
                 channel=MetricServiceGrpcTransport.create_channel(
                     options=_OPTIONS,
+                    credentials=credentials,
                 )
             )
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -329,8 +329,12 @@ def system(session, protobuf_implementation, database_dialect):
         session.skip(
             "Credentials or emulator host must be set via environment variable"
         )
-    if not os.environ.get("SPANNER_EMULATOR_HOST"):
-        session.skip("only run system tests on the emulator to speed the build up")
+    if not (
+        os.environ.get("SPANNER_EMULATOR_HOST") or protobuf_implementation == "python"
+    ):
+        session.skip(
+            "Only run system tests on real Spanner with one protobuf implementation to speed up the build"
+        )
 
     # Install pyopenssl for mTLS testing.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,21 +181,6 @@ def install_unittest_dependencies(session, *constraints):
     # XXX: Dump installed versions to debug OT issue
     session.run("pip", "list")
 
-    # Run py.test against the unit tests with OpenTelemetry.
-    session.run(
-        "py.test",
-        "--quiet",
-        "--cov=google.cloud.spanner",
-        "--cov=google.cloud",
-        "--cov=tests.unit",
-        "--cov-append",
-        "--cov-config=.coveragerc",
-        "--cov-report=",
-        "--cov-fail-under=0",
-        os.path.join("tests", "unit"),
-        *session.posargs,
-    )
-
 
 @nox.session(python=UNIT_TEST_PYTHON_VERSIONS)
 @nox.parametrize(
@@ -368,7 +353,7 @@ def system(session, protobuf_implementation, database_dialect):
                 "SKIP_BACKUP_TESTS": "true",
             },
         )
-    if system_test_folder_exists:
+    elif system_test_folder_exists:
         session.run(
             "py.test",
             "--quiet",
@@ -570,30 +555,32 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
-    # Only run system tests if found.
-    if os.path.exists(system_test_path):
-        session.run(
-            "py.test",
-            "--verbose",
-            f"--junitxml=system_{session.python}_sponge_log.xml",
-            system_test_path,
-            *session.posargs,
-            env={
-                "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
-                "SPANNER_DATABASE_DIALECT": database_dialect,
-                "SKIP_BACKUP_TESTS": "true",
-            },
-        )
-    if os.path.exists(system_test_folder_path):
-        session.run(
-            "py.test",
-            "--verbose",
-            f"--junitxml=system_{session.python}_sponge_log.xml",
-            system_test_folder_path,
-            *session.posargs,
-            env={
-                "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
-                "SPANNER_DATABASE_DIALECT": database_dialect,
-                "SKIP_BACKUP_TESTS": "true",
-            },
-        )
+    # Only run system tests for one protobuf implementation on real Spanner to speed up the build.
+    if os.environ.get("SPANNER_EMULATOR_HOST") or protobuf_implementation == "python":
+        # Only run system tests if found.
+        if os.path.exists(system_test_path):
+            session.run(
+                "py.test",
+                "--verbose",
+                f"--junitxml=system_{session.python}_sponge_log.xml",
+                system_test_path,
+                *session.posargs,
+                env={
+                    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                    "SPANNER_DATABASE_DIALECT": database_dialect,
+                    "SKIP_BACKUP_TESTS": "true",
+                },
+            )
+        elif os.path.exists(system_test_folder_path):
+            session.run(
+                "py.test",
+                "--verbose",
+                f"--junitxml=system_{session.python}_sponge_log.xml",
+                system_test_folder_path,
+                *session.posargs,
+                env={
+                    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+                    "SPANNER_DATABASE_DIALECT": database_dialect,
+                    "SKIP_BACKUP_TESTS": "true",
+                },
+            )

--- a/noxfile.py
+++ b/noxfile.py
@@ -323,9 +323,8 @@ def system(session, protobuf_implementation, database_dialect):
         session.skip(
             "Credentials or emulator host must be set via environment variable"
         )
-    # If POSTGRESQL tests and Emulator, skip the tests
-    if os.environ.get("SPANNER_EMULATOR_HOST") and database_dialect == "POSTGRESQL":
-        session.skip("Postgresql is not supported by Emulator yet.")
+    if not os.environ.get("SPANNER_EMULATOR_HOST"):
+        session.skip("only run system tests on the emulator to speed the build up")
 
     # Install pyopenssl for mTLS testing.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":

--- a/tests/unit/spanner_dbapi/test_connect.py
+++ b/tests/unit/spanner_dbapi/test_connect.py
@@ -17,8 +17,8 @@
 import unittest
 from unittest import mock
 
-import google.auth.credentials
-
+import google
+from google.auth.credentials import AnonymousCredentials
 
 INSTANCE = "test-instance"
 DATABASE = "test-database"
@@ -45,7 +45,13 @@ class Test_connect(unittest.TestCase):
         instance = client.instance.return_value
         database = instance.database.return_value
 
-        connection = connect(INSTANCE, DATABASE)
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         self.assertIsInstance(connection, Connection)
 
@@ -55,6 +61,7 @@ class Test_connect(unittest.TestCase):
             project=mock.ANY,
             credentials=mock.ANY,
             client_info=mock.ANY,
+            client_options=mock.ANY,
             route_to_leader_enabled=True,
         )
 
@@ -92,6 +99,7 @@ class Test_connect(unittest.TestCase):
             project=PROJECT,
             credentials=credentials,
             client_info=mock.ANY,
+            client_options=mock.ANY,
             route_to_leader_enabled=False,
         )
         client_info = mock_client.call_args_list[0][1]["client_info"]

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -19,6 +19,7 @@ import mock
 import unittest
 import warnings
 import pytest
+from google.auth.credentials import AnonymousCredentials
 
 from google.cloud.spanner_admin_database_v1 import DatabaseDialect
 from google.cloud.spanner_dbapi.batch_dml_executor import BatchMode
@@ -68,7 +69,11 @@ class TestConnection(unittest.TestCase):
         from google.cloud.spanner_v1.client import Client
 
         # We don't need a real Client object to test the constructor
-        client = Client()
+        client = Client(
+            project="test",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
         instance = Instance(INSTANCE, client=client)
         database = instance.database(DATABASE, database_dialect=database_dialect)
         return Connection(instance, database, **kwargs)
@@ -239,7 +244,13 @@ class TestConnection(unittest.TestCase):
         from google.cloud.spanner_dbapi import connect
         from google.cloud.spanner_dbapi import InterfaceError
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         self.assertFalse(connection.is_closed)
 
@@ -830,7 +841,12 @@ class TestConnection(unittest.TestCase):
     def test_connection_wo_database(self):
         from google.cloud.spanner_dbapi import connect
 
-        connection = connect("test-instance")
+        connection = connect(
+            "test-instance",
+            credentials=AnonymousCredentials(),
+            project="test-project",
+            client_options={"api_endpoint": "none"},
+        )
         self.assertTrue(connection.database is None)
 
 

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -16,6 +16,8 @@
 from unittest import mock
 import sys
 import unittest
+
+from google.auth.credentials import AnonymousCredentials
 from google.rpc.code_pb2 import ABORTED
 
 from google.cloud.spanner_dbapi.parsed_statement import (
@@ -127,7 +129,13 @@ class TestCursor(unittest.TestCase):
 
         sql = "DELETE FROM table WHERE col1 = %s"
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         connection.autocommit = True
         transaction = self._transaction_mock(mock_response=[1, 1, 1])
@@ -479,7 +487,13 @@ class TestCursor(unittest.TestCase):
     def test_executemany_client_statement(self):
         from google.cloud.spanner_dbapi import connect, ProgrammingError
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         cursor = connection.cursor()
 
@@ -497,7 +511,13 @@ class TestCursor(unittest.TestCase):
         operation = """SELECT * FROM table1 WHERE "col1" = @a1"""
         params_seq = ((1,), (2,))
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         cursor = connection.cursor()
         cursor._result_set = [1, 2, 3]
@@ -519,7 +539,13 @@ class TestCursor(unittest.TestCase):
 
         sql = "DELETE FROM table WHERE col1 = %s"
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         connection.autocommit = True
         transaction = self._transaction_mock()
@@ -551,7 +577,13 @@ class TestCursor(unittest.TestCase):
 
         sql = "UPDATE table SET col1 = %s WHERE col2 = %s"
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         connection.autocommit = True
         transaction = self._transaction_mock()
@@ -595,7 +627,13 @@ class TestCursor(unittest.TestCase):
 
         sql = """INSERT INTO table (col1, "col2", `col3`, `"col4"`) VALUES (%s, %s, %s, %s)"""
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         transaction = self._transaction_mock()
 
@@ -632,7 +670,13 @@ class TestCursor(unittest.TestCase):
 
         sql = """INSERT INTO table (col1, "col2", `col3`, `"col4"`) VALUES (%s, %s, %s, %s)"""
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         connection.autocommit = True
 
@@ -676,7 +720,13 @@ class TestCursor(unittest.TestCase):
         sql = """INSERT INTO table (col1, "col2", `col3`, `"col4"`) VALUES (%s, %s, %s, %s)"""
         err_details = "Details here"
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         connection.autocommit = True
         cursor = connection.cursor()
@@ -705,7 +755,13 @@ class TestCursor(unittest.TestCase):
         args = [(1, 2, 3, 4), (5, 6, 7, 8)]
         err_details = "Aborted details here"
 
-        connection = connect("test-instance", "test-database")
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
 
         transaction1 = mock.Mock()
         transaction1.batch_update = mock.Mock(

--- a/tests/unit/spanner_dbapi/test_transaction_helper.py
+++ b/tests/unit/spanner_dbapi/test_transaction_helper.py
@@ -323,7 +323,7 @@ class TestTransactionHelper(unittest.TestCase):
             None,
         ]
 
-        self._under_test.retry_transaction()
+        self._under_test.retry_transaction(default_retry_delay=0)
 
         run_mock.assert_has_calls(
             (

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -277,16 +277,12 @@ class TestBatch(_BaseTest, OpenTelemetryBase):
 
         # Assertion: Ensure that calling batch.commit() raises the Aborted exception
         with self.assertRaises(Aborted) as context:
-            batch.commit()
+            batch.commit(timeout_secs=0.1, default_retry_delay=0)
 
         # Verify additional details about the exception
         self.assertEqual(str(context.exception), "409 Transaction was aborted")
         self.assertGreater(
             api.commit.call_count, 1, "commit should be called more than once"
-        )
-        # Since we are using exponential backoff here and default timeout is set to 30 sec 2^x <= 30. So value for x will be 4
-        self.assertEqual(
-            api.commit.call_count, 4, "commit should be called exactly 4 times"
         )
 
     def _test_commit_with_options(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -16,6 +16,8 @@ import unittest
 
 import os
 import mock
+from google.auth.credentials import AnonymousCredentials
+
 from google.cloud.spanner_v1 import DirectedReadOptions, DefaultTransactionOptions
 
 
@@ -513,7 +515,7 @@ class TestClient(unittest.TestCase):
         from google.cloud.spanner_admin_instance_v1 import ListInstanceConfigsRequest
         from google.cloud.spanner_admin_instance_v1 import ListInstanceConfigsResponse
 
-        api = InstanceAdminClient()
+        api = InstanceAdminClient(credentials=AnonymousCredentials())
         credentials = _make_credentials()
         client = self._make_one(project=self.PROJECT, credentials=credentials)
         client._instance_admin_api = api
@@ -560,8 +562,8 @@ class TestClient(unittest.TestCase):
         from google.cloud.spanner_admin_instance_v1 import ListInstanceConfigsRequest
         from google.cloud.spanner_admin_instance_v1 import ListInstanceConfigsResponse
 
-        api = InstanceAdminClient()
         credentials = _make_credentials()
+        api = InstanceAdminClient(credentials=credentials)
         client = self._make_one(project=self.PROJECT, credentials=credentials)
         client._instance_admin_api = api
 
@@ -636,8 +638,8 @@ class TestClient(unittest.TestCase):
         from google.cloud.spanner_admin_instance_v1 import ListInstancesRequest
         from google.cloud.spanner_admin_instance_v1 import ListInstancesResponse
 
-        api = InstanceAdminClient()
         credentials = _make_credentials()
+        api = InstanceAdminClient(credentials=credentials)
         client = self._make_one(project=self.PROJECT, credentials=credentials)
         client._instance_admin_api = api
 
@@ -684,8 +686,8 @@ class TestClient(unittest.TestCase):
         from google.cloud.spanner_admin_instance_v1 import ListInstancesRequest
         from google.cloud.spanner_admin_instance_v1 import ListInstancesResponse
 
-        api = InstanceAdminClient()
         credentials = _make_credentials()
+        api = InstanceAdminClient(credentials=credentials)
         client = self._make_one(project=self.PROJECT, credentials=credentials)
         client._instance_admin_api = api
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1916,7 +1916,7 @@ class TestBatchCheckout(_BaseTest):
         pool = database._pool = _Pool()
         session = _Session(database)
         pool.put(session)
-        checkout = self._make_one(database)
+        checkout = self._make_one(database, timeout_secs=0.1, default_retry_delay=0)
 
         with self.assertRaises(Aborted):
             with checkout as batch:
@@ -1935,9 +1935,7 @@ class TestBatchCheckout(_BaseTest):
             return_commit_stats=True,
             request_options=RequestOptions(),
         )
-        # Asserts that the exponential backoff retry for aborted transactions with a 30-second deadline
-        # allows for a maximum of 4 retries (2^x <= 30) to stay within the time limit.
-        self.assertEqual(api.commit.call_count, 4)
+        self.assertGreater(api.commit.call_count, 1)
         api.commit.assert_any_call(
             request=request,
             metadata=[

--- a/tests/unit/test_instance.py
+++ b/tests/unit/test_instance.py
@@ -14,6 +14,8 @@
 
 import unittest
 import mock
+from google.auth.credentials import AnonymousCredentials
+
 from google.cloud.spanner_v1 import DefaultTransactionOptions
 
 
@@ -586,7 +588,7 @@ class TestInstance(unittest.TestCase):
         from google.cloud.spanner_admin_database_v1 import ListDatabasesRequest
         from google.cloud.spanner_admin_database_v1 import ListDatabasesResponse
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -625,7 +627,7 @@ class TestInstance(unittest.TestCase):
         from google.cloud.spanner_admin_database_v1 import ListDatabasesRequest
         from google.cloud.spanner_admin_database_v1 import ListDatabasesResponse
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -704,7 +706,7 @@ class TestInstance(unittest.TestCase):
         from google.cloud.spanner_admin_database_v1 import ListBackupsRequest
         from google.cloud.spanner_admin_database_v1 import ListBackupsResponse
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -743,7 +745,7 @@ class TestInstance(unittest.TestCase):
         from google.cloud.spanner_admin_database_v1 import ListBackupsRequest
         from google.cloud.spanner_admin_database_v1 import ListBackupsResponse
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -787,7 +789,7 @@ class TestInstance(unittest.TestCase):
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -832,7 +834,7 @@ class TestInstance(unittest.TestCase):
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -884,7 +886,7 @@ class TestInstance(unittest.TestCase):
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)
@@ -941,7 +943,7 @@ class TestInstance(unittest.TestCase):
         from google.longrunning import operations_pb2
         from google.protobuf.any_pb2 import Any
 
-        api = DatabaseAdminClient()
+        api = DatabaseAdminClient(credentials=AnonymousCredentials())
         client = _Client(self.PROJECT)
         client.database_admin_api = api
         instance = self._make_one(self.INSTANCE_ID, client)

--- a/tests/unit/test_metrics_exporter.py
+++ b/tests/unit/test_metrics_exporter.py
@@ -14,6 +14,9 @@
 
 import unittest
 from unittest.mock import patch, MagicMock, Mock
+
+from google.auth.credentials import AnonymousCredentials
+
 from google.cloud.spanner_v1.metrics.metrics_exporter import (
     CloudMonitoringMetricsExporter,
     _normalize_label_key,
@@ -73,10 +76,6 @@ if HAS_OPENTELEMETRY_INSTALLED:
                 description="A test counter",
                 unit="counts",
             )
-
-        def test_default_ctor(self):
-            exporter = CloudMonitoringMetricsExporter()
-            self.assertIsNotNone(exporter.project_id)
 
         def test_normalize_label_key(self):
             """Test label key normalization"""
@@ -236,7 +235,9 @@ if HAS_OPENTELEMETRY_INSTALLED:
             metrics = self.metric_reader.get_metrics_data()
             self.assertTrue(metrics is not None)
 
-            exporter = CloudMonitoringMetricsExporter(PROJECT_ID)
+            exporter = CloudMonitoringMetricsExporter(
+                PROJECT_ID, credentials=AnonymousCredentials()
+            )
             timeseries = exporter._resource_metrics_to_timeseries_pb(metrics)
 
             # Both counter values should be summed together
@@ -257,7 +258,9 @@ if HAS_OPENTELEMETRY_INSTALLED:
 
             # Export metrics
             metrics = self.metric_reader.get_metrics_data()
-            exporter = CloudMonitoringMetricsExporter(PROJECT_ID)
+            exporter = CloudMonitoringMetricsExporter(
+                PROJECT_ID, credentials=AnonymousCredentials()
+            )
             timeseries = exporter._resource_metrics_to_timeseries_pb(metrics)
 
             # Metris with incorrect sope should be filtered out
@@ -342,7 +345,9 @@ if HAS_OPENTELEMETRY_INSTALLED:
             with self.assertLogs(
                 "google.cloud.spanner_v1.metrics.metrics_exporter", level="WARNING"
             ) as log:
-                exporter = CloudMonitoringMetricsExporter(PROJECT_ID)
+                exporter = CloudMonitoringMetricsExporter(
+                    PROJECT_ID, credentials=AnonymousCredentials()
+                )
                 self.assertFalse(exporter.export([]))
                 self.assertIn(
                     "WARNING:google.cloud.spanner_v1.metrics.metrics_exporter:Metric exporter called without dependencies installed.",
@@ -382,12 +387,16 @@ if HAS_OPENTELEMETRY_INSTALLED:
 
         def test_force_flush(self):
             """Verify that the unimplemented force flush can be called."""
-            exporter = CloudMonitoringMetricsExporter(PROJECT_ID)
+            exporter = CloudMonitoringMetricsExporter(
+                PROJECT_ID, credentials=AnonymousCredentials()
+            )
             self.assertTrue(exporter.force_flush())
 
         def test_shutdown(self):
             """Verify that the unimplemented shutdown can be called."""
-            exporter = CloudMonitoringMetricsExporter()
+            exporter = CloudMonitoringMetricsExporter(
+                project_id="test", credentials=AnonymousCredentials()
+            )
             try:
                 exporter.shutdown()
             except Exception as e:
@@ -409,7 +418,9 @@ if HAS_OPENTELEMETRY_INSTALLED:
             self, mocked_data_point_to_timeseries_pb
         ):
             """Verify that metric entries with no timeseries data do not return a time series entry."""
-            exporter = CloudMonitoringMetricsExporter()
+            exporter = CloudMonitoringMetricsExporter(
+                project_id="test", credentials=AnonymousCredentials()
+            )
             data_point = Mock()
             metric = Mock(data_points=[data_point])
             scope_metric = Mock(
@@ -422,7 +433,9 @@ if HAS_OPENTELEMETRY_INSTALLED:
 
         def test_to_point(self):
             """Verify conversion of datapoints."""
-            exporter = CloudMonitoringMetricsExporter()
+            exporter = CloudMonitoringMetricsExporter(
+                project_id="test", credentials=AnonymousCredentials()
+            )
 
             number_point = NumberDataPoint(
                 attributes=[], start_time_unix_nano=0, time_unix_nano=0, value=9

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -283,7 +283,7 @@ class TestFixedSizePool(OpenTelemetryBase):
             return
 
         # Tests trying to invoke pool.get() from an empty pool.
-        pool = self._make_one(size=0)
+        pool = self._make_one(size=0, default_timeout=0.1)
         database = _Database("name")
         session1 = _Session(database)
         with trace_call("pool.Get", session1):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1031,7 +1031,9 @@ class TestSession(OpenTelemetryBase):
             txn.insert(TABLE_NAME, COLUMNS, VALUES)
             return "answer"
 
-        return_value = session.run_in_transaction(unit_of_work, "abc", some_arg="def")
+        return_value = session.run_in_transaction(
+            unit_of_work, "abc", some_arg="def", default_retry_delay=0
+        )
 
         self.assertEqual(len(called_with), 2)
         for index, (txn, args, kw) in enumerate(called_with):
@@ -1858,7 +1860,7 @@ class TestSession(OpenTelemetryBase):
         # check if current time > deadline
         with mock.patch("time.time", _time_func):
             with self.assertRaises(Exception):
-                _delay_until_retry(exc_mock, 2, 1)
+                _delay_until_retry(exc_mock, 2, 1, default_retry_delay=0)
 
         with mock.patch("time.time", _time_func):
             with mock.patch(


### PR DESCRIPTION
Change the build setup to significantly reduce the overall build time. The slowest presubmit check ([Kokoro Prerelease Dependencies](https://source.cloud.google.com/results/invocations/8b3e0081-1822-41f0-b063-114138d4c260)) now takes ±30 minutes.