### PR TITLE
test: add explicit credentials and project to test

### DIFF
--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -1,7 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Only run a subset of all nox sessions
+# Disable system tests.
 env_vars: {
-    key: "NOX_SESSION"
-    value: "unit-3.8 unit-3.12 cover docs docfx"
+    key: "RUN_SYSTEM_TESTS"
+    value: "false"
 }

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -830,7 +830,14 @@ class TestConnection(unittest.TestCase):
         from google.cloud.spanner_dbapi import connect
 
         role = "some_role"
-        connection = connect("test-instance", "test-database", database_role=role)
+        connection = connect(
+            "test-instance",
+            "test-database",
+            project="test-project",
+            database_role=role,
+            credentials=AnonymousCredentials(),
+            client_options={"api_endpoint": "none"},
+        )
         self.assertEqual(connection.database.database_role, role)
 
     def test_invalid_custom_client_connection(self):


### PR DESCRIPTION
Tests need to be able to run in environments without any default credentials. This requires the test to explictly set the credentials and the project that should be used.
