### PR TITLE
chore(x-goog-spanner-request-id): add x_goog_spanner_request_id as an attribute to OTEL spans

### DIFF
--- a/google/cloud/spanner_v1/batch.py
+++ b/google/cloud/spanner_v1/batch.py
@@ -26,6 +26,7 @@ from google.cloud.spanner_v1._helpers import (
     _metadata_with_prefix,
     _metadata_with_leader_aware_routing,
     _merge_Transaction_Options,
+    AtomicCounter,
 )
 from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
 from google.cloud.spanner_v1 import RequestOptions
@@ -248,7 +249,7 @@ class Batch(_BatchBase):
             trace_attributes,
             observability_options=observability_options,
             metadata=metadata,
-        ), MetricsCapture():
+        ) as span, MetricsCapture():
 
             def wrapped_method(*args, **kwargs):
                 method = functools.partial(
@@ -261,6 +262,7 @@ class Batch(_BatchBase):
                         getattr(database, "_next_nth_request", 0),
                         1,
                         metadata,
+                        span,
                     ),
                 )
                 return method(*args, **kwargs)
@@ -384,14 +386,25 @@ class MutationGroups(_SessionWrapper):
             trace_attributes,
             observability_options=observability_options,
             metadata=metadata,
-        ), MetricsCapture():
-            method = functools.partial(
-                api.batch_write,
-                request=request,
-                metadata=metadata,
-            )
+        ) as span, MetricsCapture():
+            attempt = AtomicCounter(0)
+            nth_request = getattr(database, "_next_nth_request", 0)
+
+            def wrapped_method(*args, **kwargs):
+                method = functools.partial(
+                    api.batch_write,
+                    request=request,
+                    metadata=database.metadata_with_request_id(
+                        nth_request,
+                        attempt.increment(),
+                        metadata,
+                        span,
+                    ),
+                )
+                return method(*args, **kwargs)
+
             response = _retry(
-                method,
+                wrapped_method,
                 allowed_exceptions={
                     InternalServerError: _check_rst_stream_error,
                 },

--- a/google/cloud/spanner_v1/database.py
+++ b/google/cloud/spanner_v1/database.py
@@ -462,13 +462,19 @@ class Database(object):
 
         return self._spanner_api
 
-    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+    def metadata_with_request_id(
+        self, nth_request, nth_attempt, prior_metadata=[], span=None
+    ):
+        if span is None:
+            span = get_current_span()
+
         return _metadata_with_request_id(
             self._nth_client_id,
             self._channel_id,
             nth_request,
             nth_attempt,
             prior_metadata,
+            span,
         )
 
     def __eq__(self, other):
@@ -762,6 +768,7 @@ class Database(object):
                             self._next_nth_request,
                             1,
                             metadata,
+                            span,
                         ),
                     )
 

--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -257,7 +257,10 @@ class FixedSizePool(AbstractSessionPool):
                 resp = api.batch_create_sessions(
                     request=request,
                     metadata=database.metadata_with_request_id(
-                        database._next_nth_request, 1, metadata
+                        database._next_nth_request,
+                        1,
+                        metadata,
+                        span,
                     ),
                 )
 
@@ -564,7 +567,10 @@ class PingingPool(AbstractSessionPool):
                 resp = api.batch_create_sessions(
                     request=request,
                     metadata=database.metadata_with_request_id(
-                        database._next_nth_request, 1, metadata
+                        database._next_nth_request,
+                        1,
+                        metadata,
+                        span,
                     ),
                 )
 

--- a/google/cloud/spanner_v1/request_id_header.py
+++ b/google/cloud/spanner_v1/request_id_header.py
@@ -33,10 +33,32 @@ def generate_rand_uint64():
 
 
 REQ_RAND_PROCESS_ID = generate_rand_uint64()
+X_GOOG_SPANNER_REQUEST_ID_SPAN_ATTR = "x_goog_spanner_request_id"
 
 
-def with_request_id(client_id, channel_id, nth_request, attempt, other_metadata=[]):
+def with_request_id(
+    client_id, channel_id, nth_request, attempt, other_metadata=[], span=None
+):
     req_id = f"{REQ_ID_VERSION}.{REQ_RAND_PROCESS_ID}.{client_id}.{channel_id}.{nth_request}.{attempt}"
     all_metadata = (other_metadata or []).copy()
     all_metadata.append((REQ_ID_HEADER_KEY, req_id))
+
+    if span is not None:
+        span.set_attribute(X_GOOG_SPANNER_REQUEST_ID_SPAN_ATTR, req_id)
+
     return all_metadata
+
+
+def parse_request_id(request_id_str):
+    splits = request_id_str.split(".")
+    version, rand_process_id, client_id, channel_id, nth_request, nth_attempt = list(
+        map(lambda v: int(v), splits)
+    )
+    return (
+        version,
+        rand_process_id,
+        client_id,
+        channel_id,
+        nth_request,
+        nth_attempt,
+    )

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -167,11 +167,14 @@ class Session(object):
             self._labels,
             observability_options=observability_options,
             metadata=metadata,
-        ), MetricsCapture():
+        ) as span, MetricsCapture():
             session_pb = api.create_session(
                 request=request,
                 metadata=self._database.metadata_with_request_id(
-                    self._database._next_nth_request, 1, metadata
+                    self._database._next_nth_request,
+                    1,
+                    metadata,
+                    span,
                 ),
             )
         self._session_id = session_pb.name.split("/")[-1]
@@ -218,7 +221,10 @@ class Session(object):
                 api.get_session(
                     name=self.name,
                     metadata=database.metadata_with_request_id(
-                        database._next_nth_request, 1, metadata
+                        database._next_nth_request,
+                        1,
+                        metadata,
+                        span,
                     ),
                 )
                 if span:
@@ -263,11 +269,14 @@ class Session(object):
             },
             observability_options=observability_options,
             metadata=metadata,
-        ), MetricsCapture():
+        ) as span, MetricsCapture():
             api.delete_session(
                 name=self.name,
                 metadata=database.metadata_with_request_id(
-                    database._next_nth_request, 1, metadata
+                    database._next_nth_request,
+                    1,
+                    metadata,
+                    span,
                 ),
             )
 

--- a/google/cloud/spanner_v1/testing/interceptors.py
+++ b/google/cloud/spanner_v1/testing/interceptors.py
@@ -17,6 +17,7 @@ import threading
 
 from grpc_interceptor import ClientInterceptor
 from google.api_core.exceptions import Aborted
+from google.cloud.spanner_v1.request_id_header import parse_request_id
 
 
 class MethodCountInterceptor(ClientInterceptor):
@@ -119,18 +120,3 @@ class XGoogRequestIDHeaderInterceptor(ClientInterceptor):
     def reset(self):
         self._stream_req_segments.clear()
         self._unary_req_segments.clear()
-
-
-def parse_request_id(request_id_str):
-    splits = request_id_str.split(".")
-    version, rand_process_id, client_id, channel_id, nth_request, nth_attempt = list(
-        map(lambda v: int(v), splits)
-    )
-    return (
-        version,
-        rand_process_id,
-        client_id,
-        channel_id,
-        nth_request,
-        nth_attempt,
-    )

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -191,7 +191,10 @@ class Transaction(_SnapshotBase, _BatchBase):
                     session=self._session.name,
                     options=txn_options,
                     metadata=database.metadata_with_request_id(
-                        nth_request, attempt.increment(), metadata
+                        nth_request,
+                        attempt.increment(),
+                        metadata,
+                        span,
                     ),
                 )
                 return method(*args, **kwargs)
@@ -232,7 +235,7 @@ class Transaction(_SnapshotBase, _BatchBase):
                 self._session,
                 observability_options=observability_options,
                 metadata=metadata,
-            ), MetricsCapture():
+            ) as span, MetricsCapture():
                 attempt = AtomicCounter(0)
                 nth_request = database._next_nth_request
 
@@ -243,7 +246,10 @@ class Transaction(_SnapshotBase, _BatchBase):
                         session=self._session.name,
                         transaction_id=self._transaction_id,
                         metadata=database.metadata_with_request_id(
-                            nth_request, attempt.value, metadata
+                            nth_request,
+                            attempt.value,
+                            metadata,
+                            span,
                         ),
                     )
                     return method(*args, **kwargs)
@@ -334,7 +340,10 @@ class Transaction(_SnapshotBase, _BatchBase):
                     api.commit,
                     request=request,
                     metadata=database.metadata_with_request_id(
-                        nth_request, attempt.value, metadata
+                        nth_request,
+                        attempt.value,
+                        metadata,
+                        span,
                     ),
                 )
                 return method(*args, **kwargs)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -92,6 +92,7 @@ class OpenTelemetryBase(unittest.TestCase):
 
             self.assertEqual(span.name, name)
             self.assertEqual(span.status.status_code, status)
+            print("got_attributes\n", span.attributes, "vs\n", attributes)
             self.assertEqual(dict(span.attributes), attributes)
 
     def assertSpanEvents(self, name, wantEventNames=[], span=None):

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -92,7 +92,6 @@ class OpenTelemetryBase(unittest.TestCase):
 
             self.assertEqual(span.name, name)
             self.assertEqual(span.status.status_code, status)
-            print("got_attributes\n", span.attributes, "vs\n", attributes)
             self.assertEqual(dict(span.attributes), attributes)
 
     def assertSpanEvents(self, name, wantEventNames=[], span=None):

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -3241,6 +3241,10 @@ class TestMutationGroupsCheckout(_BaseTest):
             metadata=[
                 ("google-cloud-resource-prefix", database.name),
                 ("x-goog-spanner-route-to-leader", "true"),
+                (
+                    "x-goog-spanner-request-id",
+                    f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1",
+                ),
             ],
         )
 
@@ -3405,13 +3409,16 @@ class _Database(object):
     def _next_nth_request(self):
         return self._nth_request.increment()
 
-    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+    def metadata_with_request_id(
+        self, nth_request, nth_attempt, prior_metadata=[], span=None
+    ):
         return _metadata_with_request_id(
             self._nth_client_id,
             self._channel_id,
             nth_request,
             nth_attempt,
             prior_metadata,
+            span,
         )
 
     @property

--- a/tests/unit/test_spanner.py
+++ b/tests/unit/test_spanner.py
@@ -1264,13 +1264,16 @@ class _Database(object):
     def _nth_client_id(self):
         return self._instance._client._nth_client_id
 
-    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+    def metadata_with_request_id(
+        self, nth_request, nth_attempt, prior_metadata=[], span=None
+    ):
         return _metadata_with_request_id(
             self._nth_client_id,
             self._channel_id,
             nth_request,
             nth_attempt,
             prior_metadata,
+            span,
         )
 
     @property

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -172,10 +172,13 @@ class TestTransaction(OpenTelemetryBase):
         with self.assertRaises(RuntimeError):
             transaction.begin()
 
+        req_id = f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1"
         self.assertSpanAttributes(
             "CloudSpanner.Transaction.begin",
             status=StatusCode.ERROR,
-            attributes=TestTransaction.BASE_ATTRIBUTES,
+            attributes=dict(
+                TestTransaction.BASE_ATTRIBUTES, x_goog_spanner_request_id=req_id
+            ),
         )
 
     def test_begin_ok(self):
@@ -197,6 +200,7 @@ class TestTransaction(OpenTelemetryBase):
         session_id, txn_options, metadata = api._begun
         self.assertEqual(session_id, session.name)
         self.assertTrue(type(txn_options).pb(txn_options).HasField("read_write"))
+        req_id = f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1"
         self.assertEqual(
             metadata,
             [
@@ -204,13 +208,16 @@ class TestTransaction(OpenTelemetryBase):
                 ("x-goog-spanner-route-to-leader", "true"),
                 (
                     "x-goog-spanner-request-id",
-                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                    req_id,
                 ),
             ],
         )
 
         self.assertSpanAttributes(
-            "CloudSpanner.Transaction.begin", attributes=TestTransaction.BASE_ATTRIBUTES
+            "CloudSpanner.Transaction.begin",
+            attributes=dict(
+                TestTransaction.BASE_ATTRIBUTES, x_goog_spanner_request_id=req_id
+            ),
         )
 
     def test_begin_w_retry(self):
@@ -280,10 +287,13 @@ class TestTransaction(OpenTelemetryBase):
 
         self.assertFalse(transaction.rolled_back)
 
+        req_id = f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1"
         self.assertSpanAttributes(
             "CloudSpanner.Transaction.rollback",
             status=StatusCode.ERROR,
-            attributes=TestTransaction.BASE_ATTRIBUTES,
+            attributes=dict(
+                TestTransaction.BASE_ATTRIBUTES, x_goog_spanner_request_id=req_id
+            ),
         )
 
     def test_rollback_ok(self):
@@ -305,6 +315,7 @@ class TestTransaction(OpenTelemetryBase):
         session_id, txn_id, metadata = api._rolled_back
         self.assertEqual(session_id, session.name)
         self.assertEqual(txn_id, self.TRANSACTION_ID)
+        req_id = f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1"
         self.assertEqual(
             metadata,
             [
@@ -312,14 +323,16 @@ class TestTransaction(OpenTelemetryBase):
                 ("x-goog-spanner-route-to-leader", "true"),
                 (
                     "x-goog-spanner-request-id",
-                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                    req_id,
                 ),
             ],
         )
 
         self.assertSpanAttributes(
             "CloudSpanner.Transaction.rollback",
-            attributes=TestTransaction.BASE_ATTRIBUTES,
+            attributes=dict(
+                TestTransaction.BASE_ATTRIBUTES, x_goog_spanner_request_id=req_id
+            ),
         )
 
     def test_commit_not_begun(self):
@@ -430,10 +443,15 @@ class TestTransaction(OpenTelemetryBase):
 
         self.assertIsNone(transaction.committed)
 
+        req_id = f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1"
         self.assertSpanAttributes(
             "CloudSpanner.Transaction.commit",
             status=StatusCode.ERROR,
-            attributes=dict(TestTransaction.BASE_ATTRIBUTES, num_mutations=1),
+            attributes=dict(
+                TestTransaction.BASE_ATTRIBUTES,
+                num_mutations=1,
+                x_goog_spanner_request_id=req_id,
+            ),
         )
 
     def _commit_helper(
@@ -500,6 +518,7 @@ class TestTransaction(OpenTelemetryBase):
         self.assertEqual(session_id, session.name)
         self.assertEqual(txn_id, self.TRANSACTION_ID)
         self.assertEqual(mutations, transaction._mutations)
+        req_id = f"1.{REQ_RAND_PROCESS_ID}.{database._nth_client_id}.{database._channel_id}.1.1"
         self.assertEqual(
             metadata,
             [
@@ -507,7 +526,7 @@ class TestTransaction(OpenTelemetryBase):
                 ("x-goog-spanner-route-to-leader", "true"),
                 (
                     "x-goog-spanner-request-id",
-                    f"1.{REQ_RAND_PROCESS_ID}.{_Client.NTH_CLIENT.value}.1.1.1",
+                    req_id,
                 ),
             ],
         )
@@ -521,6 +540,7 @@ class TestTransaction(OpenTelemetryBase):
             attributes=dict(
                 TestTransaction.BASE_ATTRIBUTES,
                 num_mutations=len(transaction._mutations),
+                x_goog_spanner_request_id=req_id,
             ),
         )
 
@@ -1069,13 +1089,16 @@ class _Database(object):
     def _nth_client_id(self):
         return self._instance._client._nth_client_id
 
-    def metadata_with_request_id(self, nth_request, nth_attempt, prior_metadata=[]):
+    def metadata_with_request_id(
+        self, nth_request, nth_attempt, prior_metadata=[], span=None
+    ):
         return _metadata_with_request_id(
             self._nth_client_id,
             self._channel_id,
             nth_request,
             nth_attempt,
             prior_metadata,
+            span,
         )
 
     @property


### PR DESCRIPTION
This change is effectively 3/3 of the work to complete x-goog-spanner-request-id propagation. While here instrumented batch_write as well to send over the header too.

Updates googleapis/google-cloud-python#15905