### PR TITLE
feat: Add support for multiplexed sessions - read/write

### DIFF
--- a/google/cloud/spanner_v1/database_sessions_manager.py
+++ b/google/cloud/spanner_v1/database_sessions_manager.py
@@ -86,16 +86,10 @@ class DatabaseSessionsManager(object):
         :returns: a session for the given transaction type.
         """
 
-        use_multiplexed = self._use_multiplexed(transaction_type)
-
-        # TODO multiplexed: enable for read/write transactions
-        if use_multiplexed and transaction_type == TransactionType.READ_WRITE:
-            raise NotImplementedError(
-                f"Multiplexed sessions are not yet supported for {transaction_type} transactions."
-            )
-
         session = (
-            self._get_multiplexed_session() if use_multiplexed else self._pool.get()
+            self._get_multiplexed_session()
+            if self._use_multiplexed(transaction_type)
+            else self._pool.get()
         )
 
         add_span_event(

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -74,9 +74,6 @@ class Session(object):
         self._database = database
         self._session_id: Optional[str] = None
 
-        # TODO multiplexed - remove
-        self._transaction: Optional[Transaction] = None
-
         if labels is None:
             labels = {}
 
@@ -467,23 +464,19 @@ class Session(object):
 
         return Batch(self)
 
-    def transaction(self):
+    # TODO multiplexed - deprecate
+    def transaction(self) -> Transaction:
         """Create a transaction to perform a set of reads with shared staleness.
 
         :rtype: :class:`~google.cloud.spanner_v1.transaction.Transaction`
         :returns: a transaction bound to this session
+
         :raises ValueError: if the session has not yet been created.
         """
         if self._session_id is None:
             raise ValueError("Session has not been created.")
 
-        # TODO multiplexed - remove
-        if self._transaction is not None:
-            self._transaction.rolled_back = True
-            self._transaction = None
-
-        txn = self._transaction = Transaction(self)
-        return txn
+        return Transaction(self)
 
     def run_in_transaction(self, func, *args, **kw):
         """Perform a unit of work in a transaction, retrying on abort.
@@ -528,42 +521,36 @@ class Session(object):
         )
         isolation_level = kw.pop("isolation_level", None)
 
-        attempts = 0
+        database = self._database
+        log_commit_stats = database.log_commit_stats
 
-        observability_options = getattr(self._database, "observability_options", None)
         with trace_call(
             "CloudSpanner.Session.run_in_transaction",
             self,
-            observability_options=observability_options,
+            observability_options=getattr(database, "observability_options", None),
         ) as span, MetricsCapture():
-            while True:
-                # TODO multiplexed - remove
-                if self._transaction is None:
-                    txn = self.transaction()
-                    txn.transaction_tag = transaction_tag
-                    txn.exclude_txn_from_change_streams = (
-                        exclude_txn_from_change_streams
-                    )
-                    txn.isolation_level = isolation_level
-                else:
-                    txn = self._transaction
+            attempts: int = 0
 
-                span_attributes = dict()
+            while True:
+                # [A] Build transaction
+                # ---------------------
+
+                txn = self.transaction()
+                txn.transaction_tag = transaction_tag
+                txn.exclude_txn_from_change_streams = exclude_txn_from_change_streams
+                txn.isolation_level = isolation_level
+
+                # [B] Run user operation
+                # ----------------------
+
+                attempts += 1
+                span_attributes = dict(attempt=attempts)
 
                 try:
-                    attempts += 1
-                    span_attributes["attempt"] = attempts
-                    txn_id = getattr(txn, "_transaction_id", "") or ""
-                    if txn_id:
-                        span_attributes["transaction.id"] = txn_id
-
                     return_value = func(txn, *args, **kw)
 
                 # TODO multiplexed: store previous transaction ID.
                 except Aborted as exc:
-                    # TODO multiplexed - remove
-                    self._transaction = None
-
                     if span:
                         delay_seconds = _get_retry_delay(
                             exc.errors[0],
@@ -582,16 +569,15 @@ class Session(object):
                         exc, deadline, attempts, default_retry_delay=default_retry_delay
                     )
                     continue
-                except GoogleAPICallError:
-                    # TODO multiplexed - remove
-                    self._transaction = None
 
+                except GoogleAPICallError:
                     add_span_event(
                         span,
                         "User operation failed due to GoogleAPICallError, not retrying",
                         span_attributes,
                     )
                     raise
+
                 except Exception:
                     add_span_event(
                         span,
@@ -601,16 +587,17 @@ class Session(object):
                     txn.rollback()
                     raise
 
+                # [C] Commit transaction
+                # ----------------------
+
                 try:
                     txn.commit(
-                        return_commit_stats=self._database.log_commit_stats,
+                        return_commit_stats=log_commit_stats,
                         request_options=commit_request_options,
                         max_commit_delay=max_commit_delay,
                     )
-                except Aborted as exc:
-                    # TODO multiplexed - remove
-                    self._transaction = None
 
+                except Aborted as exc:
                     if span:
                         delay_seconds = _get_retry_delay(
                             exc.errors[0],
@@ -621,7 +608,7 @@ class Session(object):
                         attributes.update(span_attributes)
                         add_span_event(
                             span,
-                            "Transaction got aborted during commit, retrying afresh",
+                            "Transaction was aborted during commit, retrying",
                             attributes,
                         )
 
@@ -629,9 +616,6 @@ class Session(object):
                         exc, deadline, attempts, default_retry_delay=default_retry_delay
                     )
                 except GoogleAPICallError:
-                    # TODO multiplexed - remove
-                    self._transaction = None
-
                     add_span_event(
                         span,
                         "Transaction.commit failed due to GoogleAPICallError, not retrying",
@@ -639,8 +623,8 @@ class Session(object):
                     )
                     raise
                 else:
-                    if self._database.log_commit_stats and txn.commit_stats:
-                        self._database.logger.info(
+                    if log_commit_stats and txn.commit_stats:
+                        database.logger.info(
                             "CommitStats: {}".format(txn.commit_stats),
                             extra={"commit_stats": txn.commit_stats},
                         )

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -537,17 +537,11 @@ class Session(object):
             previous_transaction_id: Optional[bytes] = None
 
             while True:
-                # [A] Build transaction
-                # ---------------------
-
                 txn = self.transaction()
                 txn.transaction_tag = transaction_tag
                 txn.exclude_txn_from_change_streams = exclude_txn_from_change_streams
                 txn.isolation_level = isolation_level
                 txn._previous_transaction_id = previous_transaction_id
-
-                # [B] Run user operation
-                # ----------------------
 
                 attempts += 1
                 span_attributes = dict(attempt=attempts)
@@ -592,9 +586,6 @@ class Session(object):
                     )
                     txn.rollback()
                     raise
-
-                # [C] Commit transaction
-                # ----------------------
 
                 try:
                     txn.commit(

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -70,6 +70,12 @@ class Transaction(_SnapshotBase, _BatchBase):
         super(Transaction, self).__init__(session)
         self.rolled_back: bool = False
 
+        # If this transaction is used to retry a previous aborted transaction, the
+        # identifier for that transaction is used to increase the lock order of the new
+        # transaction (see :meth:`_build_transaction_options_pb`). This attribute should
+        # only be set by :meth:`~google.cloud.spanner_v1.session.Session.run_in_transaction`.
+        self._previous_transaction_id: Optional[bytes] = None
+
     def _build_transaction_options_pb(self) -> TransactionOptions:
         """Builds and returns transaction options for this transaction.
 
@@ -82,7 +88,9 @@ class Transaction(_SnapshotBase, _BatchBase):
         )
 
         merge_transaction_options = TransactionOptions(
-            read_write=TransactionOptions.ReadWrite(),
+            read_write=TransactionOptions.ReadWrite(
+                multiplexed_session_previous_transaction_id=self._previous_transaction_id
+            ),
             exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
             isolation_level=self.isolation_level,
         )

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -68,10 +68,6 @@ class Transaction(_SnapshotBase, _BatchBase):
     _read_only: bool = False
 
     def __init__(self, session):
-        # TODO multiplexed - remove
-        if session._transaction is not None:
-            raise ValueError("Session has existing transaction.")
-
         super(Transaction, self).__init__(session)
         self.rolled_back: bool = False
 
@@ -197,9 +193,6 @@ class Transaction(_SnapshotBase, _BatchBase):
                 )
 
         self.rolled_back = True
-
-        # TODO multiplexed - remove
-        self._session._transaction = None
 
     def commit(
         self, return_commit_stats=False, request_options=None, max_commit_delay=None
@@ -338,9 +331,6 @@ class Transaction(_SnapshotBase, _BatchBase):
         self.committed = commit_response_pb.commit_timestamp
         if return_commit_stats:
             self.commit_stats = commit_response_pb.commit_stats
-
-        # TODO multiplexed - remove
-        self._session._transaction = None
 
         return self.committed
 

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -70,11 +70,11 @@ class Transaction(_SnapshotBase, _BatchBase):
         super(Transaction, self).__init__(session)
         self.rolled_back: bool = False
 
-        # If this transaction is used to retry a previous aborted transaction, the
-        # identifier for that transaction is used to increase the lock order of the new
-        # transaction (see :meth:`_build_transaction_options_pb`). This attribute should
-        # only be set by :meth:`~google.cloud.spanner_v1.session.Session.run_in_transaction`.
-        self._previous_transaction_id: Optional[bytes] = None
+        # If this transaction is used to retry a previous aborted transaction with a
+        # multiplexed session, the identifier for that transaction is used to increase
+        # the lock order of the new transaction (see :meth:`_build_transaction_options_pb`).
+        # This attribute should only be set by :meth:`~google.cloud.spanner_v1.session.Session.run_in_transaction`.
+        self._multiplexed_session_previous_transaction_id: Optional[bytes] = None
 
     def _build_transaction_options_pb(self) -> TransactionOptions:
         """Builds and returns transaction options for this transaction.
@@ -89,7 +89,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         merge_transaction_options = TransactionOptions(
             read_write=TransactionOptions.ReadWrite(
-                multiplexed_session_previous_transaction_id=self._previous_transaction_id
+                multiplexed_session_previous_transaction_id=self._multiplexed_session_previous_transaction_id
             ),
             exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
             isolation_level=self.isolation_level,

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -35,7 +35,6 @@ from google.cloud.spanner_v1 import (
 )
 from google.cloud.spanner_v1 import ExecuteBatchDmlRequest
 from google.cloud.spanner_v1 import ExecuteSqlRequest
-from google.cloud.spanner_v1 import TransactionSelector
 from google.cloud.spanner_v1 import TransactionOptions
 from google.cloud.spanner_v1._helpers import AtomicCounter
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
@@ -71,27 +70,27 @@ class Transaction(_SnapshotBase, _BatchBase):
         super(Transaction, self).__init__(session)
         self.rolled_back: bool = False
 
-    def _make_txn_selector(self):
-        """Helper for :meth:`read`.
+    def _build_transaction_options_pb(self) -> TransactionOptions:
+        """Builds and returns transaction options for this transaction.
 
-        :rtype: :class:`~.transaction_pb2.TransactionSelector`
-        :returns: a selector configured for read-write transaction semantics.
+        :rtype: :class:`~.transaction_pb2.TransactionOptions`
+        :returns: transaction options for this transaction.
         """
 
-        if self._transaction_id is None:
-            txn_options = TransactionOptions(
-                read_write=TransactionOptions.ReadWrite(),
-                exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
-                isolation_level=self.isolation_level,
-            )
+        default_transaction_options = (
+            self._session._database.default_transaction_options.default_read_write_transaction_options
+        )
 
-            txn_options = _merge_Transaction_Options(
-                self._session._database.default_transaction_options.default_read_write_transaction_options,
-                txn_options,
-            )
-            return TransactionSelector(begin=txn_options)
-        else:
-            return TransactionSelector(id=self._transaction_id)
+        merge_transaction_options = TransactionOptions(
+            read_write=TransactionOptions.ReadWrite(),
+            exclude_txn_from_change_streams=self.exclude_txn_from_change_streams,
+            isolation_level=self.isolation_level,
+        )
+
+        return _merge_Transaction_Options(
+            defaultTransactionOptions=default_transaction_options,
+            mergeTransactionOptions=merge_transaction_options,
+        )
 
     def _execute_request(
         self,
@@ -118,7 +117,7 @@ class Transaction(_SnapshotBase, _BatchBase):
             raise ValueError("Transaction already rolled back.")
 
         session = self._session
-        transaction = self._make_txn_selector()
+        transaction = self._build_transaction_selector_pb()
         request.transaction = transaction
 
         with trace_call(
@@ -469,7 +468,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         execute_sql_request = ExecuteSqlRequest(
             session=session.name,
-            transaction=self._make_txn_selector(),
+            transaction=self._build_transaction_selector_pb(),
             sql=dml,
             params=params_pb,
             param_types=param_types,
@@ -617,7 +616,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
         execute_batch_dml_request = ExecuteBatchDmlRequest(
             session=session.name,
-            transaction=self._make_txn_selector(),
+            transaction=self._build_transaction_selector_pb(),
             statements=parsed,
             seqno=seqno,
             request_options=request_options,

--- a/tests/_builders.py
+++ b/tests/_builders.py
@@ -172,6 +172,19 @@ def build_session(**kwargs: Mapping) -> Session:
     return Session(**kwargs)
 
 
+def build_snapshot(**kwargs):
+    """Builds and returns a snapshot for testing using the given arguments.
+    If a required argument is not provided, a default value will be used."""
+
+    session = kwargs.pop("session", build_session())
+
+    # Ensure session exists.
+    if session.session_id is None:
+        session._session_id = _SESSION_ID
+
+    return session.snapshot(**kwargs)
+
+
 def build_transaction(session=None) -> Transaction:
     """Builds and returns a transaction for testing using the given arguments.
     If a required argument is not provided, a default value will be used."""

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from threading import Lock
 from typing import Mapping
 from datetime import timedelta
 
@@ -36,6 +37,7 @@ from google.cloud.spanner_v1._helpers import (
 )
 from google.cloud.spanner_v1.batch import _make_write_pb
 from google.cloud.spanner_v1.database import Database
+from google.cloud.spanner_v1.transaction import Transaction
 from google.cloud.spanner_v1.request_id_header import (
     REQ_RAND_PROCESS_ID,
     build_request_id,
@@ -114,21 +116,28 @@ class TestTransaction(OpenTelemetryBase):
         return mock.create_autospec(SpannerClient, instance=True)
 
     def test_ctor_defaults(self):
-        session = _Session()
-        transaction = self._make_one(session)
-        self.assertIs(transaction._session, session)
-        self.assertIsNone(transaction._transaction_id)
-        self.assertIsNone(transaction.committed)
-        self.assertFalse(transaction.rolled_back)
+        session = build_session()
+        transaction = Transaction(session=session)
+
+        # Attributes from _SessionWrapper
+        self.assertEqual(transaction._session, session)
+
+        # Attributes from _SnapshotBase
+        self.assertFalse(transaction._read_only)
         self.assertTrue(transaction._multi_use)
         self.assertEqual(transaction._execute_sql_request_count, 0)
+        self.assertEqual(transaction._read_request_count, 0)
+        self.assertIsNone(transaction._transaction_id)
+        self.assertIsNone(transaction._precommit_token)
+        self.assertIsInstance(transaction._lock, type(Lock()))
 
-    def test__make_txn_selector(self):
-        session = _Session()
-        transaction = self._make_one(session)
-        transaction._transaction_id = TRANSACTION_ID
-        selector = transaction._make_txn_selector()
-        self.assertEqual(selector.id, TRANSACTION_ID)
+        # Attributes from _BatchBase
+        self.assertEqual(transaction._mutations, [])
+        self.assertIsNone(transaction._precommit_token)
+        self.assertIsNone(transaction.committed)
+        self.assertIsNone(transaction.commit_stats)
+
+        self.assertFalse(transaction.rolled_back)
 
     def test_begin_already_rolled_back(self):
         session = _Session()
@@ -219,7 +228,6 @@ class TestTransaction(OpenTelemetryBase):
         transaction.rollback()
 
         self.assertTrue(transaction.rolled_back)
-        self.assertIsNone(session._transaction)
 
         session_id, txn_id, metadata = api._rolled_back
         self.assertEqual(session_id, session.name)

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -113,12 +113,6 @@ class TestTransaction(OpenTelemetryBase):
 
         return mock.create_autospec(SpannerClient, instance=True)
 
-    def test_ctor_session_w_existing_txn(self):
-        session = _Session()
-        session._transaction = object()
-        with self.assertRaises(ValueError):
-            self._make_one(session)
-
     def test_ctor_defaults(self):
         session = _Session()
         transaction = self._make_one(session)
@@ -434,7 +428,6 @@ class TestTransaction(OpenTelemetryBase):
 
         # Verify transaction state.
         self.assertEqual(transaction.committed, commit_timestamp)
-        self.assertIsNone(session._transaction)
 
         if return_commit_stats:
             self.assertEqual(transaction.commit_stats.mutation_count, 4)


### PR DESCRIPTION
feat: Add support for multiplexed sessions:
- Support multiplexed sessions for read/write transactions.
- Remove `Session._transaction` attribute.
- Refactor logic for creating transaction selector to base class.
- Add previous commit ID for transaction using `run_in_transaction`.
