### PR TITLE
tests: update default runtime used for tests

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -8,7 +8,7 @@ branchProtectionRules:
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
     - 'Kokoro'
-    - 'Kokoro system-3.8'
+    - 'Kokoro system-3.12'
     - 'cla/google'
     - 'Samples - Lint'
     - 'Samples - Python 3.8'

--- a/.kokoro/presubmit/integration-multiplexed-sessions-enabled.cfg
+++ b/.kokoro/presubmit/integration-multiplexed-sessions-enabled.cfg
@@ -3,7 +3,7 @@
 # Only run a subset of all nox sessions
 env_vars: {
     key: "NOX_SESSION"
-    value: "unit-3.8 unit-3.12 system-3.8"
+    value: "unit-3.9 unit-3.12 system-3.12"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/presubmit.cfg
+++ b/.kokoro/presubmit/presubmit.cfg
@@ -3,5 +3,5 @@
 # Only run a subset of all nox sessions
 env_vars: {
     key: "NOX_SESSION"
-    value: "unit-3.8 unit-3.12 cover docs docfx"
+    value: "unit-3.9 unit-3.12 cover docs docfx"
 }

--- a/.kokoro/presubmit/system-3.12.cfg
+++ b/.kokoro/presubmit/system-3.12.cfg
@@ -3,5 +3,5 @@
 # Only run this nox session.
 env_vars: {
     key: "NOX_SESSION"
-    value: "system-3.8"
+    value: "system-3.12"
 }

--- a/.kokoro/presubmit/system-3.8.cfg
+++ b/.kokoro/presubmit/system-3.8.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "system-3.8"
-}

--- a/.kokoro/presubmit/system-3.8.cfg
+++ b/.kokoro/presubmit/system-3.8.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system-3.8"
+}

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.12"
 
 DEFAULT_MOCK_SERVER_TESTS_PYTHON_VERSION = "3.12"
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,7 +108,9 @@ def lint(session):
     session.run("flake8", "google", "tests")
 
 
-@nox.session(python=DEFAULT_PYTHON_VERSION)
+# Use a python runtime which is available in the owlbot post processor here
+# https://github.com/googleapis/synthtool/blob/master/docker/owlbot/python/Dockerfile
+@nox.session(python=["3.10", DEFAULT_PYTHON_VERSION])
 def blacken(session):
     """Run black. Format code to uniform standard."""
     session.install(BLACK_VERSION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,7 +77,13 @@ SYSTEM_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 nox.options.sessions = [
-    "unit",
+    # TODO(https://github.com/googleapis/python-spanner/issues/1392):
+    # Remove or restore testing for Python 3.7/3.8
+    "unit-3.9",
+    "unit-3.10",
+    "unit-3.11",
+    "unit-3.12",
+    "unit-3.13",
     "system",
     "cover",
     "lint",

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,6 +35,8 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 DEFAULT_PYTHON_VERSION = "3.12"
 
 DEFAULT_MOCK_SERVER_TESTS_PYTHON_VERSION = "3.12"
+SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.12"]
+
 UNIT_TEST_PYTHON_VERSIONS: List[str] = [
     "3.7",
     "3.8",
@@ -60,7 +62,6 @@ UNIT_TEST_DEPENDENCIES: List[str] = []
 UNIT_TEST_EXTRAS: List[str] = []
 UNIT_TEST_EXTRAS_BY_PYTHON: Dict[str, List[str]] = {}
 
-SYSTEM_TEST_PYTHON_VERSIONS: List[str] = ["3.8"]
 SYSTEM_TEST_STANDARD_DEPENDENCIES: List[str] = [
     "mock",
     "pytest",

--- a/noxfile.py
+++ b/noxfile.py
@@ -330,6 +330,9 @@ def system(session, protobuf_implementation, database_dialect):
             "Only run system tests on real Spanner with one protobuf implementation to speed up the build"
         )
 
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13"):
+        session.skip("cpp implementation is not supported in python 3.11+")
+
     # Install pyopenssl for mTLS testing.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":
         session.install("pyopenssl")

--- a/noxfile.py
+++ b/noxfile.py
@@ -143,7 +143,7 @@ def format(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.install("docutils", "pygments")
+    session.install("docutils", "pygments", "setuptools>=79.0.1")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -258,4 +258,6 @@ s.replace("CONTRIBUTING.rst", "samples/snippets", "samples/samples")
 
 python.py_samples()
 
-s.shell.run(["nox", "-s", "blacken"], hide_output=False)
+# Use a python runtime which is available in the owlbot post processor here
+# https://github.com/googleapis/synthtool/blob/master/docker/owlbot/python/Dockerfile
+s.shell.run(["nox", "-s", "blacken-3.10"], hide_output=False)

--- a/owlbot.py
+++ b/owlbot.py
@@ -225,6 +225,7 @@ templated_files = common.py_library(
     cov_level=98,
     split_system_tests=True,
     system_test_extras=["tracing"],
+    system_test_python_versions=["3.12"]
 )
 s.move(
     templated_files,


### PR DESCRIPTION
This PR includes the following fixes to the test environment:

- Fix presubmits following the changes in https://github.com/googleapis/testing-infra-docker/pull/491 which removes setuptools which don't include a patch for CVE-2025-47273/CVE-2025-47273
- Move from Python 3.8 to Python 3.12 as the default runtime for most tests
- Remove `unit-3.7` / `unit-3.8` from the default nox session/presubmits. See https://github.com/googleapis/python-spanner/issues/1392 where we will follow up on this