### PR TITLE
tests: update constraints for python 3.9 testing

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -195,6 +195,7 @@ from google.cloud.spanner_v1.metrics.metrics_interceptor import MetricsIntercept
             "google/cloud/spanner_v1/__init__.py",
             "**/gapic_version.py",
             "testing/constraints-3.7.txt",
+            "testing/constraints-3.9.txt",
         ],
     )
 

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,7 +1,20 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
-grpc-google-iam-v1
+# Pin the version to the lower bound.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have google-cloud-foo==1.14.0
+google-api-core==1.34.0
+google-cloud-core==1.4.4
+grpc-google-iam-v1==0.12.4
+libcst==0.2.5
+proto-plus==1.22.0
+sqlparse==0.4.4
+opentelemetry-api==1.22.0
+opentelemetry-sdk==1.22.0
+opentelemetry-semantic-conventions==0.43b0
+protobuf==3.20.2
+deprecated==1.2.14
+grpc-interceptor==0.15.4
+google-cloud-monitoring==2.16.0
+mmh3==4.1.0


### PR DESCRIPTION
Since Python 3.7 is no longer being tested following https://github.com/googleapis/python-spanner/pull/1391 (see follow up in https://github.com/googleapis/python-spanner/issues/1392), we should update the constraints files for python 3.9 testing to ensure that the minimum versions of dependencies stated in setup.py are compatible.

https://github.com/googleapis/python-spanner/blob/f81fbd5ba135194d06987f98e1b031c0fd846979/testing/constraints-3.7.txt#L1-L6