### PR TITLE
chore: make precommit token check emulator-proof

### DIFF
--- a/.github/workflows/integration-tests-against-emulator.yaml
+++ b/.github/workflows/integration-tests-against-emulator.yaml
@@ -10,7 +10,7 @@ jobs:
 
     services:
       emulator:
-        image: gcr.io/cloud-spanner-emulator/emulator:1.5.37
+        image: gcr.io/cloud-spanner-emulator/emulator
         ports:
           - 9010:9010
           - 9020:9020

--- a/google/cloud/spanner_v1/snapshot.py
+++ b/google/cloud/spanner_v1/snapshot.py
@@ -133,7 +133,11 @@ def _restart_on_unavailable(
                 # Update the transaction from the response.
                 if transaction is not None:
                     transaction._update_for_result_set_pb(item)
-                if item.precommit_token is not None and transaction is not None:
+                if (
+                    item._pb is not None
+                    and item._pb.HasField("precommit_token")
+                    and transaction is not None
+                ):
                     transaction._update_for_precommit_token_pb(item.precommit_token)
 
                 if item.resume_token:
@@ -1029,7 +1033,7 @@ class _SnapshotBase(_SessionWrapper):
         if self._transaction_id is None and transaction_pb.id:
             self._transaction_id = transaction_pb.id
 
-        if transaction_pb.precommit_token:
+        if transaction_pb._pb.HasField("precommit_token"):
             self._update_for_precommit_token_pb_unsafe(transaction_pb.precommit_token)
 
     def _update_for_precommit_token_pb(

--- a/tests/system/test_database_api.py
+++ b/tests/system/test_database_api.py
@@ -569,7 +569,10 @@ def test_db_run_in_transaction_then_snapshot_execute_sql(shared_database):
         batch.delete(sd.TABLE, sd.ALL)
 
     def _unit_of_work(transaction, test):
-        rows = list(transaction.read(test.TABLE, test.COLUMNS, sd.ALL))
+        # TODO: Remove query and execute a read instead when the Emulator has been fixed
+        #       and returns pre-commit tokens for streaming read results.
+        rows = list(transaction.execute_sql(sd.SQL))
+        # rows = list(transaction.read(test.TABLE, test.COLUMNS, sd.ALL))
         assert rows == []
 
         transaction.insert_or_update(test.TABLE, test.COLUMNS, test.ROW_DATA)
@@ -882,7 +885,10 @@ def test_db_run_in_transaction_w_max_commit_delay(shared_database):
         batch.delete(sd.TABLE, sd.ALL)
 
     def _unit_of_work(transaction, test):
-        rows = list(transaction.read(test.TABLE, test.COLUMNS, sd.ALL))
+        # TODO: Remove query and execute a read instead when the Emulator has been fixed
+        #       and returns pre-commit tokens for streaming read results.
+        rows = list(transaction.execute_sql(sd.SQL))
+        # rows = list(transaction.read(test.TABLE, test.COLUMNS, sd.ALL))
         assert rows == []
 
         transaction.insert_or_update(test.TABLE, test.COLUMNS, test.ROW_DATA)

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -932,6 +932,8 @@ def test_transaction_read_and_insert_then_exception(sessions_database):
 def test_transaction_read_and_insert_or_update_then_commit(
     sessions_database,
     sessions_to_delete,
+    # TODO: Re-enable when the emulator returns pre-commit tokens for reads.
+    not_emulator,
 ):
     # [START spanner_test_dml_read_your_writes]
     sd = _sample_data
@@ -1586,7 +1588,11 @@ def _read_w_concurrent_update(transaction, pkey):
     transaction.update(COUNTERS_TABLE, COUNTERS_COLUMNS, [[pkey, value + 1]])
 
 
-def test_transaction_read_w_concurrent_updates(sessions_database):
+def test_transaction_read_w_concurrent_updates(
+    sessions_database,
+    # TODO: Re-enable when the Emulator returns pre-commit tokens for streaming reads.
+    not_emulator,
+):
     pkey = "read_w_concurrent_updates"
     _transaction_concurrency_helper(sessions_database, _read_w_concurrent_update, pkey)
 

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -158,6 +158,7 @@ class Test_restart_on_unavailable(OpenTelemetryBase):
             resume_token=resume_token,
             metadata=metadata,
             precommit_token=None,
+            _pb=None,
             spec=["value", "resume_token", "metadata", "precommit_token"],
         )
 

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -533,7 +533,7 @@ class TestTransaction(OpenTelemetryBase):
             )
             commit.assert_any_call(
                 request=expected_retry_request,
-                metadata=base_metadata,
+                metadata=expected_retry_metadata,
             )
 
         if not HAS_OPENTELEMETRY_INSTALLED:


### PR DESCRIPTION
The Emulator returns an empty pre-commit token when a commit is attempted
without a pre-commit token. This is different from not returning any
pre-commit token at all. The check for 'did the Commit return a pre-commit
token?' did not take this into account, which caused commits on the
Emulator that needed to be retried, not to be retried. This again caused
multiple test errors when running on the Emulator, as this would keep a
transaction present on the test database on the Emulator, and the Emulator
only supports one transaction at a time. These test failures went unnoticed,
because the test configuration for the Emulator had pinned the Emulator
version to 1.5.37, which did not support multiplexed sessions. This again
caused the tests to fall back to using regular sessions.

This change fixes the check for whether a pre-commit token was returned by
a Commit. It also unpins the Emulator version for the system tests using
default settings. This ensures that the tests actually use multiplexed
sessions.

See this failed test run from before making these changes (the only change for this test run was to use the latest emulator version, which triggered multiplexed sessions to be used): https://github.com/googleapis/python-spanner/actions/runs/16940453081/job/48007847941?pr=1402