### PR TITLE
docs: correct fine-grained access control link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,12 +253,13 @@ Connection API represents a wrap-around for Python Spanner API, written in accor
    result = cursor.fetchall()
 
 
-If using [fine-grained access controls](https://cloud.google.com/spanner/docs/access-with-fgac) you can pass a ``database_role`` argument to connect as that role:
+If using `fine-grained access controls`_ you can pass a ``database_role`` argument to connect as that role:
 
 .. code:: python
 
    connection = connect("instance-id", "database-id", database_role='your-role')
 
+.. _fine-grained access controls: https://cloud.google.com/spanner/docs/access-with-fgac
 
 Aborted Transactions Retry Mechanism
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The link to fine-grained access controls documentation is in markdown format rather than rst and doesn't render correctly on: https://github.com/googleapis/python-spanner?tab=readme-ov-file#connection-api
