### PR TITLE
fix(spanner): resolve TypeError in metrics resource detection

### DIFF
--- a/google/cloud/spanner_v1/metrics/spanner_metrics_tracer_factory.py
+++ b/google/cloud/spanner_v1/metrics/spanner_metrics_tracer_factory.py
@@ -169,4 +169,4 @@ class SpannerMetricsTracerFactory(MetricsTracerFactory):
         if GOOGLE_CLOUD_REGION_KEY not in resources.attributes:
             return GOOGLE_CLOUD_REGION_GLOBAL
         else:
-            return resources[GOOGLE_CLOUD_REGION_KEY]
+            return resources.attributes[GOOGLE_CLOUD_REGION_KEY]

--- a/google/cloud/spanner_v1/metrics/spanner_metrics_tracer_factory.py
+++ b/google/cloud/spanner_v1/metrics/spanner_metrics_tracer_factory.py
@@ -17,6 +17,7 @@
 
 from .metrics_tracer_factory import MetricsTracerFactory
 import os
+import logging
 from .constants import (
     SPANNER_SERVICE_NAME,
     GOOGLE_CLOUD_REGION_KEY,
@@ -33,9 +34,6 @@ try:
 
     import mmh3
 
-    # Override Resource detector logging to not warn when GCP resources are not detected
-    import logging
-
     logging.getLogger("opentelemetry.resourcedetector.gcp_resource_detector").setLevel(
         logging.ERROR
     )
@@ -47,6 +45,8 @@ except ImportError:  # pragma: NO COVER
 from .metrics_tracer import MetricsTracer
 from google.cloud.spanner_v1 import __version__
 from uuid import uuid4
+
+log = logging.getLogger(__name__)
 
 
 class SpannerMetricsTracerFactory(MetricsTracerFactory):
@@ -158,15 +158,23 @@ class SpannerMetricsTracerFactory(MetricsTracerFactory):
     def _get_location() -> str:
         """Get the location of the resource.
 
+        In case of any error during detection, this method will log a warning
+        and default to the "global" location.
+
         Returns:
             str: The location of the resource. If OpenTelemetry is not installed, returns a global region.
         """
         if not HAS_OPENTELEMETRY_INSTALLED:
             return GOOGLE_CLOUD_REGION_GLOBAL
-        detector = gcp_resource_detector.GoogleCloudResourceDetector()
-        resources = detector.detect()
+        try:
+            detector = gcp_resource_detector.GoogleCloudResourceDetector()
+            resources = detector.detect()
 
-        if GOOGLE_CLOUD_REGION_KEY not in resources.attributes:
-            return GOOGLE_CLOUD_REGION_GLOBAL
-        else:
-            return resources.attributes[GOOGLE_CLOUD_REGION_KEY]
+            if GOOGLE_CLOUD_REGION_KEY in resources.attributes:
+                return resources.attributes[GOOGLE_CLOUD_REGION_KEY]
+        except Exception as e:
+            log.warning(
+                "Failed to detect GCP resource location for Spanner metrics, defaulting to 'global'. Error: %s",
+                e,
+            )
+        return GOOGLE_CLOUD_REGION_GLOBAL


### PR DESCRIPTION
**Note**: fix(spanner): resolve TypeError in metrics resource detection

**Root cause:** 
The metrics tracer factory was attempting to access the `cloud.region` attribute directly from an OpenTelemetry `Resource` object using dictionary-style subscription (`resource['key']`).

However, the `Resource` object is not subscriptable. The correct way to access its attributes is through the `.attributes` property (`resource.attributes['key']`).

This change corrects the access pattern, resolving a `TypeError` that would crash applications upon `spanner.Client` initialization when built-in metrics were enabled in a GCP environment.


**Testing**

Tested by replicating the error locally using [this script](https://paste.googleplex.com/5874183288520704).


