### PR TITLE
feat(spanner): log client configuration at startup

### DIFF
--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -292,6 +292,36 @@ class Client(ClientWithProject):
         self._nth_client_id = Client.NTH_CLIENT.increment()
         self._nth_request = AtomicCounter(0)
 
+        self.host = "spanner.googleapis.com"
+        if self._emulator_host:
+            self.host = self._emulator_host
+        elif self._experimental_host:
+            self.host = self._experimental_host
+        elif self._client_options and self._client_options.api_endpoint:
+            self.host = self._client_options.api_endpoint
+
+        self._log_spanner_options()
+
+    def _log_spanner_options(self):
+        """Logs Spanner client options."""
+        log.info(
+            "Spanner options: \n"
+            "  Project ID: %s\n"
+            "  Host: %s\n"
+            "  Route to leader enabled: %s\n"
+            "  Directed read options: %s\n"
+            "  Default transaction options: %s\n"
+            "  Observability options: %s\n"
+            "  Built-in metrics enabled: %s",
+            self.project,
+            self.host,
+            self.route_to_leader_enabled,
+            self._directed_read_options,
+            self._default_transaction_options,
+            self._observability_options,
+            _get_spanner_enable_builtin_metrics_env(),
+        )
+
     @property
     def _next_nth_request(self):
         return self._nth_request.increment()

--- a/google/cloud/spanner_v1/client.py
+++ b/google/cloud/spanner_v1/client.py
@@ -75,6 +75,7 @@ from google.cloud.spanner_v1._helpers import AtomicCounter
 _CLIENT_INFO = client_info.ClientInfo(client_library_version=__version__)
 EMULATOR_ENV_VAR = "SPANNER_EMULATOR_HOST"
 SPANNER_DISABLE_BUILTIN_METRICS_ENV_VAR = "SPANNER_DISABLE_BUILTIN_METRICS"
+LOG_CLIENT_OPTIONS_ENV_VAR = "GOOGLE_CLOUD_SPANNER_ENABLE_LOG_CLIENT_OPTIONS"
 _EMULATOR_HOST_HTTP_SCHEME = (
     "%s contains a http scheme. When used with a scheme it may cause gRPC's "
     "DNS resolver to endlessly attempt to resolve. %s is intended to be used "
@@ -102,6 +103,10 @@ log = logging.getLogger(__name__)
 
 def _get_spanner_enable_builtin_metrics_env():
     return os.getenv(SPANNER_DISABLE_BUILTIN_METRICS_ENV_VAR) != "true"
+
+
+def _get_spanner_log_client_options_env():
+    return os.getenv(LOG_CLIENT_OPTIONS_ENV_VAR, "false").lower() == "true"
 
 
 class Client(ClientWithProject):
@@ -300,7 +305,8 @@ class Client(ClientWithProject):
         elif self._client_options and self._client_options.api_endpoint:
             self.host = self._client_options.api_endpoint
 
-        self._log_spanner_options()
+        if _get_spanner_log_client_options_env():
+            self._log_spanner_options()
 
     def _log_spanner_options(self):
         """Logs Spanner client options."""


### PR DESCRIPTION
This change introduces logging for Spanner client options upon initialization.

This allows customers to easily capture and inspect the configuration being used, which is valuable for debugging and verification.

This feature mirrors the existing logSpannerOptions functionality in the Java client, improving consistency across client libraries. https://github.com/googleapis/java-spanner/pull/4141