### PR TITLE
chore: librarian release pull request: 20251210T220651Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
 libraries:
   - id: google-cloud-spanner
-    version: 3.59.0
+    version: 3.60.0
     last_generated_commit: a17b84add8318f780fcc8a027815d5fee644b9f7
     apis:
       - path: google/spanner/admin/instance/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@
 
 [1]: https://pypi.org/project/google-cloud-spanner/#history
 
+## [3.60.0](https://github.com/googleapis/python-spanner/compare/v3.59.0...v3.60.0) (2025-12-10)
+
+
+### Documentation
+
+* Update description for the BatchCreateSessionsRequest and Session ([e08260fe24b62313d7964572eeb963eb8c3c923f](https://github.com/googleapis/python-spanner/commit/e08260fe24b62313d7964572eeb963eb8c3c923f))
+* Update description for the IsolationLevel ([e08260fe24b62313d7964572eeb963eb8c3c923f](https://github.com/googleapis/python-spanner/commit/e08260fe24b62313d7964572eeb963eb8c3c923f))
+
+
+### Features
+
+* make built-in metrics enabled by default (#1459) ([64aebe7e3ecfec756435f7d102b36f5a41f7cc52](https://github.com/googleapis/python-spanner/commit/64aebe7e3ecfec756435f7d102b36f5a41f7cc52))
+* Add Spanner location API (#1457) ([e08260fe24b62313d7964572eeb963eb8c3c923f](https://github.com/googleapis/python-spanner/commit/e08260fe24b62313d7964572eeb963eb8c3c923f))
+* Add Send and Ack mutations for Queues ([e08260fe24b62313d7964572eeb963eb8c3c923f](https://github.com/googleapis/python-spanner/commit/e08260fe24b62313d7964572eeb963eb8c3c923f))
+* Add QueryAdvisorResult for query plan ([e08260fe24b62313d7964572eeb963eb8c3c923f](https://github.com/googleapis/python-spanner/commit/e08260fe24b62313d7964572eeb963eb8c3c923f))
+* add cloud.region, request_tag and transaction_tag in span attributes (#1449) ([d37fb80a39aea859059ae7d85adc75095a6e14e6](https://github.com/googleapis/python-spanner/commit/d37fb80a39aea859059ae7d85adc75095a6e14e6))
+* Exposing AutoscalingConfig in InstancePartition ([8b6f154085543953556acde161a739414988b7f0](https://github.com/googleapis/python-spanner/commit/8b6f154085543953556acde161a739414988b7f0))
+* enable OpenTelemetry metrics and tracing by default (#1410) ([bb5095dfb615159a575933a332382ba93ba4bbd1](https://github.com/googleapis/python-spanner/commit/bb5095dfb615159a575933a332382ba93ba4bbd1))
+* add support for experimental host (#1452) ([9535e5e096f6ab53f2817af4fd7ac1fa2ca71660](https://github.com/googleapis/python-spanner/commit/9535e5e096f6ab53f2817af4fd7ac1fa2ca71660))
+
+
+### Bug Fixes
+
+* Provide Spanner Option to disable metrics (#1460) ([f1ebc43ba4c1ee3a8ee77ae4b0b2468937f06b71](https://github.com/googleapis/python-spanner/commit/f1ebc43ba4c1ee3a8ee77ae4b0b2468937f06b71))
+* Deprecate credentials_file argument ([8b6f154085543953556acde161a739414988b7f0](https://github.com/googleapis/python-spanner/commit/8b6f154085543953556acde161a739414988b7f0))
+* configure keepAlive time for gRPC TCP connections (#1448) ([efb2833e52e54b096e552a4d91f94b017ac733bb](https://github.com/googleapis/python-spanner/commit/efb2833e52e54b096e552a4d91f94b017ac733bb))
+
 ## [3.59.0](https://github.com/googleapis/python-spanner/compare/v3.58.0...v3.59.0) (2025-10-18)
 
 

--- a/google/cloud/spanner_admin_database_v1/gapic_version.py
+++ b/google/cloud/spanner_admin_database_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.59.0"  # {x-release-please-version}
+__version__ = "3.60.0"  # {x-release-please-version}

--- a/google/cloud/spanner_admin_instance_v1/gapic_version.py
+++ b/google/cloud/spanner_admin_instance_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.59.0"  # {x-release-please-version}
+__version__ = "3.60.0"  # {x-release-please-version}

--- a/google/cloud/spanner_dbapi/version.py
+++ b/google/cloud/spanner_dbapi/version.py
@@ -15,6 +15,6 @@
 import platform
 
 PY_VERSION = platform.python_version()
-__version__ = "3.59.0"
+__version__ = "3.60.0"
 VERSION = __version__
 DEFAULT_USER_AGENT = "gl-dbapi/" + VERSION

--- a/google/cloud/spanner_v1/gapic_version.py
+++ b/google/cloud/spanner_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.59.0"  # {x-release-please-version}
+__version__ = "3.60.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-database",
-    "version": "3.59.0"
+    "version": "3.60.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-instance",
-    "version": "3.59.0"
+    "version": "3.60.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.spanner.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner",
-    "version": "3.59.0"
+    "version": "3.60.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
<details><summary>google-cloud-spanner: 3.60.0</summary>

## [3.60.0](https://github.com/googleapis/python-spanner/compare/v3.59.0...v3.60.0) (2025-12-10)

### Features

* make built-in metrics enabled by default (#1459) ([64aebe7e](https://github.com/googleapis/python-spanner/commit/64aebe7e))

* Exposing AutoscalingConfig in InstancePartition ([8b6f1540](https://github.com/googleapis/python-spanner/commit/8b6f1540))

* add support for experimental host (#1452) ([9535e5e0](https://github.com/googleapis/python-spanner/commit/9535e5e0))

* enable OpenTelemetry metrics and tracing by default (#1410) ([bb5095df](https://github.com/googleapis/python-spanner/commit/bb5095df))

* add cloud.region, request_tag and transaction_tag in span attributes (#1449) ([d37fb80a](https://github.com/googleapis/python-spanner/commit/d37fb80a))

* Add QueryAdvisorResult for query plan (PiperOrigin-RevId: 832425466) ([e08260fe](https://github.com/googleapis/python-spanner/commit/e08260fe))

* Add Send and Ack mutations for Queues (PiperOrigin-RevId: 832425466) ([e08260fe](https://github.com/googleapis/python-spanner/commit/e08260fe))

* Add Spanner location API (#1457) (PiperOrigin-RevId: 833474957) ([e08260fe](https://github.com/googleapis/python-spanner/commit/e08260fe))

### Bug Fixes

* Deprecate credentials_file argument ([8b6f1540](https://github.com/googleapis/python-spanner/commit/8b6f1540))

* configure keepAlive time for gRPC TCP connections (#1448) ([efb2833e](https://github.com/googleapis/python-spanner/commit/efb2833e))

* Provide Spanner Option to disable metrics (#1460) ([f1ebc43b](https://github.com/googleapis/python-spanner/commit/f1ebc43b))

### Documentation

* Update description for the BatchCreateSessionsRequest and Session (PiperOrigin-RevId: 832425466) ([e08260fe](https://github.com/googleapis/python-spanner/commit/e08260fe))

* Update description for the IsolationLevel (PiperOrigin-RevId: 832425466) ([e08260fe](https://github.com/googleapis/python-spanner/commit/e08260fe))

</details>