### PR TITLE
fix: resolve pre-release dependency failures and sqlparse recursion

### DIFF
--- a/google/cloud/spanner_dbapi/parse_utils.py
+++ b/google/cloud/spanner_dbapi/parse_utils.py
@@ -233,6 +233,11 @@ def classify_statement(query, args=None):
     :rtype: ParsedStatement
     :returns: parsed statement attributes.
     """
+    # Check for RUN PARTITION command to avoid sqlparse processing it.
+    # sqlparse fails with "Maximum grouping depth exceeded" on long partition IDs.
+    if re.match(r"^\s*RUN\s+PARTITION\s+.+", query, re.IGNORECASE):
+        return client_side_statement_parser.parse_stmt(query.strip())
+
     # sqlparse will strip Cloud Spanner comments,
     # still, special commenting styles, like
     # PostgreSQL dollar quoted comments are not

--- a/noxfile.py
+++ b/noxfile.py
@@ -555,6 +555,9 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
         "google-cloud-testutils",
         # dependencies of google-cloud-testutils"
         "click",
+        # dependency of google-auth
+        "cffi",
+        "cryptography",
     ]
 
     for dep in prerel_deps:


### PR DESCRIPTION
1. add cryptography to prerelease dependencies
The prerelease dependency check installs packages with `--no-deps`, which causes `google-auth` to fail because its dependency `cryptography` and `cffi` is missing. This change explicitly adds `cryptography` and `cffi` to the `prerel_deps` list in `noxfile.py` to ensure it is installed during the test session.

2. bypass sqlparse for RUN PARTITION commands
Check for RUN PARTITION command to avoid sqlparse processing it. sqlparse fails with "Maximum grouping depth exceeded" on long partition IDs causing flakiness in system tests.