### PR TITLE
docs(spanner): snippet for setting read lock mode

### DIFF
--- a/samples/samples/requirements.txt
+++ b/samples/samples/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-spanner==3.57.0
+google-cloud-spanner==3.58.0
 futures==3.4.0; python_version < "3"

--- a/samples/samples/snippets_test.py
+++ b/samples/samples/snippets_test.py
@@ -993,8 +993,15 @@ def test_set_custom_timeout_and_retry(capsys, instance_id, sample_database):
 
 
 @pytest.mark.dependency(depends=["insert_data"])
-def test_isolated_level_options(capsys, instance_id, sample_database):
+def test_isolation_level_options(capsys, instance_id, sample_database):
     snippets.isolation_level_options(instance_id, sample_database.database_id)
+    out, _ = capsys.readouterr()
+    assert "1 record(s) updated." in out
+
+
+@pytest.mark.dependency(depends=["insert_data"])
+def test_read_lock_mode_options(capsys, instance_id, sample_database):
+    snippets.read_lock_mode_options(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()
     assert "1 record(s) updated." in out
 


### PR DESCRIPTION
Snippet shows how to set the read lock mode at the client-level and how to override the option at the transaction-level.
