### PR TITLE
chore: librarian release pull request: 20260112T142428Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-cloud-spanner
-    version: 3.61.0
+    version: 3.62.0
     last_generated_commit: a17b84add8318f780fcc8a027815d5fee644b9f7
     apis:
       - path: google/spanner/admin/instance/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 [1]: https://pypi.org/project/google-cloud-spanner/#history
 
+## [3.62.0](https://github.com/googleapis/python-spanner/compare/v3.61.0...v3.62.0) (2026-01-12)
+
+
+### Features
+
+* add uuid support (#1310) ([3b1792aad1d046b6ae1e5c982f5047289dffd95c](https://github.com/googleapis/python-spanner/commit/3b1792aad1d046b6ae1e5c982f5047289dffd95c))
+
+
+### Bug Fixes
+
+* resolve pre-release dependency failures and sqlparse recursion (#1472) ([9ec95b7df5e921112bd58b820722103177e0e5b6](https://github.com/googleapis/python-spanner/commit/9ec95b7df5e921112bd58b820722103177e0e5b6))
+* transaction_tag should be set on BeginTransactionRequest (#1463) ([3d3cea0b5afb414a506ab08eebae733d803f17ac](https://github.com/googleapis/python-spanner/commit/3d3cea0b5afb414a506ab08eebae733d803f17ac))
+
 ## [3.61.0](https://github.com/googleapis/python-spanner/compare/v3.60.0...v3.61.0) (2025-12-16)
 
 

--- a/google/cloud/spanner_admin_database_v1/gapic_version.py
+++ b/google/cloud/spanner_admin_database_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.61.0"  # {x-release-please-version}
+__version__ = "3.62.0"  # {x-release-please-version}

--- a/google/cloud/spanner_admin_instance_v1/gapic_version.py
+++ b/google/cloud/spanner_admin_instance_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.61.0"  # {x-release-please-version}
+__version__ = "3.62.0"  # {x-release-please-version}

--- a/google/cloud/spanner_dbapi/version.py
+++ b/google/cloud/spanner_dbapi/version.py
@@ -15,6 +15,6 @@
 import platform
 
 PY_VERSION = platform.python_version()
-__version__ = "3.61.0"
+__version__ = "3.62.0"
 VERSION = __version__
 DEFAULT_USER_AGENT = "gl-dbapi/" + VERSION

--- a/google/cloud/spanner_v1/gapic_version.py
+++ b/google/cloud/spanner_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.61.0"  # {x-release-please-version}
+__version__ = "3.62.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-database",
-    "version": "3.61.0"
+    "version": "3.62.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-instance",
-    "version": "3.61.0"
+    "version": "3.62.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.spanner.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner",
-    "version": "3.61.0"
+    "version": "3.62.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-cloud-spanner: 3.62.0</summary>

## [3.62.0](https://github.com/googleapis/python-spanner/compare/v3.61.0...v3.62.0) (2026-01-12)

### Features

* add uuid support (#1310) ([3b1792aa](https://github.com/googleapis/python-spanner/commit/3b1792aa))

### Bug Fixes

* transaction_tag should be set on BeginTransactionRequest (#1463) ([3d3cea0b](https://github.com/googleapis/python-spanner/commit/3d3cea0b))

* resolve pre-release dependency failures and sqlparse recursion (#1472) ([9ec95b7d](https://github.com/googleapis/python-spanner/commit/9ec95b7d))

</details>