### PR TITLE
chore: Add gcp resource name span attribute

### DIFF
--- a/google/cloud/spanner_v1/_opentelemetry_tracing.py
+++ b/google/cloud/spanner_v1/_opentelemetry_tracing.py
@@ -36,6 +36,7 @@ from google.cloud.spanner_v1.metrics.metrics_capture import MetricsCapture
 
 TRACER_NAME = "cloud.google.com/python/spanner"
 TRACER_VERSION = gapic_version.__version__
+GCP_RESOURCE_NAME_PREFIX = "//spanner.googleapis.com/"
 extended_tracing_globally_disabled = (
     os.getenv("SPANNER_ENABLE_EXTENDED_TRACING", "").lower() == "false"
 )
@@ -106,6 +107,7 @@ def trace_call(
         "gcp.client.service": "spanner",
         "gcp.client.version": TRACER_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": GCP_RESOURCE_NAME_PREFIX + db_name,
     }
 
     if extra_attributes:

--- a/tests/system/test_session_api.py
+++ b/tests/system/test_session_api.py
@@ -21,6 +21,7 @@ import struct
 import threading
 import time
 import uuid
+from google.cloud.spanner_v1 import _opentelemetry_tracing
 import pytest
 
 import grpc
@@ -362,6 +363,8 @@ def _make_attributes(db_instance, **kwargs):
         "gcp.client.service": "spanner",
         "gcp.client.version": ot_helpers.LIB_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX
+        + db_instance,
     }
     ot_helpers.enrich_with_otel_scope(attributes)
 

--- a/tests/unit/test__opentelemetry_tracing.py
+++ b/tests/unit/test__opentelemetry_tracing.py
@@ -28,7 +28,10 @@ def _make_rpc_error(error_cls, trailing_metadata=None):
 def _make_session():
     from google.cloud.spanner_v1.session import Session
 
-    return mock.Mock(autospec=Session, instance=True)
+    session = mock.Mock(autospec=Session, instance=True)
+    # Set a string name to allow concatenation
+    session._database.name = "projects/p/instances/i/databases/d"
+    return session
 
 
 class TestTracing(OpenTelemetryBase):
@@ -52,6 +55,8 @@ class TestTracing(OpenTelemetryBase):
                 "gcp.client.service": "spanner",
                 "gcp.client.version": LIB_VERSION,
                 "gcp.client.repo": "googleapis/python-spanner",
+                "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX
+                + "projects/p/instances/i/databases/d",
             }
         )
         expected_attributes.update(extra_attributes)
@@ -87,6 +92,8 @@ class TestTracing(OpenTelemetryBase):
                 "gcp.client.service": "spanner",
                 "gcp.client.version": LIB_VERSION,
                 "gcp.client.repo": "googleapis/python-spanner",
+                "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX
+                + "projects/p/instances/i/databases/d",
             }
         )
         expected_attributes.update(extra_attributes)

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -29,6 +29,7 @@ from google.cloud.spanner_v1 import (
     Mutation,
     BatchWriteResponse,
     DefaultTransactionOptions,
+    _opentelemetry_tracing,
 )
 import mock
 from google.cloud._helpers import UTC, _datetime_to_pb_timestamp
@@ -58,6 +59,7 @@ BASE_ATTRIBUTES = {
     "gcp.client.service": "spanner",
     "gcp.client.version": LIB_VERSION,
     "gcp.client.repo": "googleapis/python-spanner",
+    "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX + "testing",
     "cloud.region": "global",
 }
 enrich_with_otel_scope(BASE_ATTRIBUTES)

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -19,6 +19,7 @@ import unittest
 from datetime import datetime, timedelta
 
 import mock
+from google.cloud.spanner_v1 import _opentelemetry_tracing
 from google.cloud.spanner_v1._helpers import (
     _metadata_with_request_id,
     AtomicCounter,
@@ -155,6 +156,7 @@ class TestFixedSizePool(OpenTelemetryBase):
         "gcp.client.service": "spanner",
         "gcp.client.version": LIB_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX + "name",
         "cloud.region": "global",
     }
     enrich_with_otel_scope(BASE_ATTRIBUTES)
@@ -549,6 +551,7 @@ class TestBurstyPool(OpenTelemetryBase):
         "gcp.client.service": "spanner",
         "gcp.client.version": LIB_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX + "name",
         "cloud.region": "global",
     }
     enrich_with_otel_scope(BASE_ATTRIBUTES)
@@ -839,6 +842,7 @@ class TestPingingPool(OpenTelemetryBase):
         "gcp.client.service": "spanner",
         "gcp.client.version": LIB_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX + "name",
         "cloud.region": "global",
     }
     enrich_with_otel_scope(BASE_ATTRIBUTES)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -14,7 +14,10 @@
 
 
 import google.api_core.gapic_v1.method
-from google.cloud.spanner_v1._opentelemetry_tracing import trace_call
+from google.cloud.spanner_v1._opentelemetry_tracing import (
+    trace_call,
+    GCP_RESOURCE_NAME_PREFIX,
+)
 import mock
 import datetime
 from google.cloud.spanner_v1 import (
@@ -130,6 +133,7 @@ class TestSession(OpenTelemetryBase):
         "gcp.client.service": "spanner",
         "gcp.client.version": LIB_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": GCP_RESOURCE_NAME_PREFIX + DATABASE_NAME,
         "cloud.region": "global",
     }
     enrich_with_otel_scope(BASE_ATTRIBUTES)

--- a/tests/unit/test_snapshot.py
+++ b/tests/unit/test_snapshot.py
@@ -26,6 +26,7 @@ from google.cloud.spanner_v1 import (
     BeginTransactionRequest,
     TransactionOptions,
     TransactionSelector,
+    _opentelemetry_tracing,
 )
 from google.cloud.spanner_v1.snapshot import _SnapshotBase
 from tests._builders import (
@@ -80,6 +81,7 @@ BASE_ATTRIBUTES = {
     "gcp.client.service": "spanner",
     "gcp.client.version": LIB_VERSION,
     "gcp.client.repo": "googleapis/python-spanner",
+    "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX + "testing",
 }
 enrich_with_otel_scope(BASE_ATTRIBUTES)
 
@@ -2282,6 +2284,8 @@ def _build_span_attributes(
         "gcp.client.service": "spanner",
         "gcp.client.version": LIB_VERSION,
         "gcp.client.repo": "googleapis/python-spanner",
+        "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX
+        + database.name,
         "x_goog_spanner_request_id": _build_request_id(database, attempt),
     }
     attributes.update(extra_attributes)

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -25,6 +25,7 @@ from google.cloud.spanner_v1 import (
     BeginTransactionRequest,
     TransactionOptions,
     ResultSetMetadata,
+    _opentelemetry_tracing,
 )
 from google.cloud.spanner_v1._helpers import GOOGLE_CLOUD_REGION_GLOBAL
 from google.cloud.spanner_v1 import DefaultTransactionOptions
@@ -1345,6 +1346,8 @@ class TestTransaction(OpenTelemetryBase):
                 "gcp.client.service": "spanner",
                 "gcp.client.version": LIB_VERSION,
                 "gcp.client.repo": "googleapis/python-spanner",
+                "gcp.resource.name": _opentelemetry_tracing.GCP_RESOURCE_NAME_PREFIX
+                + database.name,
                 "cloud.region": GOOGLE_CLOUD_REGION_GLOBAL,
             }
         )


### PR DESCRIPTION
Adding a new span attribute called gcp.resource.name which contains an identifier to a particular spanner instance and database in the following format:

//spanner.googleapis.com/projects/{project}/instances/{instance_id}/databases/{database_id}
Example:

//spanner.googleapis.com/projects/my_project/instances/my_instance/databases/my_database