### PR TITLE
chore: librarian release pull request: 20260324T002237Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
 libraries:
   - id: google-cloud-spanner
-    version: 3.63.0
+    version: 3.64.0
     last_generated_commit: a17b84add8318f780fcc8a027815d5fee644b9f7
     apis:
       - path: google/spanner/admin/instance/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 [1]: https://pypi.org/project/google-cloud-spanner/#history
 
+## [3.64.0](https://github.com/googleapis/python-spanner/compare/v3.63.0...v3.64.0) (2026-03-24)
+
+
+### Features
+
+* implement native asyncio support via Cross-Sync (#1509) ([0aa1eda564a9463e776eacdff920fa5dc6c46cac](https://github.com/googleapis/python-spanner/commit/0aa1eda564a9463e776eacdff920fa5dc6c46cac))
+* use inline begin to eliminate BeginTransaction RPC (#1502) ([15eebdfb24f13ada111c50f14f5aab2529f839ca](https://github.com/googleapis/python-spanner/commit/15eebdfb24f13ada111c50f14f5aab2529f839ca))
+* add Client Context support to options (#1499) ([9fcb64703d7e77a1864c864b9cda5d4ea310e13e](https://github.com/googleapis/python-spanner/commit/9fcb64703d7e77a1864c864b9cda5d4ea310e13e))
+* add TLS/mTLS support for experimental host (#1479) ([12773d77a9664b1042a319fbef71008cb6a0d462](https://github.com/googleapis/python-spanner/commit/12773d77a9664b1042a319fbef71008cb6a0d462))
+
 ## [3.63.0](https://github.com/googleapis/python-spanner/compare/v3.62.0...v3.63.0) (2026-02-13)
 
 

--- a/google/cloud/spanner_admin_database_v1/gapic_version.py
+++ b/google/cloud/spanner_admin_database_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.63.0"  # {x-release-please-version}
+__version__ = "3.64.0"  # {x-release-please-version}

--- a/google/cloud/spanner_admin_instance_v1/gapic_version.py
+++ b/google/cloud/spanner_admin_instance_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.63.0"  # {x-release-please-version}
+__version__ = "3.64.0"  # {x-release-please-version}

--- a/google/cloud/spanner_dbapi/version.py
+++ b/google/cloud/spanner_dbapi/version.py
@@ -15,6 +15,6 @@
 import platform
 
 PY_VERSION = platform.python_version()
-__version__ = "3.63.0"
+__version__ = "3.64.0"
 VERSION = __version__
 DEFAULT_USER_AGENT = "gl-dbapi/" + VERSION

--- a/google/cloud/spanner_v1/gapic_version.py
+++ b/google/cloud/spanner_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "3.63.0"  # {x-release-please-version}
+__version__ = "3.64.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.admin.database.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-database",
-    "version": "3.63.0"
+    "version": "3.64.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.admin.instance.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner-admin-instance",
-    "version": "3.63.0"
+    "version": "3.64.0"
   },
   "snippets": [
     {

--- a/samples/generated_samples/snippet_metadata_google.spanner.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.spanner.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-spanner",
-    "version": "3.63.0"
+    "version": "3.64.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:b8058df4c45e9a6e07f6b4d65b458d0d059241dd34c814f151c8bf6b89211209
<details><summary>google-cloud-spanner: 3.64.0</summary>

## [3.64.0](https://github.com/googleapis/python-spanner/compare/v3.63.0...v3.64.0) (2026-03-24)

### Features

* implement native asyncio support via Cross-Sync (#1509) ([0aa1eda5](https://github.com/googleapis/python-spanner/commit/0aa1eda5))

* add TLS/mTLS support for experimental host (#1479) ([12773d77](https://github.com/googleapis/python-spanner/commit/12773d77))

* use inline begin to eliminate BeginTransaction RPC (#1502) ([15eebdfb](https://github.com/googleapis/python-spanner/commit/15eebdfb))

* add Client Context support to options (#1499) ([9fcb6470](https://github.com/googleapis/python-spanner/commit/9fcb6470))

</details>