### PR TITLE
tests: use Python 3.10 in `Integration with Regular Sessions` presubmit

### DIFF
--- a/.kokoro/presubmit/integration-regular-sessions-enabled.cfg
+++ b/.kokoro/presubmit/integration-regular-sessions-enabled.cfg
@@ -3,7 +3,7 @@
 # Only run a subset of all nox sessions
 env_vars: {
     key: "NOX_SESSION"
-    value: "unit-3.9 unit-3.14 system-3.14"
+    value: "unit-3.10 unit-3.14 system-3.14"
 }
 
 env_vars: {


### PR DESCRIPTION
In https://github.com/googleapis/python-spanner/pull/1529, Presubmit `Kokoro - Test: Integration with Regular Sessions` failed because Python 3.9 is no longer supported in the Python Kokoro CI. This PR fixes the presubmit by using 3.10 instead.