### PR TITLE
feat(dbapi): wire timeout parameter through Connection to execute_sql

### DIFF
--- a/google/cloud/spanner_dbapi/connection.py
+++ b/google/cloud/spanner_dbapi/connection.py
@@ -111,6 +111,7 @@ class Connection:
         self._read_only = read_only
         self._staleness = None
         self.request_priority = None
+        self._timeout = None
         self._transaction_begin_marked = False
         self._transaction_isolation_level = None
         # whether transaction started at Spanner. This means that we had
@@ -347,6 +348,30 @@ class Connection:
 
         self._staleness = value
 
+    @property
+    def timeout(self):
+        """Timeout in seconds for the next SQL operation on this connection.
+
+        When set, this value is passed as the ``timeout`` argument to
+        ``execute_sql`` calls on the underlying Spanner client, controlling
+        the gRPC deadline for those calls.
+
+        Returns:
+            Optional[float]: The timeout in seconds, or None to use the
+                default gRPC timeout (3600s).
+        """
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value):
+        """Set the timeout for subsequent SQL operations.
+
+        Args:
+            value (Optional[float]): Timeout in seconds. Set to None to
+                revert to the default gRPC timeout.
+        """
+        self._timeout = value
+
     def _session_checkout(self):
         """Get a Cloud Spanner session from the pool.
 
@@ -559,11 +584,16 @@ class Connection:
                   checksum of this statement results.
         """
         transaction = self.transaction_checkout()
+        kwargs = dict(
+            param_types=statement.param_types,
+            request_options=request_options or self.request_options,
+        )
+        if self._timeout is not None:
+            kwargs["timeout"] = self._timeout
         return transaction.execute_sql(
             statement.sql,
             statement.params,
-            param_types=statement.param_types,
-            request_options=request_options or self.request_options,
+            **kwargs,
         )
 
     @check_not_closed

--- a/google/cloud/spanner_dbapi/cursor.py
+++ b/google/cloud/spanner_dbapi/cursor.py
@@ -227,11 +227,16 @@ class Cursor(object):
         """This function should only be used in autocommit mode."""
         self.connection._transaction = transaction
         self.connection._snapshot = None
-        self._result_set = transaction.execute_sql(
-            sql,
+        kwargs = dict(
             params=params,
             param_types=get_param_types(params),
             last_statement=True,
+        )
+        if self.connection._timeout is not None:
+            kwargs["timeout"] = self.connection._timeout
+        self._result_set = transaction.execute_sql(
+            sql,
+            **kwargs,
         )
         self._itr = PeekIterator(self._result_set)
         self._row_count = None
@@ -541,11 +546,16 @@ class Cursor(object):
         return rows
 
     def _handle_DQL_with_snapshot(self, snapshot, sql, params):
+        kwargs = dict(
+            param_types=get_param_types(params),
+            request_options=self.request_options,
+        )
+        if self.connection._timeout is not None:
+            kwargs["timeout"] = self.connection._timeout
         self._result_set = snapshot.execute_sql(
             sql,
             params,
-            get_param_types(params),
-            request_options=self.request_options,
+            **kwargs,
         )
         # Read the first element so that the StreamedResultSet can
         # return the metadata after a DQL statement.

--- a/tests/unit/spanner_dbapi/test_connection.py
+++ b/tests/unit/spanner_dbapi/test_connection.py
@@ -838,6 +838,56 @@ class TestConnection(unittest.TestCase):
             sql, params, param_types=param_types, request_options=None
         )
 
+    def test_timeout_default_none(self):
+        connection = self._make_connection()
+        self.assertIsNone(connection.timeout)
+
+    def test_timeout_property(self):
+        connection = self._make_connection()
+        connection.timeout = 60
+        self.assertEqual(connection.timeout, 60)
+
+        connection.timeout = None
+        self.assertIsNone(connection.timeout)
+
+    def test_timeout_passed_to_run_statement(self):
+        from google.cloud.spanner_dbapi.parsed_statement import Statement
+
+        sql = "SELECT 1"
+        params = []
+        param_types = {}
+
+        connection = self._make_connection()
+        connection._spanner_transaction_started = True
+        connection._transaction = mock.Mock()
+        connection._transaction.execute_sql = mock.Mock()
+
+        connection.timeout = 60
+
+        connection.run_statement(Statement(sql, params, param_types))
+
+        connection._transaction.execute_sql.assert_called_with(
+            sql, params, param_types=param_types, request_options=None, timeout=60
+        )
+
+    def test_timeout_not_passed_when_none(self):
+        from google.cloud.spanner_dbapi.parsed_statement import Statement
+
+        sql = "SELECT 1"
+        params = []
+        param_types = {}
+
+        connection = self._make_connection()
+        connection._spanner_transaction_started = True
+        connection._transaction = mock.Mock()
+        connection._transaction.execute_sql = mock.Mock()
+
+        connection.run_statement(Statement(sql, params, param_types))
+
+        connection._transaction.execute_sql.assert_called_with(
+            sql, params, param_types=param_types, request_options=None
+        )
+
     def test_custom_client_connection(self):
         from google.cloud.spanner_dbapi import connect
 

--- a/tests/unit/spanner_dbapi/test_cursor.py
+++ b/tests/unit/spanner_dbapi/test_cursor.py
@@ -122,6 +122,64 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(cursor._result_set, result_set)
         self.assertEqual(cursor.rowcount, 1234)
 
+    def test_do_execute_update_with_timeout(self):
+        connection = self._make_connection(self.INSTANCE, self.DATABASE)
+        connection._timeout = 30
+        cursor = self._make_one(connection)
+        transaction = mock.MagicMock()
+
+        cursor._do_execute_update_in_autocommit(
+            transaction=transaction,
+            sql="UPDATE t SET x=1 WHERE true",
+            params={},
+        )
+
+        transaction.execute_sql.assert_called_once_with(
+            "UPDATE t SET x=1 WHERE true",
+            params={},
+            param_types={},
+            last_statement=True,
+            timeout=30,
+        )
+
+    def test_handle_DQL_with_snapshot_timeout(self):
+        connection = self._make_connection(self.INSTANCE, self.DATABASE)
+        connection._timeout = 45
+        cursor = self._make_one(connection)
+
+        snapshot = mock.MagicMock()
+        result_set = mock.MagicMock()
+        result_set.metadata.transaction.read_timestamp = None
+        snapshot.execute_sql.return_value = result_set
+
+        cursor._handle_DQL_with_snapshot(snapshot, "SELECT 1", None)
+
+        snapshot.execute_sql.assert_called_once_with(
+            "SELECT 1",
+            None,
+            param_types=None,
+            request_options=None,
+            timeout=45,
+        )
+
+    def test_handle_DQL_with_snapshot_no_timeout(self):
+        connection = self._make_connection(self.INSTANCE, self.DATABASE)
+        cursor = self._make_one(connection)
+
+        snapshot = mock.MagicMock()
+        result_set = mock.MagicMock()
+        result_set.metadata.transaction.read_timestamp = None
+        snapshot.execute_sql.return_value = result_set
+
+        cursor._handle_DQL_with_snapshot(snapshot, "SELECT 1", None)
+
+        snapshot.execute_sql.assert_called_once_with(
+            "SELECT 1",
+            None,
+            param_types=None,
+            request_options=None,
+        )
+
     def test_do_batch_update(self):
         from google.cloud.spanner_dbapi import connect
         from google.cloud.spanner_v1.param_types import INT64
@@ -952,7 +1010,7 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(cursor._itr, MockedPeekIterator())
         self.assertEqual(cursor._row_count, None)
         mock_snapshot.execute_sql.assert_called_with(
-            sql, None, None, request_options=RequestOptions(priority=1)
+            sql, None, param_types=None, request_options=RequestOptions(priority=1)
         )
 
     def test_handle_dql_database_error(self):


### PR DESCRIPTION
## Summary

Add a `timeout` property to `Connection` and pass `timeout=` to `execute_sql()` in the three DBAPI code paths that currently omit it: snapshot reads, transaction statements, and autocommit DML.

Fixes googleapis/google-cloud-python#16492

## Background

`_SnapshotBase.execute_sql()` accepts a `timeout` parameter that controls the gRPC deadline for the `ExecuteStreamingSql` RPC. When not provided, it defaults to `gapic_v1.method.DEFAULT`, which resolves to `default_timeout=3600.0` in the transport layer.

The DBAPI calls `execute_sql()` in three locations, none of which pass `timeout=`:

1. **Snapshot reads** — [`cursor._handle_DQL_with_snapshot()`](https://github.com/googleapis/python-spanner/blob/e5638ab932d0b4281f02ffb72533250433c43fef/google/cloud/spanner_dbapi/cursor.py#L543-L549) calls `snapshot.execute_sql(sql, params, param_types, request_options=...)` without `timeout=`
2. **Transaction reads/writes** — [`connection.run_statement()`](https://github.com/googleapis/python-spanner/blob/e5638ab932d0b4281f02ffb72533250433c43fef/google/cloud/spanner_dbapi/connection.py#L561-L567) calls `transaction.execute_sql(sql, params, param_types=..., request_options=...)` without `timeout=`
3. **Autocommit DML** — [`cursor._do_execute_update_in_autocommit()`](https://github.com/googleapis/python-spanner/blob/e5638ab932d0b4281f02ffb72533250433c43fef/google/cloud/spanner_dbapi/cursor.py#L226-L237) calls `transaction.execute_sql(sql, params=..., param_types=..., last_statement=True)` without `timeout=`

This means DBAPI consumers (SQLAlchemy, Django, raw DBAPI) cannot control the gRPC deadline for individual statements — all queries use the 3600-second default.

## Timeline

| Date | Commit | Event |
|---|---|---|
| Nov 2018 | `9b7fcd6` ([PR #6536](https://github.com/googleapis/google-cloud-python/pull/6536)) | `timeout=` parameter added to `_SnapshotBase.execute_sql()` in the Spanner client |
| Nov 2020 | `2493fa1` (PR googleapis/python-spanner#160) | DBAPI created — `cursor._handle_DQL_with_snapshot()` calls `execute_sql()` without `timeout=` |
| Nov 2020 | `d59d502` (PR googleapis/python-spanner#168) | `connection.run_statement()` added — calls `execute_sql()` without `timeout=` |
| Mar 2021 | `1a7c9d2` (PR googleapis/python-spanner#278) | `timeout=` expanded to `read()`, `partition_read()`, `partition_query()` in the client |
| Oct 2021 | `cd3b950` (PR googleapis/python-spanner#475) | `_handle_DQL_with_snapshot()` extracted as separate method — still no `timeout=` |
| Oct 2022 | `ab768e4` (PR googleapis/python-spanner#838) | `request_options` added to `_handle_DQL_with_snapshot()` — `timeout=` not added |
| Jan 2025 | `ee9662f` (PR googleapis/python-spanner#1262) | `request_tag`/`transaction_tag` added to cursor/connection — `timeout=` not added |

Other execution parameters (`request_options`, `request_priority`, `transaction_tag`, `request_tag`) were each wired through the DBAPI incrementally. The `timeout` parameter was not included in any of these additions.

## Changes

### `connection.py`

- Add `self._timeout = None` to `__init__`
- Add `timeout` property and setter
- Pass `timeout=self._timeout` in `run_statement()` when set

### `cursor.py`

- Pass `timeout=self.connection._timeout` in `_handle_DQL_with_snapshot()` when set
- Pass `timeout=self.connection._timeout` in `_do_execute_update_in_autocommit()` when set

When `timeout` is `None` (the default), `timeout=` is not passed, preserving the existing behavior of using `gapic_v1.method.DEFAULT`.

### Usage

```python
from google.cloud.spanner_dbapi import connect

conn = connect(instance_id, database_id, project=project)
conn.timeout = 60  # 60-second gRPC deadline for subsequent statements

cursor = conn.cursor()
cursor.execute("SELECT * FROM my_table")
```

## Tests

Added 7 unit tests:

- `test_timeout_default_none` — verifies default is `None`
- `test_timeout_property` — verifies getter/setter
- `test_timeout_passed_to_run_statement` — verifies `timeout=` is passed in `run_statement()`
- `test_timeout_not_passed_when_none` — verifies `timeout=` is omitted when `None`
- `test_do_execute_update_with_timeout` — verifies `timeout=` in autocommit DML path
- `test_handle_DQL_with_snapshot_timeout` — verifies `timeout=` in snapshot read path
- `test_handle_DQL_with_snapshot_no_timeout` — verifies omission in snapshot read path

All 205 existing DBAPI tests continue to pass.

## Related

- Companion dialect change: googleapis/google-cloud-python#16467
- Google's own samples demonstrate `timeout=` on `execute_sql()`: PR googleapis/python-spanner#1380 (`spanner_set_statement_timeout`), PR googleapis/python-spanner#1107 (`spanner_set_custom_timeout_and_retry`)